### PR TITLE
Added UI block for unsupported connection methods

### DIFF
--- a/src/components/NewDevice.tsx
+++ b/src/components/NewDevice.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useEffect, useState } from "react";
 
 import { FiBluetooth, FiTerminal, FiWifi } from "react-icons/fi";
 
@@ -8,23 +9,27 @@ import { HTTP } from "./PageComponents/Connect/HTTP.js";
 import { Serial } from "./PageComponents/Connect/Serial.js";
 
 export const NewDevice = () => {
-  const tabs: TabType[] = [
+
+  const [tabs, _setTabs] = useState<TabType[]>([
     {
       name: "BLE",
       icon: <FiBluetooth className="h-4" />,
       element: BLE,
+      disabled: !navigator.bluetooth
     },
     {
       name: "HTTP",
       icon: <FiWifi className="h-4" />,
       element: HTTP,
+      disabled: false
     },
     {
       name: "Serial",
       icon: <FiTerminal className="h-4" />,
       element: Serial,
-    },
-  ];
+      disabled: !navigator.serial
+    }
+  ]);
 
   return (
     <div className="m-auto h-96 w-96">

--- a/src/components/NewDevice.tsx
+++ b/src/components/NewDevice.tsx
@@ -1,5 +1,4 @@
-import type React from "react";
-import { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { FiBluetooth, FiTerminal, FiWifi } from "react-icons/fi";
 

--- a/src/components/NewDevice.tsx
+++ b/src/components/NewDevice.tsx
@@ -9,7 +9,6 @@ import { HTTP } from "./PageComponents/Connect/HTTP.js";
 import { Serial } from "./PageComponents/Connect/Serial.js";
 
 export const NewDevice = () => {
-
   const [tabs, _setTabs] = useState<TabType[]>([
     {
       name: "BLE",

--- a/src/components/layout/page/TabbedContent.tsx
+++ b/src/components/layout/page/TabbedContent.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import { Fragment } from "react";
 
 import { Tab } from "@headlessui/react";
+import { Mono } from "@app/components/Mono";
 
 export interface TabType {
   name: string;
@@ -50,7 +51,11 @@ export const TabbedContent = ({
       <Tab.Panels as={Fragment}>
         {tabs.map((entry, index) => (
           <Tab.Panel key={index} className="flex flex-grow">
-            <entry.element />
+            {!entry.disabled ? <entry.element /> : (
+              <Mono>
+                This functionality is not supported in your browser.
+              </Mono>
+            )}
           </Tab.Panel>
         ))}
       </Tab.Panels>


### PR DESCRIPTION
This PR adds UI that tells a user when a web API is unsupported in their browser, which will prevent the current site crashes. This change will not change behavior for "supported browsers."

![image](https://user-images.githubusercontent.com/46639306/193935138-c0d6e863-3802-4c96-bd69-5b86b31947e1.png)
*Serial is unsupported in Firefox*

![image](https://user-images.githubusercontent.com/46639306/193935170-e2c99a31-b826-4b50-89f3-3917017fa25e.png)
*Serial is supported in Chromium*

Closes #38 