### PR TITLE
Make Unsupported Connection Links Clickable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
   "css.validate": false,
   "editor.quickSuggestions": {
     "strings": true
-},
-"editor.tabSize": 2
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "css.validate": false,
   "editor.quickSuggestions": {
     "strings": true
-  }
+},
+"editor.tabSize": 2
 }

--- a/src/components/NewDevice.tsx
+++ b/src/components/NewDevice.tsx
@@ -14,8 +14,8 @@ export const NewDevice = () => {
       icon: <FiBluetooth className="h-4" />,
       element: BLE,
       disabled: !navigator.bluetooth,
-      disabledMessage:
-        "WebBluetooth is currently only supported by Chromium based browsers: https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API#browser_compatibility",
+      disabledMessage: "Web Bluetooth is currently only supported by Chromium-based browsers",
+      disabledLink: "https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API#browser_compatibility"
     },
     {
       name: "HTTP",
@@ -28,8 +28,8 @@ export const NewDevice = () => {
       icon: <FiTerminal className="h-4" />,
       element: Serial,
       disabled: !navigator.serial,
-      disabledMessage:
-        "WebSerial is currently only supported by Chromium based browsers: https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API#browser_compatibility",
+      disabledMessage: "Web Serial is currently only supported by Chromium-based browsers",
+      disabledLink: "https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API#browser_compatibility"
     },
   ]);
 

--- a/src/components/NewDevice.tsx
+++ b/src/components/NewDevice.tsx
@@ -22,6 +22,7 @@ export const NewDevice = () => {
       icon: <FiWifi className="h-4" />,
       element: HTTP,
       disabled: false,
+      disabledMessage: "Unsuported connection method"
     },
     {
       name: "Serial",

--- a/src/components/layout/page/TabbedContent.tsx
+++ b/src/components/layout/page/TabbedContent.tsx
@@ -8,8 +8,8 @@ export interface TabType {
   name: string;
   icon?: JSX.Element;
   element: () => JSX.Element;
-  disabled?: boolean;
-  disabledMessage?: string;
+  disabled: boolean;
+  disabledMessage: string;
   disabledLink?: string;
 }
 
@@ -56,24 +56,26 @@ export const TabbedContent = ({
               <entry.element />
             ) : (
               <div>
-                {entry.disabledMessage && (
-                  <Mono>
-                    {entry.disabledMessage}.
-                    {' '}
-                    Click
-                    {' '}
-                    <a
-                      className="underline"
-                      target="_blank"
-                      rel="noreferrer"
-                      href={entry.disabledLink}
-                    >
-                      here
-                    </a>
-                    {' '}
-                    for more information.
-                  </Mono>
-                )}
+                <Mono>
+                  {entry.disabledMessage}.
+                  {' '}
+                  {entry.disabledLink && (
+                    <>
+                      Click
+                      {' '}
+                      <a
+                        className="underline"
+                        target="_blank"
+                        rel="noreferrer"
+                        href={entry.disabledLink}
+                      >
+                        here
+                      </a>
+                      {' '}
+                      for more information.
+                    </>
+                  )}
+                </Mono>
               </div>
             )}
           </Tab.Panel>

--- a/src/components/layout/page/TabbedContent.tsx
+++ b/src/components/layout/page/TabbedContent.tsx
@@ -8,8 +8,8 @@ export interface TabType {
   name: string;
   icon?: JSX.Element;
   element: () => JSX.Element;
-  disabled: boolean;
-  disabledMessage: string;
+  disabled?: boolean;
+  disabledMessage?: string;
   disabledLink?: string;
 }
 
@@ -57,7 +57,7 @@ export const TabbedContent = ({
             ) : (
               <div>
                 <Mono>
-                  {entry.disabledMessage}.
+                  {entry.disabledMessage || "This tab is disabled"}.
                   {' '}
                   {entry.disabledLink && (
                     <>

--- a/src/components/layout/page/TabbedContent.tsx
+++ b/src/components/layout/page/TabbedContent.tsx
@@ -10,6 +10,7 @@ export interface TabType {
   element: () => JSX.Element;
   disabled?: boolean;
   disabledMessage?: string;
+  disabledLink?: string;
 }
 
 export interface TabbedContentProps {
@@ -28,11 +29,10 @@ export const TabbedContent = ({
           <Tab key={index}>
             {({ selected }) => (
               <div
-                className={`flex h-10 cursor-pointer gap-3 rounded-md px-3 text-sm font-medium ${
-                  selected
-                    ? "bg-gray-100 text-gray-700"
-                    : "text-gray-500 hover:text-gray-700"
-                }
+                className={`flex h-10 cursor-pointer gap-3 rounded-md px-3 text-sm font-medium ${selected
+                  ? "bg-gray-100 text-gray-700"
+                  : "text-gray-500 hover:text-gray-700"
+                  }
                    `}
               >
                 {entry.icon && (
@@ -55,7 +55,26 @@ export const TabbedContent = ({
             {!entry.disabled ? (
               <entry.element />
             ) : (
-              <Mono>{entry.disabledMessage}</Mono>
+              <div>
+                {entry.disabledMessage && (
+                  <Mono>
+                    {entry.disabledMessage}.
+                    {' '}
+                    Click
+                    {' '}
+                    <a
+                      className="underline"
+                      target="_blank"
+                      rel="noreferrer"
+                      href={entry.disabledLink}
+                    >
+                      here
+                    </a>
+                    {' '}
+                    for more information.
+                  </Mono>
+                )}
+              </div>
             )}
           </Tab.Panel>
         ))}


### PR DESCRIPTION
Currently unsupported connection links are not clickable in the web client. This PR updates the UI for handling a new optional `TabType.disabledLink` field.

![image](https://user-images.githubusercontent.com/46639306/198888062-31fceccb-79bd-496b-8479-5b270a2df07b.png)
*Current web client*

![image](https://user-images.githubusercontent.com/46639306/198888632-802e54a6-56de-402a-b585-e5154776fcfe.png)
*Proposed changes with defined `TabType.disabledLink` field*

![image](https://user-images.githubusercontent.com/46639306/198888663-8ccecccc-58cd-431b-8830-7f5fd200befc.png)
*Proposed changes with undefined `TabType.disabledLink` field*

Closes #54 