### PR TITLE
Fix immediate device reloading on owner edit

### DIFF
--- a/src/components/PageComponents/Config/User.tsx
+++ b/src/components/PageComponents/Config/User.tsx
@@ -13,39 +13,26 @@ import { classValidatorResolver } from "@hookform/resolvers/class-validator";
 import { Protobuf } from "@meshtastic/meshtasticjs";
 
 export const User = (): JSX.Element => {
-  const { hardware, nodes, connection } = useDevice();
+  const { hardware, nodes, connection, setWorkingOwner } = useDevice();
 
   const myNode = nodes.find((n) => n.data.num === hardware.myNodeNum);
 
   const { register, handleSubmit, reset, control } = useForm<UserValidation>({
     defaultValues: myNode?.data.user,
-    resolver: classValidatorResolver(UserValidation)
+    resolver: classValidatorResolver(UserValidation),
   });
 
   useEffect(() => {
-    reset({
-      longName: myNode?.data.user?.longName,
-      shortName: myNode?.data.user?.shortName,
-      isLicensed: myNode?.data.user?.isLicensed
-    });
+    reset(myNode?.data.user);
   }, [reset, myNode]);
 
   const onSubmit = handleSubmit((data) => {
     if (connection && myNode?.data.user) {
-      void toast.promise(
-        connection
-          .setOwner(
-            new Protobuf.User({
-              ...myNode.data.user,
-              ...data
-            })
-          )
-          .then(() => reset({ ...data })),
-        {
-          loading: "Saving...",
-          success: "Saved User, Restarting Node",
-          error: "No response received"
-        }
+      setWorkingOwner(
+        new Protobuf.User({
+          ...myNode.data.user,
+          ...data,
+        })
       );
     }
   });

--- a/src/pages/Config/DeviceConfig.tsx
+++ b/src/pages/Config/DeviceConfig.tsx
@@ -16,42 +16,42 @@ import { NavBar } from "@app/Nav/NavBar.js";
 import { VerticalTabbedContent } from "@app/components/generic/VerticalTabbedContent.js";
 
 export const DeviceConfig = (): JSX.Element => {
-  const { hardware, workingConfig, connection } = useDevice();
+  const { hardware, workingConfig, workingOwner, connection } = useDevice();
 
   const tabs = [
     {
       label: "User",
-      element: User
+      element: User,
     },
     {
       label: "Device",
-      element: Device
+      element: Device,
     },
     {
       label: "Position",
-      element: Position
+      element: Position,
     },
     {
       label: "Power",
-      element: Power
+      element: Power,
     },
     {
       label: "Network",
       element: Network,
-      disabled: !hardware.hasWifi
+      disabled: !hardware.hasWifi,
     },
     {
       label: "Display",
-      element: Display
+      element: Display,
     },
     {
       label: "LoRa",
-      element: LoRa
+      element: LoRa,
     },
     {
       label: "Bluetooth",
-      element: Bluetooth
-    }
+      element: Bluetooth,
+    },
   ];
 
   return (
@@ -65,9 +65,10 @@ export const DeviceConfig = (): JSX.Element => {
               workingConfig.map(async (config) => {
                 await connection?.setConfig(config);
               });
+              connection?.setOwner(workingOwner);
               await connection?.commitEditSettings();
-            }
-          }
+            },
+          },
         ]}
       />
 


### PR DESCRIPTION
This PR fixes #80 by adding an intermediate `device.workingOwner` field, which functions similarly to the `device.workingConfig` field. This field will update the device's owner field on click of `"Apply & Reboot"`.