### PR TITLE
Restore network tab

### DIFF
--- a/src/pages/Config/DeviceConfig.tsx
+++ b/src/pages/Config/DeviceConfig.tsx
@@ -34,7 +34,6 @@ export const DeviceConfig = (): JSX.Element => {
     {
       label: "Network",
       element: Network,
-      disabled: !hardware.hasWifi,
     },
     {
       label: "Display",


### PR DESCRIPTION
This is a quick fix to bring back the network tab. If wifi is turned on, but not configured correctly from a bluetooth client, the only way to turn it off is over serial.  Most users will choose the web client which at the moment does not allow network administration, so they're stuck.

Checking for wifi enabled devices is nice but I don't think it's absolutely necessary.  

fixes #117 
