### PR TITLE
Fix Connect Button on New Connection HTTP Tab

### DIFF
--- a/src/components/PageComponents/Connect/HTTP.tsx
+++ b/src/components/PageComponents/Connect/HTTP.tsx
@@ -76,7 +76,7 @@ export const HTTP = (): JSX.Element => {
           )}
         />
       </div>
-      <Button>
+      <Button type="submit">
         <span>Connect</span>
       </Button>
     </form>


### PR DESCRIPTION
This PR addresses the broken button on the HTTP tab of the New Connection Window.  The current <Button> implementation has no action. Only by hitting the return key with the IP field highlighted can the user submit the value.