### PR TITLE
Fix URL Validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshtastic-web",
-  "version": "2.2.12-0",
+  "version": "2.2.12-1",
   "type": "module",
   "description": "Meshtastic web client",
   "license": "GPL-3.0-only",

--- a/src/components/Dialog/ImportDialog.tsx
+++ b/src/components/Dialog/ImportDialog.tsx
@@ -34,11 +34,12 @@ export const ImportDialog = ({
 
   useEffect(() => {
     const base64String = QRCodeURL.split("e/#")[1]
-      ?.replace(/-/g, "+")
-      .replace(/_/g, "/")
-      .padEnd(QRCodeURL.length + ((4 - (QRCodeURL.length % 4)) % 4), "=");
+    const paddedString = base64String
+      ?.padEnd(base64String.length + ((4 - (base64String.length % 4)) % 4), "=")
+      .replace(/-/g, "+")
+      .replace(/_/g, "/");
     try {
-      setChannelSet(Protobuf.ChannelSet.fromBinary(toByteArray(base64String)));
+      setChannelSet(Protobuf.ChannelSet.fromBinary(toByteArray(paddedString)));
       setValidURL(true);
     } catch (error) {
       setValidURL(false);


### PR DESCRIPTION
This PR fixes the validation function when entering a Channels URL.   The current implementation attempts to add padding to the URL based on length of QRCodeURL when it should base this on the length of base64String.