### PR TITLE
Modify PSK options in description

### DIFF
--- a/src/components/PageComponents/Channel.tsx
+++ b/src/components/PageComponents/Channel.tsx
@@ -61,7 +61,7 @@ export const Channel = ({ channel }: SettingsPanelProps): JSX.Element => {
               type: "password",
               name: "settings.psk",
               label: "pre-Shared Key",
-              description: "16, or 32 bytes, \"0\"= no crypto, \"1\" = default key",
+              description: "16, or 32 bytes",
               properties: {
                 // act
               },


### PR DESCRIPTION
Entering a 1 or 0 does not get sent to the device.