### PR TITLE
Set disabled property last

### DIFF
--- a/src/components/Form/FormInput.tsx
+++ b/src/components/Form/FormInput.tsx
@@ -38,9 +38,9 @@ export function GenericInput<T extends FieldValues>({
                 : e.target.value,
             )
           }
-          disabled={disabled}
           {...field.properties}
           {...rest}
+          disabled={disabled}
         />
       )}
     />


### PR DESCRIPTION
otherwise it will be overwritten with 'undefined' from the spreaded rest property.

This will now respect the `disabledBy` directives for fields that should be disabled until other fields have (or don't have) a specific value.