### PR TITLE
Enable map control

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -131,7 +131,8 @@ export const MapPage = (): JSX.Element => {
           dragRotate={false}
           touchZoomRotate={false}
           initialViewState={{
-            latitude: 50,
+            zoom: 1.5,
+            latitude: 35,
             longitude: 0,
           }}
         >

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -73,9 +73,9 @@ export const MapPage = (): JSX.Element => {
   }, [map]);
 
   useEffect(() => {
-    if (map) {
+    map?.on("load", () => {
       getBBox();
-    }
+    });
   }, [map, getBBox]);
 
   return (
@@ -131,9 +131,8 @@ export const MapPage = (): JSX.Element => {
           dragRotate={false}
           touchZoomRotate={false}
           initialViewState={{
-            zoom: 10,
-            latitude: -38,
-            longitude: 145,
+            latitude: 50,
+            longitude: 0,
           }}
         >
           {waypoints.map((wp) => (

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -131,7 +131,7 @@ export const MapPage = (): JSX.Element => {
           dragRotate={false}
           touchZoomRotate={false}
           initialViewState={{
-            zoom: 1.5,
+            zoom: 1.6,
             latitude: 35,
             longitude: 0,
           }}


### PR DESCRIPTION
I found that map control wasn't working after the initial map load with peers. The map view would be set to a bounding box around my peers but would then become unresponsive. The buttons in the top right of the map (zoom in/out, bound) would not work.

This was an issue as I'd enabled MQTT while initially testing my node (showing me global peers) but I wanted to zoom in on my own area after disabling it later, which I couldn't do. I adjusted this initial behaviour to occur once, which then allows the user to interact with the map as expected.

I also adjusted the default "peerless" map location to be zoomed out and central-ish on the map in use, rather than zoomed into Melbourne. There's probably a better solution for this, but for now starting at a high zoom level feels more natural than a specific city - happy to revert this out if you'd prefer to keep things as is. 