### PR TITLE
Fix sorting on peers table

### DIFF
--- a/src/components/generic/Table/index.tsx
+++ b/src/components/generic/Table/index.tsx
@@ -34,8 +34,8 @@ export const Table = ({ headings, rows }: TableProps): JSX.Element => {
 
     // Custom comparison for 'Last Heard' column
     if (sortColumn === "Last Heard") {
-      const aTimestamp = a[columnIndex].props.timestamp;
-      const bTimestamp = b[columnIndex].props.timestamp;
+      const aTimestamp = a[columnIndex].props.timestamp ? a[columnIndex].props.timestamp : 0;
+      const bTimestamp = b[columnIndex].props.timestamp ? b[columnIndex].props.timestamp : 0;
 
       if (aTimestamp < bTimestamp) {
         return sortOrder === "asc" ? -1 : 1;


### PR DESCRIPTION
The peers list table has carets in the column headings, indicating that it should be possible to sort by those fields, which does not seem to be the case.

The PR enables sorting by clicking column heading, and defaults to most recent contacts at the top

Closes #146 