### PR TITLE
Support for cmdk v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshtastic-web",
-  "version": "2.2.19-1",
+  "version": "2.2.20",
   "type": "module",
   "description": "Meshtastic web client",
   "license": "GPL-3.0-only",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@bufbuild/protobuf": "^1.8.0",
     "@emeraldpay/hashicon-react": "^0.5.2",
-    "@meshtastic/js": "2.3.0-0",
+    "@meshtastic/js": "2.3.2-0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^0.5.2
     version: 0.5.2
   '@meshtastic/js':
-    specifier: 2.3.0-0
-    version: 2.3.0-0
+    specifier: 2.3.2-0
+    version: 2.3.2-0
   '@radix-ui/react-accordion':
     specifier: ^1.1.2
     version: 1.1.2(@types/react-dom@18.2.22)(@types/react@18.2.66)(react-dom@18.2.0)(react@18.2.0)
@@ -883,8 +883,8 @@ packages:
       sort-object: 3.0.3
     dev: false
 
-  /@meshtastic/js@2.3.0-0:
-    resolution: {integrity: sha512-BN+SZU1weKw9jSAV905wOaCL5R2nh1f9LGKz3csXqJcbe2Dxbjg2KMZjR8jbC1e9gprcEbifVCDgGZfMc9hN1Q==}
+  /@meshtastic/js@2.3.2-0:
+    resolution: {integrity: sha512-N8LDHWL2qtdb5y3xV6bos945jPAdj/dInzD1ost05N+ma3nji2YNw0lQekyfnwD/raMA+FrydKaHDT+O3umrhg==}
     dependencies:
       crc: 4.3.2
       sub-events: 1.9.0

--- a/src/components/UI/Command.tsx
+++ b/src/components/UI/Command.tsx
@@ -116,7 +116,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-md py-1.5 px-2 text-sm font-medium outline-none aria-selected:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:aria-selected:bg-slate-700",
+      "relative flex cursor-default select-none items-center rounded-md py-1.5 px-2 text-sm font-medium outline-none aria-selected:bg-slate-100 data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50 dark:aria-selected:bg-slate-700",
       className,
     )}
     {...props}


### PR DESCRIPTION
Fixes #173 

Package `cmdk` was updated to v1.0.0 with [breaking changes](https://github.com/pacocoursey/cmdk/releases/tag/v1.0.0).  A couple things needed to be updated to support the major version.


This pull request does the following:
- Update `data-disabled` to true in Command.tsx to support `cmdk` v1
   - Help found here: https://github.com/shadcn-ui/ui/issues/2944#issuecomment-1985153126) 
- Updated this app to use latest `Meshtastic.js` version (2.3.2-0)
- Bumped this app version to 2.2.20

---

I did not see any contributing guidelines.  Please let me know if anything needs to be changed. 