### PR TITLE
Add seconds properties to fields that are missing them

### DIFF
--- a/src/components/PageComponents/Config/Display.tsx
+++ b/src/components/PageComponents/Config/Display.tsx
@@ -32,7 +32,7 @@ export const Display = (): JSX.Element => {
               label: "Screen Timeout",
               description: "Turn off the display after this long",
               properties: {
-                suffix: "seconds",
+                suffix: "Seconds",
               },
             },
             {
@@ -50,6 +50,9 @@ export const Display = (): JSX.Element => {
               name: "autoScreenCarouselSecs",
               label: "Carousel Delay",
               description: "How fast to cycle through windows",
+              properties: {
+                suffix: "Seconds",
+              },
             },
             {
               type: "toggle",

--- a/src/components/PageComponents/Config/Position.tsx
+++ b/src/components/PageComponents/Config/Position.tsx
@@ -94,12 +94,18 @@ export const Position = (): JSX.Element => {
               name: "positionBroadcastSecs",
               label: "Broadcast Interval",
               description: "How often your position is sent out over the mesh",
+              properties: {
+                suffix: "Seconds",
+              },
             },
             {
               type: "number",
               name: "gpsUpdateInterval",
               label: "GPS Update Interval",
               description: "How often a GPS fix should be acquired",
+              properties: {
+                suffix: "Seconds",
+              },
             },
             {
               type: "number",

--- a/src/components/PageComponents/ModuleConfig/DetectionSensor.tsx
+++ b/src/components/PageComponents/ModuleConfig/DetectionSensor.tsx
@@ -38,6 +38,9 @@ export const DetectionSensor = (): JSX.Element => {
               label: "Minimum Broadcast Seconds",
               description:
                 "The interval in seconds of how often we can send a message to the mesh when a state change is detected",
+                properties: {
+                  suffix: "Seconds",
+                },  
               disabledBy: [
                 {
                   fieldName: "enabled",

--- a/src/components/PageComponents/ModuleConfig/MQTT.tsx
+++ b/src/components/PageComponents/ModuleConfig/MQTT.tsx
@@ -138,6 +138,9 @@ export const MQTT = (): JSX.Element => {
               name: "mapReportSettings.publishIntervalSecs",
               label: "Map Report Publish Interval (s)",
               description: "Interval in seconds to publish map reports",
+              properties: {
+                suffix: "Seconds",
+              },
               disabledBy: [
                 {
                   fieldName: "enabled",

--- a/src/components/PageComponents/ModuleConfig/NeighborInfo.tsx
+++ b/src/components/PageComponents/ModuleConfig/NeighborInfo.tsx
@@ -36,8 +36,11 @@ export const NeighborInfo = (): JSX.Element => {
               type: "number",
               name: "updateInterval",
               label: "Update Interval",
-              description:
+              description: 
                 "Interval in seconds of how often we should try to send our Neighbor Info to the mesh",
+              properties: {
+                suffix: "Seconds",
+              },
               disabledBy: [
                 {
                   fieldName: "enabled",

--- a/src/components/PageComponents/ModuleConfig/Paxcounter.tsx
+++ b/src/components/PageComponents/ModuleConfig/Paxcounter.tsx
@@ -37,6 +37,9 @@ export const Paxcounter = (): JSX.Element => {
               name: "paxcounterUpdateInterval",
               label: "Update Interval (seconds)",
               description: "How long to wait between sending paxcounter packets",
+              properties: {
+                suffix: "Seconds",
+              },
               disabledBy: [
                 {
                   fieldName: "enabled",

--- a/src/components/PageComponents/ModuleConfig/RangeTest.tsx
+++ b/src/components/PageComponents/ModuleConfig/RangeTest.tsx
@@ -37,6 +37,9 @@ export const RangeTest = (): JSX.Element => {
               name: "sender",
               label: "Message Interval",
               description: "How long to wait between sending test packets",
+              properties: {
+                suffix: "Seconds",
+              },
               disabledBy: [
                 {
                   fieldName: "enabled",

--- a/src/components/PageComponents/ModuleConfig/Telemetry.tsx
+++ b/src/components/PageComponents/ModuleConfig/Telemetry.tsx
@@ -32,7 +32,7 @@ export const Telemetry = (): JSX.Element => {
               label: "Query Interval",
               description: "Interval to get telemetry data",
               properties: {
-                suffix: "seconds",
+                suffix: "Seconds",
               },
             },
             {
@@ -41,7 +41,7 @@ export const Telemetry = (): JSX.Element => {
               label: "Update Interval",
               description: "How often to send Metrics over the mesh",
               properties: {
-                suffix: "seconds",
+                suffix: "Seconds",
               },
             },
             {


### PR DESCRIPTION
Some of the config pages were missing the Seconds property and some had it in lowercase so this should fix all that.