### PR TITLE
Use localStorage to store theme preference

### DIFF
--- a/src/core/stores/appStore.ts
+++ b/src/core/stores/appStore.ts
@@ -48,7 +48,7 @@ export const useAppStore = create<AppState>()((set) => ({
   currentPage: "messages",
   rasterSources: [],
   commandPaletteOpen: false,
-  darkMode: window.matchMedia("(prefers-color-scheme: dark)").matches,
+  darkMode: (localStorage.getItem('theme-dark') !== null ? (localStorage.getItem('theme-dark') === 'true' ? true : false) : window.matchMedia("(prefers-color-scheme: dark)").matches),
   accent: "orange",
   connectDialogOpen: false,
 
@@ -93,6 +93,7 @@ export const useAppStore = create<AppState>()((set) => ({
     );
   },
   setDarkMode: (enabled: boolean) => {
+    localStorage.setItem('theme-dark', enabled.toString());
     set(
       produce<AppState>((draft) => {
         draft.darkMode = enabled;


### PR DESCRIPTION
Resolves this #88 by storing the theme value in localStorage, if not present will fall back to system preference until changed