### PR TITLE
Use localStorage to store theme preference

### DIFF
--- a/src/core/stores/appStore.ts
+++ b/src/core/stores/appStore.ts
@@ -48,7 +48,7 @@ export const useAppStore = create<AppState>()((set) => ({
   currentPage: "messages",
   rasterSources: [],
   commandPaletteOpen: false,
-  darkMode: window.matchMedia("(prefers-color-scheme: dark)").matches,
+  darkMode: (localStorage.getItem('theme-dark') !== null ? (localStorage.getItem('theme-dark') === 'true' ? true : false) : window.matchMedia("(prefers-color-scheme: dark)").matches),
   accent: "orange",
   connectDialogOpen: false,
 
@@ -93,6 +93,7 @@ export const useAppStore = create<AppState>()((set) => ({
     );
   },
   setDarkMode: (enabled: boolean) => {
+    localStorage.setItem('theme-dark', enabled.toString());
     set(
       produce<AppState>((draft) => {
         draft.darkMode = enabled;


### PR DESCRIPTION
Resolves #88 by storing the preference of dark-theme in localStorage, if it isn't present it will query the browser for the preferred scheme.