### PR TITLE
chore(workflows): use pnpm/action-setup@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: latest
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: latest
 


### PR DESCRIPTION
latest version, [v3 updated to run on Node.js v20](https://github.com/pnpm/action-setup/releases/tag/v3.0.0)

resolves warnings in Action runs
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

e.g. https://github.com/meshtastic/web/actions/runs/8148286105