### PR TITLE
change validation type to IsNumber

### DIFF
--- a/src/validation/config/power.ts
+++ b/src/validation/config/power.ts
@@ -1,6 +1,6 @@
 import type { Message } from "@bufbuild/protobuf";
 import type { Protobuf } from "@meshtastic/js";
-import { IsBoolean, IsInt, Max, Min } from "class-validator";
+import { IsBoolean, IsInt, IsNumber, Max, Min } from "class-validator";
 
 export class PowerValidation
   implements Omit<Protobuf.Config.Config_PowerConfig, keyof Message>
@@ -11,7 +11,7 @@ export class PowerValidation
   @IsInt()
   onBatteryShutdownAfterSecs: number;
 
-  @IsInt()
+  @IsNumber()
   @Min(2)
   @Max(4)
   adcMultiplierOverride: number;


### PR DESCRIPTION
Fixes #155 Web client will not allow decimals for adc_multiplier_override.

Enter decimal values allowed in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Edge
