### PR TITLE
Add Connection info to Nodes Table

### DIFF
--- a/src/pages/Nodes.tsx
+++ b/src/pages/Nodes.tsx
@@ -26,6 +26,7 @@ export const NodesPage = (): JSX.Element => {
             { title: "MAC Address", type: "normal", sortable: true },
             { title: "Last Heard", type: "normal", sortable: true },
             { title: "SNR", type: "normal", sortable: true },
+            { title: "Connection", type: "normal", sortable: true },
           ]}
           rows={filteredNodes.map((node) => [
             <Hashicon size={24} value={node.num.toString()} />,
@@ -55,6 +56,10 @@ export const NodesPage = (): JSX.Element => {
               {Math.min(Math.max((node.snr + 10) * 5, 0), 100)}%/
               {(node.snr + 10) * 5}raw
             </Mono>,
+            <Mono>
+              {node.viaMqtt === false && node.hopsAway === 0? "Direct": node.hopsAway.toString() + " hops away"}
+              {node.viaMqtt === true? ", via MQTT": ""}
+            </Mono>
           ])}
         />
       </div>

--- a/src/pages/Nodes.tsx
+++ b/src/pages/Nodes.tsx
@@ -57,7 +57,10 @@ export const NodesPage = (): JSX.Element => {
               {(node.snr + 10) * 5}raw
             </Mono>,
             <Mono>
-              {node.viaMqtt === false && node.hopsAway === 0? "Direct": node.hopsAway.toString() + " hops away"}
+              {node.lastHeard != 0 ?
+                (node.viaMqtt === false && node.hopsAway === 0
+                  ? "Direct": node.hopsAway.toString() + " hops away")
+                  : "-"}
               {node.viaMqtt === true? ", via MQTT": ""}
             </Mono>
           ])}


### PR DESCRIPTION
As requested in meshtastic/web#195 meshtastic/web#209, information about whether nodes were connected by MQTT is highly useful for users of the web interface.

This patch adds a new column to the Nodes page which lists whether a connection is direct (0 hops, via lora), or how many hops away and whether the connection is via MQTT.

![Screenshot_20240525_114659](https://github.com/meshtastic/web/assets/1287116/b9614e49-4228-4eb0-b889-dc13bd0572eb)


fixes meshtastic/web#195
fixes meshtastic/web#209