### PR TITLE
fix: move qrcode URL query-string before fragment

### DIFF
--- a/src/components/Dialog/QRDialog.tsx
+++ b/src/components/Dialog/QRDialog.tsx
@@ -51,7 +51,7 @@ export const QRDialog = ({
       .replace(/\//g, "_");
 
     setQrCodeUrl(
-      `https://meshtastic.org/e/#${base64}${qrCodeAdd ? "?add=true" : ""}`,
+      `https://meshtastic.org/e/${qrCodeAdd ? "?add=true" : ""}#${base64}`,
     );
   }, [allChannels, selectedChannels, qrCodeAdd, loraConfig]);
 


### PR DESCRIPTION
Resolves #259.

Pictures of changes:

**Create QR Code Dialog**:
![image](https://github.com/user-attachments/assets/63d0dea1-6353-4a8e-9917-cbb1ed40ebdd)

**Import QR Code Dialog**:
![image](https://github.com/user-attachments/assets/705c34de-65df-497c-895a-99a764dc3b0e)
