### PR TITLE
Allow single character messages in MessageInput

### DIFF
--- a/src/components/PageComponents/Messages/MessageInput.tsx
+++ b/src/components/PageComponents/Messages/MessageInput.tsx
@@ -62,7 +62,7 @@ export const MessageInput = ({
           <span className="w-full">
             <Input
               autoFocus={true}
-              minLength={2}
+              minLength={1}
               placeholder="Enter Message"
               value={messageDraft}
               onChange={(e) => setMessageDraft(e.target.value)}


### PR DESCRIPTION
In character-based languages (eg Chinese, Japanese, Korean), there are many common interjections that are single characters. Allow single character messages to support these users to communicate naturally.

fixes meshtastic/web#264