### PR TITLE
Fix/static ip display

### DIFF
--- a/src/components/PageComponents/Config/Network.tsx
+++ b/src/components/PageComponents/Config/Network.tsx
@@ -10,22 +10,6 @@ import { Protobuf } from "@meshtastic/js";
 export const Network = (): JSX.Element => {
   const { config, setWorkingConfig } = useDevice();
 
-  const netConfig = {
-    wifiEnabled: config.network?.wifiEnabled,
-    wifiSsid: config.network?.wifiSsid,
-    wifiPsk: config.network?.wifiPsk,
-    ethEnabled: config.network?.ethEnabled,
-    addressMode: config.network?.addressMode,
-    ipv4Config: {
-      ip: convertIntToIpAddress(config.network?.ipv4Config?.ip ?? 0),
-      gateway: convertIntToIpAddress(config.network?.ipv4Config?.gateway ?? 0),
-      subnet: convertIntToIpAddress(config.network?.ipv4Config?.subnet ?? 0),
-      dns: convertIntToIpAddress(config.network?.ipv4Config?.dns ?? 0),
-    },
-    ntpServer: config.network?.ntpServer,
-    rsyslogServer: config.network?.rsyslogServer,
-  };
-
   const onSubmit = (data: NetworkValidation) => {
     setWorkingConfig(
       new Protobuf.Config.Config({
@@ -48,7 +32,19 @@ export const Network = (): JSX.Element => {
   return (
     <DynamicForm<NetworkValidation>
       onSubmit={onSubmit}
-      defaultValues={netConfig}
+      defaultValues={{
+        ...config.network,
+        ipv4Config: {
+          ip: convertIntToIpAddress(config.network?.ipv4Config?.ip ?? 0),
+          gateway: convertIntToIpAddress(
+            config.network?.ipv4Config?.gateway ?? 0,
+          ),
+          subnet: convertIntToIpAddress(
+            config.network?.ipv4Config?.subnet ?? 0,
+          ),
+          dns: convertIntToIpAddress(config.network?.ipv4Config?.dns ?? 0),
+        },
+      }}
       fieldGroups={[
         {
           label: "WiFi Config",

--- a/src/components/PageComponents/Config/Network.tsx
+++ b/src/components/PageComponents/Config/Network.tsx
@@ -1,8 +1,11 @@
 import type { NetworkValidation } from "@app/validation/config/network.js";
 import { DynamicForm } from "@components/Form/DynamicForm.js";
 import { useDevice } from "@core/stores/deviceStore.js";
+import {
+  convertIntToIpAddress,
+  convertIpAddressToInt,
+} from "@core/utils/ip.js";
 import { Protobuf } from "@meshtastic/js";
-import { convertIntToIpAddress, convertIpAddressToInt } from "@core/utils/ip.js";
 
 export const Network = (): JSX.Element => {
   const { config, setWorkingConfig } = useDevice();
@@ -21,7 +24,7 @@ export const Network = (): JSX.Element => {
     },
     ntpServer: config.network?.ntpServer,
     rsyslogServer: config.network?.rsyslogServer,
-  }
+  };
 
   const onSubmit = (data: NetworkValidation) => {
     setWorkingConfig(
@@ -30,14 +33,12 @@ export const Network = (): JSX.Element => {
           case: "network",
           value: {
             ...data,
-            ipv4Config: new Protobuf.Config.Config_NetworkConfig_IpV4Config(
-              {
-                ip: convertIpAddressToInt(data.ipv4Config.ip) ?? 0,
-                gateway: convertIpAddressToInt(data.ipv4Config.gateway) ?? 0,
-                subnet: convertIpAddressToInt(data.ipv4Config.subnet) ?? 0,
-                dns: convertIpAddressToInt(data.ipv4Config.dns) ?? 0,
-              },
-            ),
+            ipv4Config: new Protobuf.Config.Config_NetworkConfig_IpV4Config({
+              ip: convertIpAddressToInt(data.ipv4Config.ip) ?? 0,
+              gateway: convertIpAddressToInt(data.ipv4Config.gateway) ?? 0,
+              subnet: convertIpAddressToInt(data.ipv4Config.subnet) ?? 0,
+              dns: convertIpAddressToInt(data.ipv4Config.dns) ?? 0,
+            }),
           },
         },
       }),

--- a/src/components/PageComponents/Config/Network.tsx
+++ b/src/components/PageComponents/Config/Network.tsx
@@ -2,9 +2,26 @@ import type { NetworkValidation } from "@app/validation/config/network.js";
 import { DynamicForm } from "@components/Form/DynamicForm.js";
 import { useDevice } from "@core/stores/deviceStore.js";
 import { Protobuf } from "@meshtastic/js";
+import { convertIntToIpAddress, convertIpAddressToInt } from "@core/utils/ip.js";
 
 export const Network = (): JSX.Element => {
   const { config, setWorkingConfig } = useDevice();
+
+  const netConfig = {
+    wifiEnabled: config.network?.wifiEnabled,
+    wifiSsid: config.network?.wifiSsid,
+    wifiPsk: config.network?.wifiPsk,
+    ethEnabled: config.network?.ethEnabled,
+    addressMode: config.network?.addressMode,
+    ipv4Config: {
+      ip: convertIntToIpAddress(config.network?.ipv4Config?.ip ?? 0),
+      gateway: convertIntToIpAddress(config.network?.ipv4Config?.gateway ?? 0),
+      subnet: convertIntToIpAddress(config.network?.ipv4Config?.subnet ?? 0),
+      dns: convertIntToIpAddress(config.network?.ipv4Config?.dns ?? 0),
+    },
+    ntpServer: config.network?.ntpServer,
+    rsyslogServer: config.network?.rsyslogServer,
+  }
 
   const onSubmit = (data: NetworkValidation) => {
     setWorkingConfig(
@@ -14,7 +31,12 @@ export const Network = (): JSX.Element => {
           value: {
             ...data,
             ipv4Config: new Protobuf.Config.Config_NetworkConfig_IpV4Config(
-              data.ipv4Config,
+              {
+                ip: convertIpAddressToInt(data.ipv4Config.ip) ?? 0,
+                gateway: convertIpAddressToInt(data.ipv4Config.gateway) ?? 0,
+                subnet: convertIpAddressToInt(data.ipv4Config.subnet) ?? 0,
+                dns: convertIpAddressToInt(data.ipv4Config.dns) ?? 0,
+              },
             ),
           },
         },
@@ -25,7 +47,7 @@ export const Network = (): JSX.Element => {
   return (
     <DynamicForm<NetworkValidation>
       onSubmit={onSubmit}
-      defaultValues={config.network}
+      defaultValues={netConfig}
       fieldGroups={[
         {
           label: "WiFi Config",

--- a/src/core/utils/ip.ts
+++ b/src/core/utils/ip.ts
@@ -3,10 +3,10 @@ export function convertIntToIpAddress(int: number): string {
 }
 
 export function convertIpAddressToInt(ip: string): number | null {
-  const parts = ip.split('.').map(Number).reverse(); // little-endian byte order
+  const parts = ip.split(".").map(Number).reverse(); // little-endian byte order
 
   if (parts.some(Number.isNaN)) {
-      return null;
+    return null;
   }
 
   return parts.reduce((total, part) => (total << 8) | part, 0);

--- a/src/core/utils/ip.ts
+++ b/src/core/utils/ip.ts
@@ -1,0 +1,13 @@
+export function convertIntToIpAddress(int: number): string {
+  return `${int & 0xff}.${(int >> 8) & 0xff}.${(int >> 16) & 0xff}.${(int >> 24) & 0xff}`;
+}
+
+export function convertIpAddressToInt(ip: string): number | null {
+  const parts = ip.split('.').map(Number).reverse(); // little-endian byte order
+
+  if (parts.some(Number.isNaN)) {
+      return null;
+  }
+
+  return parts.reduce((total, part) => (total << 8) | part, 0);
+}

--- a/src/core/utils/ip.ts
+++ b/src/core/utils/ip.ts
@@ -3,5 +3,12 @@ export function convertIntToIpAddress(int: number): string {
 }
 
 export function convertIpAddressToInt(ip: string): number | null {
-  return ip.split('.').reverse().reduce((ipnum, octet) => { return (ipnum<<8) + parseInt(octet)}, 0) >>> 0;
+  return (
+    ip
+      .split(".")
+      .reverse()
+      .reduce((ipnum, octet) => {
+        return (ipnum << 8) + Number.parseInt(octet);
+      }, 0) >>> 0
+  );
 }

--- a/src/core/utils/ip.ts
+++ b/src/core/utils/ip.ts
@@ -3,11 +3,5 @@ export function convertIntToIpAddress(int: number): string {
 }
 
 export function convertIpAddressToInt(ip: string): number | null {
-  const parts = ip.split(".").map(Number).reverse(); // little-endian byte order
-
-  if (parts.some(Number.isNaN)) {
-    return null;
-  }
-
-  return parts.reduce((total, part) => (total << 8) | part, 0);
+  return ip.split('.').reverse().reduce((ipnum, octet) => { return (ipnum<<8) + parseInt(octet)}, 0) >>> 0;
 }

--- a/src/validation/config/network.ts
+++ b/src/validation/config/network.ts
@@ -45,17 +45,17 @@ export class NetworkValidationIpV4Config
 {
   @IsIP()
   @IsOptional()
-  ip: number;
+  ip: string;
 
   @IsIP()
   @IsOptional()
-  gateway: number;
+  gateway: string;
 
   @IsIP()
   @IsOptional()
-  subnet: number;
+  subnet: string;
 
   @IsIP()
   @IsOptional()
-  dns: number;
+  dns: string;
 }

--- a/src/validation/config/network.ts
+++ b/src/validation/config/network.ts
@@ -41,7 +41,10 @@ export class NetworkValidation
 
 export class NetworkValidationIpV4Config
   implements
-    Omit<Protobuf.Config.Config_NetworkConfig_IpV4Config, keyof Message>
+    Omit<
+      Protobuf.Config.Config_NetworkConfig_IpV4Config,
+      keyof Message | "ip" | "gateway" | "subnet" | "dns"
+    >
 {
   @IsIP()
   @IsOptional()


### PR DESCRIPTION
I added `convertIntToIpAddress()` and `convertIpAddressToInt()`  .

It is a little janky but it converts INT to IP:
![image](https://github.com/user-attachments/assets/445ebe37-5fca-43a2-8750-eb062a4db899)

And also IP to INT:
![image](https://github.com/user-attachments/assets/a2be1396-d895-46a9-9bc8-13abc4f3ecef)

The problem is that validator inheritances types from protobuf, so it expects a number instead of a string:
![image](https://github.com/user-attachments/assets/0492137f-72a7-497e-9634-af5b56710f93)

Can they be decoupled?

```javascript
export class NetworkValidationIpV4Config {
.
.
.
```
