### PR TITLE
feat: Provide compressed build during PR GitHub Action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm package
 
       - name: Archive compressed build
-        uses: actions/upload -artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: dist/build.tar

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,3 +19,12 @@ jobs:
 
       - name: Build Package
         run: pnpm build
+
+      - name: Compress build
+        run: pnpm package
+
+      - name: Archive compressed build
+        uses: actions/upload -artifact@v4
+        with:
+          name: build
+          path: dist/build.tar


### PR DESCRIPTION
This PR Adds:
 - An extra step to the PR GitHub Action that will package the build files to make it accessible as an artifact.
[GitHub Docs for where to find artifact](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/downloading-workflow-artifacts)