### PR TITLE
feat: Only do `CI` GHA on push to `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR scopes the `CI` GitHub Action to only run on pushes to `master`. This should prevent builds on PRs and if a PR is merged to `master`, it will do the `CI` afterwards.