### PR TITLE
Remove Channel Accuracy from Position settings

### DIFF
--- a/src/components/PageComponents/Config/Position.tsx
+++ b/src/components/PageComponents/Config/Position.tsx
@@ -78,10 +78,39 @@ export const Position = (): JSX.Element => {
               description: "GPS module enable pin override",
             },
             {
-              type: "number",
+              type: "select",
               name: "channelPrecision",
               label: "Channel Precision",
-              description: "GPS channel precision",
+              description:
+                "GPS channel precision",
+              properties: {
+                enumValue:
+                  config.display?.units === 0
+                    ? {
+                        "Within 23 km": 10,
+                        "Within 12 km": 11,
+                        "Within 5.8 km": 12,
+                        "Within 2.9 km": 13,
+                        "Within 1.5 km": 14,
+                        "Within 700 m": 15,
+                        "Within 350 m": 16,
+                        "Within 200 m": 17,
+                        "Within 90 m": 18,
+                        "Within 50 m": 19,
+                      }
+                    : {
+                        "Within 15 miles": 10,
+                        "Within 7.3 miles": 11,
+                        "Within 3.6 miles": 12,
+                        "Within 1.8 miles": 13,
+                        "Within 0.9 miles": 14,
+                        "Within 0.5 miles": 15,
+                        "Within 0.2 miles": 16,
+                        "Within 600 feet": 17,
+                        "Within 300 feet": 18,
+                        "Within 150 feet": 19,
+                      },
+              },
             },
           ],
         },

--- a/src/components/PageComponents/Config/Position.tsx
+++ b/src/components/PageComponents/Config/Position.tsx
@@ -77,41 +77,6 @@ export const Position = (): JSX.Element => {
               label: "Enable Pin",
               description: "GPS module enable pin override",
             },
-            {
-              type: "select",
-              name: "channelPrecision",
-              label: "Channel Precision",
-              description:
-                "GPS channel precision",
-              properties: {
-                enumValue:
-                  config.display?.units === 0
-                    ? {
-                        "Within 23 km": 10,
-                        "Within 12 km": 11,
-                        "Within 5.8 km": 12,
-                        "Within 2.9 km": 13,
-                        "Within 1.5 km": 14,
-                        "Within 700 m": 15,
-                        "Within 350 m": 16,
-                        "Within 200 m": 17,
-                        "Within 90 m": 18,
-                        "Within 50 m": 19,
-                      }
-                    : {
-                        "Within 15 miles": 10,
-                        "Within 7.3 miles": 11,
-                        "Within 3.6 miles": 12,
-                        "Within 1.8 miles": 13,
-                        "Within 0.9 miles": 14,
-                        "Within 0.5 miles": 15,
-                        "Within 0.2 miles": 16,
-                        "Within 600 feet": 17,
-                        "Within 300 feet": 18,
-                        "Within 150 feet": 19,
-                      },
-              },
-            },
           ],
         },
         {

--- a/src/validation/config/position.ts
+++ b/src/validation/config/position.ts
@@ -43,7 +43,4 @@ export class PositionValidation
 
   @IsEnum(Protobuf.Config.Config_PositionConfig_GpsMode)
   gpsMode: Protobuf.Config.Config_PositionConfig_GpsMode;
-
-  @IsArray()
-  channelPrecision: number[];
 }


### PR DESCRIPTION
Fix #301 

Removes Precision settings from Position config as its no longer in the protobufs