### PR TITLE
document scalar clamping of curve25519 keys

### DIFF
--- a/src/core/utils/x25519.ts
+++ b/src/core/utils/x25519.ts
@@ -3,6 +3,8 @@ import { x25519 } from "@noble/curves/ed25519";
 export function getX25519PrivateKey(): Uint8Array {
   const key = x25519.utils.randomPrivateKey();
 
+  // scalar clamping for curve25519, according to
+  // https://www.rfc-editor.org/rfc/rfc7748#section-5
   key[0] &= 248;
   key[31] &= 127;
   key[31] |= 64;


### PR DESCRIPTION
The "scalars" are just random bytes. To make them secure curve25519 keys, they need to be clamped according to rfc7748 section 5. As this is not obvious, we need to add a reference to the RFC.

No functional change.

Closes: #324