### PR TITLE
feat: Add AttributionControl to Map to comply with OSM license requirements

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -16,7 +16,7 @@ import {
   ZoomOutIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { Marker, useMap } from "react-map-gl";
+import { AttributionControl, Marker, useMap } from "react-map-gl";
 import MapGl from "react-map-gl/maplibre";
 
 export const MapPage = (): JSX.Element => {
@@ -126,6 +126,7 @@ export const MapPage = (): JSX.Element => {
           // }}
 
           // @ts-ignore
+
           attributionControl={false}
           renderWorldCopies={false}
           maxPitch={0}
@@ -142,6 +143,9 @@ export const MapPage = (): JSX.Element => {
             longitude: 0,
           }}
         >
+          <AttributionControl
+            style={{ background: darkMode ? "#ffffff" : "", color: darkMode ? "black" : "" }}
+          />
           {waypoints.map((wp) => (
             <Marker
               key={wp.id}


### PR DESCRIPTION
Adds the attribution control to the Map page, as mentioned in the issue #348 this is a license requirement for using OpenStreetMap. The attribution was adding using a single line, and I re-used the `darkMode` variable to ensure custom style are applied  so it would display correctly depending on the users light or dark mode preference. 

<img width="1286" alt="image" src="https://github.com/user-attachments/assets/c0bc84c8-8c5a-4019-ad95-2c28cdebb659" />
