### PR TITLE
fix: Node map detail dark mode

### DIFF
--- a/src/components/PageComponents/Map/NodeDetail.tsx
+++ b/src/components/PageComponents/Map/NodeDetail.tsx
@@ -30,7 +30,7 @@ export const NodeDetail = ({ node }: NodeDetailProps): JSX.Element => {
   ].replaceAll("_", " ");
 
   return (
-    <>
+    <div className="dark:text-black">
       <div className="flex gap-2">
         <div className="flex flex-col items-center gap-2 min-w-6 pt-1">
           <Hashicon value={node.num.toString()} size={22} />
@@ -166,6 +166,6 @@ export const NodeDetail = ({ node }: NodeDetailProps): JSX.Element => {
           </Mono>
         </div>
       )}
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
Fixed the issue where the new Node detail view had low contrast in dark mode.

Follow-up to #350

<img width="266" alt="Screenshot 2025-01-11 at 8 33 05 PM" src="https://github.com/user-attachments/assets/774ee5c3-2e44-40d0-9c85-6494155cbd4c" />
