### PR TITLE
Feature / Added date to messages displayed

### DIFF
--- a/src/components/PageComponents/Messages/Message.tsx
+++ b/src/components/PageComponents/Messages/Message.tsx
@@ -45,6 +45,9 @@ export const Message = ({
           {sender?.user?.longName ?? "UNK"}
         </span>
         <span className="mt-1 font-mono text-xs text-textSecondary">
+          {message.rxTime.toLocaleDateString()} 
+        </span>
+        <span className="mt-1 font-mono text-xs text-textSecondary">
           {message.rxTime.toLocaleTimeString(undefined, {
             hour: "2-digit",
             minute: "2-digit",


### PR DESCRIPTION
This PR just adds the date to the messages listed.  This is helpful in the case of channels or nodes to narrow down the date of the message