### PR TITLE
feat: add bundle analyzer script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "build": "pnpm check && rsbuild build",
+    "build:analyze": "BUNDLE_ANALYZE=true rsbuild build",
     "check": "biome check src/",
     "check:fix": "pnpm check --write src/",
     "format": "biome format --write src/",


### PR DESCRIPTION
- Added ability to easily run bundle analyzer script.
- This will output an .html file in the <project root>/dist/ folder.
- Very useful for understanding which packages make up our JS bundle, and the size of each package