### PR TITLE
fix: improve styling of messages

### DIFF
--- a/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -39,7 +39,6 @@ export const ChannelChat = ({
           scrollContainer.scrollTop -
           scrollContainer.clientHeight <
         100;
-
       if (isNearBottom) {
         messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
       }
@@ -52,8 +51,8 @@ export const ChannelChat = ({
 
   if (!messages?.length) {
     return (
-      <div className="flex flex-col h-full">
-        <div className="flex-1 flex items-center justify-center overflow-y-auto">
+      <div className="flex flex-col h-full w-full">
+        <div className="flex-1 flex items-center justify-center">
           <EmptyState />
         </div>
         <div className="flex-shrink-0 p-4 w-full bg-gray-900">
@@ -64,9 +63,9 @@ export const ChannelChat = ({
   }
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex-1 overflow-y-auto" ref={scrollContainerRef}>
-        <div className="w-full min-h-full flex flex-col justify-end">
+    <div className="flex flex-col h-full w-full">
+      <div className="flex-1 overflow-y-scroll w-full" ref={scrollContainerRef}>
+        <div className="w-full h-full flex flex-col justify-end">
           {messages.map((message, index) => (
             <Message
               key={message.id}
@@ -77,10 +76,10 @@ export const ChannelChat = ({
               sender={nodes.get(message.from)}
             />
           ))}
-          <div ref={messagesEndRef} />
+          <div ref={messagesEndRef} className="w-full" />
         </div>
       </div>
-      <div className="flex-shrink-0 p-4 w-full bg-gray-900">
+      <div className="flex-shrink-0 mt-2 p-4 w-full bg-gray-900">
         <MessageInput to={to} channel={channel} />
       </div>
     </div>

--- a/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -1,4 +1,3 @@
-import { Subtle } from "@app/components/UI/Typography/Subtle.tsx";
 import {
   type MessageWithState,
   useDevice,

--- a/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -8,6 +8,7 @@ import { MessageInput } from "@components/PageComponents/Messages/MessageInput.t
 import { TraceRoute } from "@components/PageComponents/Messages/TraceRoute.tsx";
 import type { Protobuf, Types } from "@meshtastic/js";
 import { InboxIcon } from "lucide-react";
+import type { JSX } from "react";
 
 export interface ChannelChatProps {
   messages?: MessageWithState[];
@@ -15,6 +16,13 @@ export interface ChannelChatProps {
   to: Types.Destination;
   traceroutes?: Types.PacketMetadata<Protobuf.Mesh.RouteDiscovery>[];
 }
+
+const EmptyState = () => (
+  <div className="flex flex-col place-content-center place-items-center p-8 text-white">
+    <InboxIcon className="h-8 w-8 mb-2" />
+    <span className="text-sm">No Messages</span>
+  </div>
+);
 
 export const ChannelChat = ({
   messages,
@@ -24,53 +32,53 @@ export const ChannelChat = ({
 }: ChannelChatProps): JSX.Element => {
   const { nodes } = useDevice();
 
+  if (!messages?.length) {
+    return (
+      <>
+        <div className="flex place-content-center place-items-center h-full">
+          <EmptyState />
+        </div>
+        <div className="mt-auto pb-4 w-full">
+          <MessageInput to={to} channel={channel} />
+        </div>
+      </>
+    );
+  }
+
   return (
-    <div className="flex flex-grow flex-col">
-      <div className="flex flex-grow">
-        <div className="flex flex-grow flex-col">
-          {messages ? (
-            messages.map((message, index) => (
-              <Message
-                key={message.id}
-                message={message}
-                lastMsgSameUser={
-                  index === 0
-                    ? false
-                    : messages[index - 1].from === message.from
-                }
-                sender={nodes.get(message.from)}
-              />
-            ))
-          ) : (
-            <div className="m-auto">
-              <InboxIcon className="m-auto" />
-              <Subtle>No Messages</Subtle>
-            </div>
-          )}
+    <>
+      <div className="flex flex-col h-full">
+        <div className="w-full">
+          {messages.map((message, index) => (
+            <Message
+              key={message.id}
+              message={message}
+              lastMsgSameUser={
+                index > 0 && messages[index - 1].from === message.from
+              }
+              sender={nodes.get(message.from)}
+            />
+          ))}
         </div>
-        <div
-          className={`flex flex-grow flex-col border-slate-400 border-l ${traceroutes === undefined ? "hidden" : ""}`}
-        >
-          {to === "broadcast" ? null : traceroutes ? (
-            traceroutes.map((traceroute, index) => (
-              <TraceRoute
-                key={traceroute.id}
-                from={nodes.get(traceroute.from)}
-                to={nodes.get(traceroute.to)}
-                route={traceroute.data.route}
-              />
-            ))
-          ) : (
-            <div className="m-auto">
-              <InboxIcon className="m-auto" />
-              <Subtle>No Traceroutes</Subtle>
-            </div>
-          )}
+        <div className="mt-auto pb-4 w-full">
+          <MessageInput to={to} channel={channel} />
         </div>
       </div>
-      <div className="pl-3 pr-3 pt-3 pb-1">
-        <MessageInput to={to} channel={channel} />
-      </div>
-    </div>
+      {/* {to === "broadcast" ? null : traceroutes ? (
+        traceroutes.map((traceroute, index) => (
+          <TraceRoute
+            key={traceroute.id}
+            from={nodes.get(traceroute.from)}
+            to={nodes.get(traceroute.to)}
+            route={traceroute.data.route}
+          />
+        ))
+      ) : (
+        <div className="m-auto">
+          <InboxIcon className="m-auto" />
+          <Subtle>No Traceroutes</Subtle>
+        </div>
+      )} */}
+    </>
   );
 };

--- a/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -56,7 +56,7 @@ export const ChannelChat = ({
           <EmptyState />
         </div>
         <div className="flex-shrink-0 p-4 w-full bg-gray-900">
-          <MessageInput to={to} channel={channel} />
+          <MessageInput to={to} channel={channel} maxBytes={200} />
         </div>
       </div>
     );

--- a/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -5,8 +5,7 @@ import {
 } from "@app/core/stores/deviceStore.ts";
 import { Message } from "@components/PageComponents/Messages/Message.tsx";
 import { MessageInput } from "@components/PageComponents/Messages/MessageInput.tsx";
-import { TraceRoute } from "@components/PageComponents/Messages/TraceRoute.tsx";
-import type { Protobuf, Types } from "@meshtastic/js";
+import type { Types } from "@meshtastic/js";
 import { InboxIcon } from "lucide-react";
 import type { JSX } from "react";
 
@@ -14,7 +13,6 @@ export interface ChannelChatProps {
   messages?: MessageWithState[];
   channel: Types.ChannelNumber;
   to: Types.Destination;
-  traceroutes?: Types.PacketMetadata<Protobuf.Mesh.RouteDiscovery>[];
 }
 
 const EmptyState = () => (
@@ -28,7 +26,6 @@ export const ChannelChat = ({
   messages,
   channel,
   to,
-  traceroutes,
 }: ChannelChatProps): JSX.Element => {
   const { nodes } = useDevice();
 
@@ -64,21 +61,6 @@ export const ChannelChat = ({
           <MessageInput to={to} channel={channel} />
         </div>
       </div>
-      {/* {to === "broadcast" ? null : traceroutes ? (
-        traceroutes.map((traceroute, index) => (
-          <TraceRoute
-            key={traceroute.id}
-            from={nodes.get(traceroute.from)}
-            to={nodes.get(traceroute.to)}
-            route={traceroute.data.route}
-          />
-        ))
-      ) : (
-        <div className="m-auto">
-          <InboxIcon className="m-auto" />
-          <Subtle>No Traceroutes</Subtle>
-        </div>
-      )} */}
     </>
   );
 };

--- a/src/components/PageComponents/Messages/Message.tsx
+++ b/src/components/PageComponents/Messages/Message.tsx
@@ -1,11 +1,7 @@
 import type { MessageWithState } from "@app/core/stores/deviceStore.ts";
 import { Avatar } from "@components/UI/Avatar";
 import type { Protobuf } from "@meshtastic/js";
-import {
-  AlertCircleIcon,
-  CheckCircle2Icon,
-  CircleEllipsisIcon,
-} from "lucide-react";
+import { AlertCircle, CheckCircle2, CircleEllipsis } from "lucide-react";
 
 export interface MessageProps {
   lastMsgSameUser: boolean;
@@ -13,61 +9,62 @@ export interface MessageProps {
   sender?: Protobuf.Mesh.NodeInfo;
 }
 
+const StatusIcon = ({ state }: { state: MessageWithState["state"] }) => {
+  const iconClass = "text-gray-500 dark:text-gray-400 w-4 h-4";
+  switch (state) {
+    case "ack":
+      return <CheckCircle2 className={iconClass} />;
+    case "waiting":
+      return <CircleEllipsis className={iconClass} />;
+    default:
+      return <AlertCircle className={iconClass} />;
+  }
+};
+
 export const Message = ({ lastMsgSameUser, message, sender }: MessageProps) => {
-  return lastMsgSameUser ? (
-    <div className="ml-5 flex">
-      {message.state === "ack" ? (
-        <CheckCircle2Icon size={16} className="my-auto text-textSecondary" />
-      ) : message.state === "waiting" ? (
-        <CircleEllipsisIcon size={16} className="my-auto text-textSecondary" />
-      ) : (
-        <AlertCircleIcon size={16} className="my-auto text-textSecondary" />
-      )}
-      <span
-        className={`ml-4 border-l-2 border-l-backgroundPrimary pl-2 ${
-          message.state === "ack" ? "text-textPrimary" : "text-textSecondary"
-        }`}
-      >
-        {message.data}
-      </span>
-    </div>
-  ) : (
-    <div className="mx-4 mt-2 gap-2">
-      <div className="flex gap-2">
-        <div className="w-6 cursor-pointer">
-          <Avatar text={sender?.user?.shortName ?? "UNK"} />
+  const messageTextClass =
+    message.state === "ack"
+      ? "text-gray-900 dark:text-white"
+      : "text-gray-500 dark:text-gray-400";
+  if (lastMsgSameUser) {
+    return (
+      <div className="mx-4 mt-2">
+        <div className="ml-12 flex items-start gap-2">
+          <div
+            className={`${messageTextClass} border-l-2 border-gray-200 dark:border-gray-700 pl-4 flex-grow`}
+          >
+            {message.data}
+          </div>
+          <StatusIcon state={message.state} />
         </div>
-        <span className="cursor-pointer font-medium text-textPrimary">
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-4 mt-2 space-y-2">
+      <div className="flex items-center gap-2">
+        <Avatar text={sender?.user?.shortName ?? "UNK"} />
+        <span className="font-medium text-gray-900 dark:text-white">
           {sender?.user?.longName ?? "UNK"}
         </span>
-        <span className="mt-1 font-mono text-xs text-textSecondary">
+        <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
           {message.rxTime.toLocaleDateString()}
         </span>
-        <span className="mt-1 font-mono text-xs text-textSecondary">
+        <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
           {message.rxTime.toLocaleTimeString(undefined, {
             hour: "2-digit",
             minute: "2-digit",
           })}
         </span>
       </div>
-      <div className="ml-1 flex">
-        {message.state === "ack" ? (
-          <CheckCircle2Icon size={16} className="my-auto text-textSecondary" />
-        ) : message.state === "waiting" ? (
-          <CircleEllipsisIcon
-            size={16}
-            className="my-auto text-textSecondary"
-          />
-        ) : (
-          <AlertCircleIcon size={16} className="my-auto text-textSecondary" />
-        )}
-        <span
-          className={`ml-4 border-l-2 border-l-backgroundPrimary pl-2 ${
-            message.state === "ack" ? "text-textPrimary" : "text-textSecondary"
-          }`}
+      <div className="ml-12 flex items-start gap-2">
+        <div
+          className={`${messageTextClass} border-l-2 border-gray-200 dark:border-gray-700 pl-4 flex-grow`}
         >
           {message.data}
-        </span>
+        </div>
+        <StatusIcon state={message.state} />
       </div>
     </div>
   );

--- a/src/components/PageComponents/Messages/Message.tsx
+++ b/src/components/PageComponents/Messages/Message.tsx
@@ -1,4 +1,5 @@
 import type { MessageWithState } from "@app/core/stores/deviceStore.ts";
+import { cn } from "@app/core/utils/cn";
 import { Avatar } from "@components/UI/Avatar";
 import type { Protobuf } from "@meshtastic/js";
 import * as Tooltip from "@radix-ui/react-tooltip";
@@ -45,8 +46,14 @@ const StatusTooltip = ({ state, children }: StatusTooltipProps) => (
   </Tooltip.Provider>
 );
 
-const StatusIcon = ({ state }: { state: MessageWithState["state"] }) => {
-  const iconClass = "text-gray-500 dark:text-gray-400 w-4 h-4";
+const StatusIcon = ({
+  state,
+  className,
+}: { state: MessageWithState["state"]; className?: string }) => {
+  const iconClass = cn(
+    className,
+    "text-gray-500 dark:text-gray-400 w-4 h-4 flex-shrink-0",
+  );
   const Icon = (() => {
     switch (state) {
       case "ack":
@@ -57,7 +64,6 @@ const StatusIcon = ({ state }: { state: MessageWithState["state"] }) => {
         return AlertCircle;
     }
   })();
-
   return (
     <StatusTooltip state={state}>
       <Icon className={iconClass} />
@@ -66,50 +72,52 @@ const StatusIcon = ({ state }: { state: MessageWithState["state"] }) => {
 };
 
 export const Message = ({ lastMsgSameUser, message, sender }: MessageProps) => {
-  const messageTextClass =
+  const messageTextClass = cn(
+    "border-l-2 pl-4 break-words min-w-0",
     message.state === "ack"
       ? "text-gray-900 dark:text-white"
-      : "text-gray-500 dark:text-gray-400";
+      : "text-gray-500 dark:text-gray-400",
+    lastMsgSameUser
+      ? "border-gray-600 dark:border-gray-700"
+      : "border-gray-200 dark:border-gray-600",
+  );
 
-  if (lastMsgSameUser) {
-    return (
-      <div className="mx-4 mt-2">
-        <div className="ml-12 flex items-start gap-2">
-          <div
-            className={`${messageTextClass} border-l-2 border-gray-200 dark:border-gray-700 pl-4 flex-grow`}
-          >
-            {message.data}
-          </div>
-          <StatusIcon state={message.state} />
-        </div>
-      </div>
-    );
-  }
+  const baseMessageWrapper = cn(
+    "ml-12 flex items-start gap-2 w-full max-w-full",
+    lastMsgSameUser ? "mt-1" : "mt-4",
+    !lastMsgSameUser && "flex-wrap flex-grow",
+  );
+
+  const containerClass = cn(
+    "px-4 relative",
+    lastMsgSameUser ? "mt-0" : "mt-2",
+    !lastMsgSameUser && "pt-2",
+  );
 
   return (
-    <div className="mx-4 mt-2 space-y-2">
-      <div className="flex items-center gap-2">
-        <Avatar text={sender?.user?.shortName ?? "UNK"} />
-        <span className="font-medium text-gray-900 dark:text-white">
-          {sender?.user?.longName ?? "UNK"}
-        </span>
-        <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
-          {message.rxTime.toLocaleDateString()}
-        </span>
-        <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
-          {message.rxTime.toLocaleTimeString(undefined, {
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
-        </span>
-      </div>
-      <div className="ml-12 flex items-start gap-2">
-        <div
-          className={`${messageTextClass} border-l-2 border-gray-200 dark:border-gray-700 pl-4 flex-grow`}
-        >
-          {message.data}
+    <div className={containerClass}>
+      {!lastMsgSameUser && (
+        <div className="flex items-center gap-2 mb-2">
+          <Avatar text={sender?.user?.shortName ?? "UNK"} />
+          <span className="font-medium text-gray-900 dark:text-white">
+            {sender?.user?.longName ?? "UNK"}
+          </span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
+            {message.rxTime.toLocaleDateString()}
+          </span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
+            {message.rxTime.toLocaleTimeString(undefined, {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </span>
         </div>
-        <StatusIcon state={message.state} />
+      )}
+      <div className={baseMessageWrapper}>
+        <div className="flex-1 min-w-0">
+          <div className={messageTextClass}>{message.data}</div>
+        </div>
+        <StatusIcon state={message.state} className="ml-auto" />
       </div>
     </div>
   );

--- a/src/components/PageComponents/Messages/Message.tsx
+++ b/src/components/PageComponents/Messages/Message.tsx
@@ -1,6 +1,7 @@
 import type { MessageWithState } from "@app/core/stores/deviceStore.ts";
 import { Avatar } from "@components/UI/Avatar";
 import type { Protobuf } from "@meshtastic/js";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { AlertCircle, CheckCircle2, CircleEllipsis } from "lucide-react";
 
 export interface MessageProps {
@@ -9,16 +10,59 @@ export interface MessageProps {
   sender?: Protobuf.Mesh.NodeInfo;
 }
 
-const StatusIcon = ({ state }: { state: MessageWithState["state"] }) => {
-  const iconClass = "text-gray-500 dark:text-gray-400 w-4 h-4";
+interface StatusTooltipProps {
+  state: MessageWithState["state"];
+  children: React.ReactNode;
+}
+
+const getStatusText = (state: MessageWithState["state"]): string => {
   switch (state) {
     case "ack":
-      return <CheckCircle2 className={iconClass} />;
+      return "Message delivered";
     case "waiting":
-      return <CircleEllipsis className={iconClass} />;
+      return "Waiting for delivery";
     default:
-      return <AlertCircle className={iconClass} />;
+      return "Delivery failed";
   }
+};
+
+const StatusTooltip = ({ state, children }: StatusTooltipProps) => (
+  <Tooltip.Provider>
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          className="rounded-md bg-slate-800 px-3 py-1.5 text-sm text-white shadow-md animate-in fade-in-0 zoom-in-95"
+          side="top"
+          align="center"
+          sideOffset={5}
+        >
+          {getStatusText(state)}
+          <Tooltip.Arrow className="fill-slate-800" />
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  </Tooltip.Provider>
+);
+
+const StatusIcon = ({ state }: { state: MessageWithState["state"] }) => {
+  const iconClass = "text-gray-500 dark:text-gray-400 w-4 h-4";
+  const Icon = (() => {
+    switch (state) {
+      case "ack":
+        return CheckCircle2;
+      case "waiting":
+        return CircleEllipsis;
+      default:
+        return AlertCircle;
+    }
+  })();
+
+  return (
+    <StatusTooltip state={state}>
+      <Icon className={iconClass} />
+    </StatusTooltip>
+  );
 };
 
 export const Message = ({ lastMsgSameUser, message, sender }: MessageProps) => {
@@ -26,6 +70,7 @@ export const Message = ({ lastMsgSameUser, message, sender }: MessageProps) => {
     message.state === "ack"
       ? "text-gray-900 dark:text-white"
       : "text-gray-500 dark:text-gray-400";
+
   if (lastMsgSameUser) {
     return (
       <div className="mx-4 mt-2">

--- a/src/components/PageComponents/Messages/MessageInput.tsx
+++ b/src/components/PageComponents/Messages/MessageInput.tsx
@@ -4,7 +4,7 @@ import { Input } from "@components/UI/Input.tsx";
 import { useDevice } from "@core/stores/deviceStore.ts";
 import type { Types } from "@meshtastic/js";
 import { SendIcon } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { type JSX, useCallback, useMemo, useState } from "react";
 
 export interface MessageInputProps {
   to: Types.Destination;

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -49,7 +49,7 @@ export const PageLayout = ({
         </div>
         <div
           className={cn(
-            "flex h-full w-full flex-col",
+            "flex h-full w-full flex-col overflow-y-auto",
             !noPadding && "pl-3 pr-3 ",
           )}
         >

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -49,7 +49,7 @@ export const PageLayout = ({
         </div>
         <div
           className={cn(
-            "flex h-full w-full flex-col overflow-y-auto",
+            "flex h-full w-full flex-col",
             !noPadding && "pl-3 pr-3 ",
           )}
         >

--- a/src/components/UI/Footer.tsx
+++ b/src/components/UI/Footer.tsx
@@ -6,7 +6,7 @@ const Footer = React.forwardRef<HTMLElement, FooterProps>(
   ({ className, ...props }, ref) => {
     return (
       <footer
-        className={`flex flex- justify-center p-2 ${className}`}
+        className={`flex mt-auto justify-center p-2 ${className}`}
         style={{
           backgroundColor: "var(--backgroundPrimary)",
           color: "var(--textPrimary)",

--- a/src/components/UI/Sidebar/sidebarButton.tsx
+++ b/src/components/UI/Sidebar/sidebarButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@components/UI/Button.tsx";
 import type { LucideIcon } from "lucide-react";
+import type { JSX } from "react";
 
 export interface SidebarButtonProps {
   label: string;
@@ -20,10 +21,10 @@ export const SidebarButton = ({
     onClick={onClick}
     variant={active ? "subtle" : "ghost"}
     size="sm"
-    className="w-full justify-start gap-2"
+    className="flex gap-2"
   >
     {Icon && <Icon size={16} />}
     {element && element}
-    {label}
+    <span className="flex flex-1 justify-start flex-shrink-0">{label}</span>
   </Button>
 );

--- a/src/components/UI/Sidebar/sidebarButton.tsx
+++ b/src/components/UI/Sidebar/sidebarButton.tsx
@@ -21,7 +21,7 @@ export const SidebarButton = ({
     onClick={onClick}
     variant={active ? "subtle" : "ghost"}
     size="sm"
-    className="flex gap-2"
+    className="flex gap-2 w-full"
   >
     {Icon && <Icon size={16} />}
     {element && element}

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -131,7 +131,6 @@ const MessagesPage = () => {
                   to={activeChat}
                   messages={messages.direct.get(node.num)}
                   channel={Types.ChannelNumber.Primary}
-                  traceroutes={traceroutes.get(node.num)}
                 />
               ),
           )}

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -108,21 +108,6 @@ const MessagesPage = () => {
                       });
                     },
                   },
-                  {
-                    icon: WaypointsIcon,
-                    async onClick() {
-                      const targetNode = nodes.get(activeChat)?.num;
-                      if (targetNode === undefined) return;
-                      toast({
-                        title: "Sending Traceroute, please wait...",
-                      });
-                      await connection?.traceRoute(targetNode).then(() =>
-                        toast({
-                          title: "Traceroute sent.",
-                        }),
-                      );
-                    },
-                  },
                 ]
               : []
           }


### PR DESCRIPTION
- Modified message layout to improve alignment of Avatar and longName
- Maintained existing message styling and state indicators (ack, waiting, error)
- Improved alignment of message text to long name 

<img width="2758" alt="Screenshot 2025-01-29 at 4 14 12 pm" src="https://github.com/user-attachments/assets/f6ea6d52-8fd8-4736-a72c-a9905b55902a" />
<img width="2758" alt="Screenshot 2025-01-29 at 4 14 18 pm" src="https://github.com/user-attachments/assets/216c8e0a-74a0-43b9-9b9d-09fc2f560f14" />
<img width="2758" alt="Screenshot 2025-01-29 at 4 14 23 pm" src="https://github.com/user-attachments/assets/ff098d15-d69c-48f7-ade2-0453c9b72115" />
