### PR TITLE
fix: Map Action Buttons key

### DIFF
--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -35,7 +35,7 @@ export const PageLayout = ({
               <div className="flex justify-end space-x-4">
                 {actions?.map((action, index) => (
                   <button
-                    key={action.icon.name}
+                    key={action.icon.displayName}
                     type="button"
                     className="transition-all hover:text-accent"
                     onClick={action.onClick}


### PR DESCRIPTION
<img width="832" alt="Screenshot 2025-01-30 at 19 49 19" src="https://github.com/user-attachments/assets/f43d9cb7-a673-4006-8720-666aa184a13f" />
<img width="816" alt="Screenshot 2025-01-30 at 19 50 29" src="https://github.com/user-attachments/assets/fd211523-20b0-47a0-84bf-0075b3f47c6c" />

Small change because React was shouting that we use the same keys. It happened that all of them were undefined, so I changed the key to the correct ID name.