### PR TITLE
fix: update value for tak tracker device role

### DIFF
--- a/src/components/PageComponents/Config/Device.tsx
+++ b/src/components/PageComponents/Config/Device.tsx
@@ -46,7 +46,7 @@ export const Device = (): JSX.Element => {
                   "Lost and Found":
                     Protobuf.Config.Config_DeviceConfig_Role.LOST_AND_FOUND,
                   "TAK Tracker":
-                    Protobuf.Config.Config_DeviceConfig_Role.SENSOR,
+                    Protobuf.Config.Config_DeviceConfig_Role.TAK_TRACKER,
                 },
                 formatEnumName: true,
               },


### PR DESCRIPTION
Fixes #392 

As the user had noted in their bug, the association between Tak Tracker device role and value aren't correct. This PR will update the name value with the correct value in the protobuf. 