### PR TITLE
added: added lint-staged to allow linting runs when a file is staged.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "simple-git-hooks": {
     "pre-commit": "npm run check:fix && npm run format"
   },
+  "lint-staged": {
+    "*.{ts,tsx}": ["npm run check:fix", "npm run format"]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/meshtastic/web.git"


### PR DESCRIPTION
This solves solves the issue of committing files in VSCode without staging them first, our pre-commit hook will lint/format the files, leading to more changes to commit after the initial commit. This change prevents that by linting/formatting any file moved into your git stage. 