### PR TITLE
fix: fixed issue with toast background opacity in light mode

### DIFF
--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
         success:
           "bg-green-500 text-white hover:bg-green-600 dark:hover:bg-green-600",
         outline:
-          "bg-transparent border border-slate-200 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-100",
+          "bg-transparent border border-slate-200 hover:bg-slate-100 dark:border-slate-400 dark:text-slate-100",
         subtle:
           "bg-slate-100 text-slate-900 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-100",
         ghost:

--- a/src/components/UI/Toast.tsx
+++ b/src/components/UI/Toast.tsx
@@ -28,7 +28,7 @@ const toastVariants = cva(
     variants: {
       variant: {
         default:
-          "border bg-background text-foreground dark:bg-slate-700 dark:border-slate-600 dark:text-slate-50",
+          "border bg-backgroundPrimary text-foreground dark:bg-slate-700 dark:border-slate-600 dark:text-slate-50",
         destructive:
           "group destructive bg-red-600 text-white dark:border-red-900 dark:bg-red-900 dark:text-red-50",
       },


### PR DESCRIPTION
Fixes #425 

<img width="658" alt="Screenshot 2025-02-14 at 11 19 51 am" src="https://github.com/user-attachments/assets/6cec2f79-c458-40ba-b717-30f832f847cc" />
 
<img width="521" alt="Screenshot 2025-02-14 at 11 30 52 am" src="https://github.com/user-attachments/assets/2443d448-feba-4676-abe3-fb82303d76ad" />
