### PR TITLE
fix: remove Biome formatting from build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Meshtastic web client",
   "license": "GPL-3.0-only",
   "scripts": {
-    "build": "pnpm check && rsbuild build",
+    "build": "rsbuild build",
     "build:analyze": "BUNDLE_ANALYZE=true rsbuild build",
     "check": "biome check src/",
     "check:fix": "pnpm check --write src/",


### PR DESCRIPTION
Changes:
- Remove `pnpm check` from the build script to decouple formatting checks from the build process
- Formatting and checks are still enforced via pre-commit hooks
- Build process is now faster and more focused on just building the application

Rationale:
Separating code formatting from the build step follows the single responsibility principle and allows for more efficient CI/CD pipelines. Code quality is still maintained through pre-commit hooks and can be run manually with `pnpm check` and `pnpm format`.