### PR TITLE
fix: Add 6-digit BLE PIN validation and error management

### DIFF
--- a/src/components/Form/FormSelect.tsx
+++ b/src/components/Form/FormSelect.tsx
@@ -13,6 +13,7 @@ import { Controller, type FieldValues } from "react-hook-form";
 
 export interface SelectFieldProps<T> extends BaseFormBuilderProps<T> {
   type: "select";
+  selectChange?: (e: string) => void;
   properties: BaseFormBuilderProps<T>["properties"] & {
     enumValue: {
       [s: string]: string | number;
@@ -40,7 +41,10 @@ export function SelectInput<T extends FieldValues>({
           : [];
         return (
           <Select
-            onValueChange={(e) => onChange(Number.parseInt(e))}
+            onValueChange={(e) => {
+              if (field.selectChange) field.selectChange(e);
+              onChange(Number.parseInt(e));
+            }}
             disabled={disabled}
             value={value?.toString()}
             {...remainingProperties}

--- a/src/components/PageComponents/Config/Bluetooth.tsx
+++ b/src/components/PageComponents/Config/Bluetooth.tsx
@@ -1,23 +1,57 @@
+import { useAppStore } from "@app/core/stores/appStore";
 import type { BluetoothValidation } from "@app/validation/config/bluetooth.tsx";
 import { DynamicForm } from "@components/Form/DynamicForm.tsx";
 import { useDevice } from "@core/stores/deviceStore.ts";
 import { Protobuf } from "@meshtastic/js";
 import { useState } from "react";
 
-export const Bluetooth = (): JSX.Element => {
+export const Bluetooth = () => {
   const { config, setWorkingConfig } = useDevice();
-  const [bluetoothValidationText, setBluetoothValidationText] =
-    useState<string>();
+  const {
+    hasErrors,
+    getErrorMessage,
+    hasFieldError,
+    addError,
+    removeError,
+    clearErrors,
+  } = useAppStore();
+
+  const [bluetoothPin, setBluetoothPin] = useState(
+    config?.bluetooth?.fixedPin.toString() ?? "",
+  );
+
+  const validateBluetoothPin = (pin: string) => {
+    // if empty show error they need a pin set
+    if (pin === "") {
+      return addError("fixedPin", "Bluetooth Pin is required");
+    }
+
+    // clear any existing errors
+    clearErrors();
+
+    // if it starts with 0 show error
+    if (pin[0] === "0") {
+      return addError("fixedPin", "Bluetooth Pin cannot start with 0");
+    }
+    // if it's not 6 digits show error
+    if (pin.length < 6) {
+      return addError("fixedPin", "Pin must be 6 digits");
+    }
+
+    removeError("fixedPin");
+  };
 
   const bluetoothPinChangeEvent = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value[0] === "0") {
-      setBluetoothValidationText("Bluetooth Pin cannot start with 0.");
-    } else {
-      setBluetoothValidationText("");
-    }
+    const numericValue = e.target.value.replace(/\D/g, "").slice(0, 6);
+    setBluetoothPin(numericValue);
+    validateBluetoothPin(numericValue);
   };
 
   const onSubmit = (data: BluetoothValidation) => {
+    if (hasErrors()) {
+      return;
+    }
+
     setWorkingConfig(
       new Protobuf.Config.Config({
         payloadVariant: {
@@ -48,6 +82,12 @@ export const Bluetooth = (): JSX.Element => {
               name: "mode",
               label: "Pairing mode",
               description: "Pin selection behaviour.",
+              selectChange: (e) => {
+                if (e !== "1") {
+                  setBluetoothPin("");
+                  removeError("fixedPin");
+                }
+              },
               disabledBy: [
                 {
                   fieldName: "enabled",
@@ -63,7 +103,9 @@ export const Bluetooth = (): JSX.Element => {
               name: "fixedPin",
               label: "Pin",
               description: "Pin to use when pairing",
-              validationText: bluetoothValidationText,
+              validationText: hasFieldError("fixedPin")
+                ? getErrorMessage("fixedPin")
+                : "",
               inputChange: bluetoothPinChangeEvent,
               disabledBy: [
                 {
@@ -77,7 +119,9 @@ export const Bluetooth = (): JSX.Element => {
                   fieldName: "enabled",
                 },
               ],
-              properties: {},
+              properties: {
+                value: bluetoothPin,
+              },
             },
           ],
         },

--- a/src/components/PageComponents/Connect/HTTP.tsx
+++ b/src/components/PageComponents/Connect/HTTP.tsx
@@ -70,7 +70,6 @@ export const HTTP = ({ closeDialog }: TabElementProps): JSX.Element => {
                 onCheckedChange={(checked) => {
                   checked ? setHTTPS(true) : setHTTPS(false);
                 }}
-
                 // label="Use TLS"
                 // description="Description"
                 disabled={

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@app/core/utils/cn.ts";
 import { AlignLeftIcon, type LucideIcon } from "lucide-react";
 import Footer from "./UI/Footer";
+import { Spinner } from "./UI/Spinner";
 
 export interface PageLayoutProps {
   label: string;
@@ -10,6 +11,8 @@ export interface PageLayoutProps {
     icon: LucideIcon;
     iconClasses?: string;
     onClick: () => void;
+    disabled?: boolean;
+    isLoading?: boolean;
   }[];
 }
 
@@ -18,7 +21,7 @@ export const PageLayout = ({
   noPadding,
   actions,
   children,
-}: PageLayoutProps): JSX.Element => {
+}: PageLayoutProps) => {
   return (
     <>
       <div className="relative flex h-full w-full flex-col">
@@ -33,14 +36,22 @@ export const PageLayout = ({
             <div className="flex w-full items-center">
               <span className="w-full text-lg font-medium">{label}</span>
               <div className="flex justify-end space-x-4">
-                {actions?.map((action, index) => (
+                {actions?.map((action) => (
                   <button
                     key={action.icon.displayName}
                     type="button"
+                    disabled={action?.disabled}
                     className="transition-all hover:text-accent"
                     onClick={action.onClick}
                   >
-                    <action.icon className={action.iconClasses} />
+                    {action?.isLoading ? (
+                      <Spinner />
+                    ) : (
+                      <action.icon
+                        className={action.iconClasses}
+                        aria-disabled={action.disabled}
+                      />
+                    )}
                   </button>
                 ))}
               </div>

--- a/src/components/UI/Spinner.tsx
+++ b/src/components/UI/Spinner.tsx
@@ -1,0 +1,104 @@
+import { cn } from "@app/core/utils/cn";
+
+interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: "sm" | "md" | "lg";
+}
+
+const sizeClasses = {
+  sm: "h-4 w-4",
+  md: "h-8 w-8",
+  lg: "h-12 w-12",
+};
+
+export function Spinner({ className, size = "md", ...props }: SpinnerProps) {
+  return (
+    <div
+      aria-label="Loading..."
+      className={cn(
+        "flex items-center justify-center fade-in-50 fade-out-50",
+        className,
+      )}
+      {...props}
+    >
+      <svg
+        className={cn("animate-spin-slow stroke-current", sizeClasses[size])}
+        role="img"
+        aria-label="Loading spinner"
+        viewBox="0 0 256 256"
+      >
+        <line
+          x1="128"
+          y1="32"
+          x2="128"
+          y2="64"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="24"
+        />
+        <line
+          x1="195.9"
+          y1="60.1"
+          x2="173.3"
+          y2="82.7"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="24"
+        />
+        <line
+          x1="224"
+          y1="128"
+          x2="192"
+          y2="128"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="24"
+        />
+        <line
+          x1="195.9"
+          y1="195.9"
+          x2="173.3"
+          y2="173.3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="24"
+        />
+        <line
+          x1="128"
+          y1="224"
+          x2="128"
+          y2="192"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="24"
+        />
+        <line
+          x1="60.1"
+          y1="195.9"
+          x2="82.7"
+          y2="173.3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="24"
+        />
+        <line
+          x1="32"
+          y1="128"
+          x2="64"
+          y2="128"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="24"
+        />
+        <line
+          x1="60.1"
+          y1="60.1"
+          x2="82.7"
+          y2="82.7"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="24"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/src/core/stores/appStore.ts
+++ b/src/core/stores/appStore.ts
@@ -18,6 +18,11 @@ export type AccentColor =
   | "purple"
   | "pink";
 
+interface ErrorState {
+  field: string;
+  message: string;
+}
+
 interface AppState {
   selectedDevice: number;
   devices: {
@@ -33,11 +38,11 @@ interface AppState {
   nodeNumDetails: number;
   activeChat: number;
   chatType: "broadcast" | "direct";
+  errors: ErrorState[];
 
   setRasterSources: (sources: RasterSource[]) => void;
   addRasterSource: (source: RasterSource) => void;
   removeRasterSource: (index: number) => void;
-
   setSelectedDevice: (deviceId: number) => void;
   addDevice: (device: { id: number; num: number }) => void;
   removeDevice: (deviceId: number) => void;
@@ -49,9 +54,18 @@ interface AppState {
   setNodeNumDetails: (nodeNum: number) => void;
   setActiveChat: (chat: number) => void;
   setChatType: (type: "broadcast" | "direct") => void;
+
+  // Error management
+  hasErrors: () => boolean;
+  getErrorMessage: (field: string) => string | undefined;
+  hasFieldError: (field: string) => boolean;
+  addError: (field: string, message: string) => void;
+  removeError: (field: string) => void;
+  clearErrors: () => void;
+  setNewErrors: (newErrors: ErrorState[]) => void;
 }
 
-export const useAppStore = create<AppState>()((set) => ({
+export const useAppStore = create<AppState>()((set, get) => ({
   selectedDevice: 0,
   devices: [],
   currentPage: "messages",
@@ -67,6 +81,7 @@ export const useAppStore = create<AppState>()((set) => ({
   nodeNumDetails: 0,
   activeChat: Types.ChannelNumber.Primary,
   chatType: "broadcast",
+  errors: [],
 
   setRasterSources: (sources: RasterSource[]) => {
     set(
@@ -146,4 +161,47 @@ export const useAppStore = create<AppState>()((set) => ({
     set(() => ({
       chatType: type,
     })),
+  hasErrors: () => {
+    const state = get();
+    return state.errors.length > 0;
+  },
+  getErrorMessage: (field: string) => {
+    const state = get();
+    return state.errors.find((err) => err.field === field)?.message;
+  },
+  hasFieldError: (field: string) => {
+    const state = get();
+    return state.errors.some((err) => err.field === field);
+  },
+  addError: (field: string, message: string) => {
+    set(
+      produce<AppState>((draft) => {
+        draft.errors = [
+          ...draft.errors.filter((e) => e.field !== field),
+          { field, message },
+        ];
+      }),
+    );
+  },
+  removeError: (field: string) => {
+    set(
+      produce<AppState>((draft) => {
+        draft.errors = draft.errors.filter((e) => e.field !== field);
+      }),
+    );
+  },
+  clearErrors: () => {
+    set(
+      produce<AppState>((draft) => {
+        draft.errors = [];
+      }),
+    );
+  },
+  setNewErrors: (newErrors: ErrorState[]) => {
+    set(
+      produce<AppState>((draft) => {
+        draft.errors = newErrors;
+      }),
+    );
+  },
 }));

--- a/src/index.css
+++ b/src/index.css
@@ -99,3 +99,13 @@
 img {
   -webkit-user-drag: none;
 }
+
+@keyframes spin-slower {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.animate-spin-slow {
+  animation: spin-slower 2s linear infinite;
+}

--- a/src/pages/Config/DeviceConfig.tsx
+++ b/src/pages/Config/DeviceConfig.tsx
@@ -14,7 +14,7 @@ import {
 } from "@components/UI/Tabs.tsx";
 import { useDevice } from "@core/stores/deviceStore.ts";
 
-export const DeviceConfig = (): JSX.Element => {
+export const DeviceConfig = () => {
   const { metadata } = useDevice();
 
   const tabs = [


### PR DESCRIPTION
Fixes bluetooth PIN input with validation by enforcing a 6-digit limit with error handling:
- Limits input length to exactly 6 digits
- Prevents PIN starting with '0' (was existing functionality)
- Showing a loading indicator when saving config.
- Error toast displayed if someone tries to save their configuration.
- Integrates with error manager tooling added to app state for consistent error state handling
- Adds validation feedback for incomplete/invalid PINs
- The error manager can control the save icon within the configuration (but flexible enough to be rolled out anywhere else). If any field is invalid it changes the save icon to indicate there is a problem. The appStore hook contains all of this new logic.

Fixes #438

The validation ensures correct PIN format while providing immediate user feedback through the error management system.
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/32066ca2-6143-4db5-8379-32c31a3f03c8" />
<img width="1513" alt="image" src="https://github.com/user-attachments/assets/70ba5b95-38b1-498e-94a7-5b93eb5f6a21" />
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/9b336810-b6c3-444e-9cc2-6a9bedaf72f6" />
<img width="1482" alt="image" src="https://github.com/user-attachments/assets/ab5c4c11-2b7b-4c5c-986c-3b49a45786ca" />
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/9c6eeb0f-13eb-46a3-a71e-18b38163c159" />
<img width="680" alt="image" src="https://github.com/user-attachments/assets/091ec98f-2ea1-48a0-9a37-e598bed02a3f" />
<img width="220" alt="image" src="https://github.com/user-attachments/assets/9895d090-6f0d-4165-920f-35e1f10aae61" />
<img width="421" alt="image" src="https://github.com/user-attachments/assets/a0385c31-a3c7-488a-bf97-2696c6ddd2d6" />


