### PR TITLE
feat: added nightly github action. feat: Updated docs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,61 @@
+name: 'Nightly Release'
+
+on:
+  schedule:
+    - cron: "0 5 * * *" # Run every day at 5am UTC
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Build Package
+        run: bun run build
+
+      - name: Package Output
+        run: bun run package
+
+      - name: Archive compressed build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist/build.tar
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Buildah Build
+        id: build-container
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: |
+            ./Containerfile
+          image: ${{github.event.repository.full_name}}
+          tags: nightly ${{ github.sha }}
+          oci: true
+          platforms: linux/amd64, linux/arm64
+
+      - name: Push To Registry
+        id: push-to-registry
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-container.outputs.image }}
+          tags: ${{ steps.build-container.outputs.tags }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-registry.outputs.registry-paths }}"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,32 @@ docker run -d -p 8080:8080 --restart always --name Meshtastic-Web ghcr.io/meshta
 podman run -d -p 8080:8080 --restart always --name Meshtastic-Web ghcr.io/meshtastic/web
 ```
 
+## Nightly releases 
+
+Our nightly releases provide the latest development builds with cutting-edge features and fixes. These builds are automatically generated from the latest main branch every night and are available for testing and early adoption.
+
+```bash
+# With Docker
+docker run -d -p 8080:8080 --restart always --name Meshtastic-Web ghcr.io/meshtastic/web:nightly
+#With Podman
+podman run -d -p 8080:8080 --restart always --name Meshtastic-Web ghcr.io/meshtastic/web:nightly
+```
+
+[!WARNING] 
+ - Nightly builds represent the latest development state and may contain breaking changes
+ - These builds undergo automated testing but may be less stable than tagged release versions
+ - Not recommended for production environments unless you are actively testing new features
+ - No guarantee of backward compatibility between nightly builds
+
+### Version Information
+Each nightly build is tagged with:
+
+- The nightly tag for the latest build
+- A specific SHA for build reproducibility
+
+### Feedback
+If you encounter any issues with nightly builds, please report them in our [issues tracker](https://github.com/danditomaso/meshtastic-web/issues). Your feedback helps improve the stability of future releases
+
 ## Development & Building
 You'll need to download the package manager used with this repo. You can install it by visiting [Bun.sh](https://bun.sh/) and following the installation instructions. 
 


### PR DESCRIPTION
This PR introduces an automated nightly release workflow that builds and publishes container images daily at 5am UTC 
(12 AM EST).

- Added new GitHub Action workflow for nightly releases that are built and published to Docker hub.
- Set up container image tagging with nightly and commit SHA

Fixes #453 
