### PR TITLE
Chore: Removal of mapbox-gl

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,6 @@
         "immer": "^10.1.1",
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.477.0",
-        "mapbox-gl": "^3.10.0",
         "maplibre-gl": "5.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "immer": "^10.1.1",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.477.0",
-    "mapbox-gl": "^3.10.0",
     "maplibre-gl": "5.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
While looking at requirements for [react-map-gl](https://github.com/visgl/react-map-gl), I saw that there is only needed maplibre-gl for using it and not mapbox. So I removed it from package.json.