### PR TITLE
fix: update TLS setting if URL is using HTTPS

### DIFF
--- a/src/components/PageComponents/Connect/HTTP.tsx
+++ b/src/components/PageComponents/Connect/HTTP.tsx
@@ -11,7 +11,6 @@ import { MeshDevice } from "@meshtastic/core";
 import { TransportHTTP } from "@meshtastic/transport-http";
 import { useState } from "react";
 import { useForm, useController } from "react-hook-form";
-import { FieldWrapper } from "@components/Form/FormWrapper.tsx";
 
 interface FormData {
   ip: string;
@@ -19,8 +18,11 @@ interface FormData {
 }
 
 export const HTTP = ({ closeDialog }: TabElementProps) => {
+  const isURLHTTPS = location.protocol === "https:";
+
   const { addDevice } = useDeviceStore();
   const { setSelectedDevice } = useAppStore();
+
   const { control, handleSubmit, register } = useForm<FormData>({
     defaultValues: {
       ip: ["client.meshtastic.org", "localhost"].includes(
@@ -28,7 +30,7 @@ export const HTTP = ({ closeDialog }: TabElementProps) => {
       )
         ? "meshtastic.local"
         : globalThis.location.host,
-      tls: false,
+      tls: isURLHTTPS ? true : false,
     },
   });
 
@@ -39,8 +41,6 @@ export const HTTP = ({ closeDialog }: TabElementProps) => {
   const [connectionInProgress, setConnectionInProgress] = useState(false);
 
   const onSubmit = handleSubmit(async (data) => {
-    console.log(data);
-
     setConnectionInProgress(true);
     const id = randId();
     const device = addDevice(id);
@@ -69,8 +69,8 @@ export const HTTP = ({ closeDialog }: TabElementProps) => {
         <div className="flex items-center gap-2 mt-2">
           <Switch
             onCheckedChange={setTLS}
-            disabled={location.protocol === "https:" || connectionInProgress}
-            checked={location.protocol === 'https:' || tlsValue}
+            disabled={isURLHTTPS || connectionInProgress}
+            checked={isURLHTTPS || tlsValue}
             {...register("tls")}
           />
           <Label>Use HTTPS</Label>


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This fix ensures the TLS setting is toggled on if the URL is using HTTPS

## Related Issues
<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

Fixes #481 

## Changes Made
<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->
- created variable to track https status 
- updating tls status when site is already using https
