### PR TITLE
fix: remove GlobalThis and use window instead

### DIFF
--- a/src/components/PageComponents/Connect/HTTP.tsx
+++ b/src/components/PageComponents/Connect/HTTP.tsx
@@ -26,10 +26,10 @@ export const HTTP = ({ closeDialog }: TabElementProps) => {
   const { control, handleSubmit, register } = useForm<FormData>({
     defaultValues: {
       ip: ["client.meshtastic.org", "localhost"].includes(
-        globalThis.location.hostname,
+        window.location.hostname,
       )
         ? "meshtastic.local"
-        : globalThis.location.host,
+        : window.location.host,
       tls: isURLHTTPS ? true : false,
     },
   });


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

GlobalThis works with Deno but not Vite so have to use window.location.host in production