### PR TITLE
feat: add error handling for key mismatch

### DIFF
--- a/src/components/Dialog/DialogManager.tsx
+++ b/src/components/Dialog/DialogManager.tsx
@@ -8,6 +8,7 @@ import { RebootDialog } from "@components/Dialog/RebootDialog.tsx";
 import { ShutdownDialog } from "@components/Dialog/ShutdownDialog.tsx";
 import { NodeDetailsDialog } from "@components/Dialog/NodeDetailsDialog.tsx";
 import { UnsafeRolesDialog } from "@components/Dialog/UnsafeRolesDialog/UnsafeRolesDialog.tsx";
+import { RefreshKeysDialog } from "@components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx";
 
 export const DialogManager = () => {
   const { channels, config, dialog, setDialogOpen } = useDevice();
@@ -68,6 +69,12 @@ export const DialogManager = () => {
         open={dialog.unsafeRoles}
         onOpenChange={(open) => {
           setDialogOpen("unsafeRoles", open);
+        }}
+      />
+      <RefreshKeysDialog
+        open={dialog.refreshKeys}
+        onOpenChange={(open) => {
+          setDialogOpen("refreshKeys", open);
         }}
       />
     </>

--- a/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.test.tsx
+++ b/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { RefreshKeysDialog } from "./RefreshKeysDialog";
+import { useRefreshKeysDialog } from "./useRefreshKeysDialog.ts";
+
+vi.mock("./useRefreshKeysDialog.ts", () => ({
+  useRefreshKeysDialog: vi.fn(),
+}));
+
+describe("RefreshKeysDialog Component", () => {
+  let handleCloseDialogMock: Mock;
+  let handleNodeRemoveMock: Mock;
+  let onOpenChangeMock: Mock;
+
+  beforeEach(() => {
+    handleCloseDialogMock = vi.fn();
+    handleNodeRemoveMock = vi.fn();
+    onOpenChangeMock = vi.fn();
+
+    (useRefreshKeysDialog as Mock).mockReturnValue({
+      handleCloseDialog: handleCloseDialogMock,
+      handleNodeRemove: handleNodeRemoveMock,
+    });
+  });
+
+  it("renders the dialog with correct content", () => {
+    render(<RefreshKeysDialog open={true} onOpenChange={onOpenChangeMock} />);
+    expect(screen.getByText("Keys Mismatch")).toBeInTheDocument();
+    expect(screen.getByText("Request New Keys")).toBeInTheDocument();
+    expect(screen.getByText("Dismiss")).toBeInTheDocument();
+  });
+
+  it("calls handleNodeRemove when 'Request New Keys' button is clicked", () => {
+    render(<RefreshKeysDialog open={true} onOpenChange={onOpenChangeMock} />);
+    fireEvent.click(screen.getByText("Request New Keys"));
+    expect(handleNodeRemoveMock).toHaveBeenCalled();
+  });
+
+  it("calls handleCloseDialog when 'Dismiss' button is clicked", () => {
+    render(<RefreshKeysDialog open={true} onOpenChange={onOpenChangeMock} />);
+    fireEvent.click(screen.getByText("Dismiss"));
+    expect(handleCloseDialogMock).toHaveBeenCalled();
+  });
+
+  it("calls onOpenChange when dialog close button is clicked", () => {
+    render(<RefreshKeysDialog open={true} onOpenChange={onOpenChangeMock} />);
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(handleCloseDialogMock).toHaveBeenCalled();
+  });
+
+  it("does not render when open is false", () => {
+    render(<RefreshKeysDialog open={false} onOpenChange={onOpenChangeMock} />);
+    expect(screen.queryByText("Keys Mismatch")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx
+++ b/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx
@@ -7,7 +7,6 @@ import {
 } from "@components/UI/Dialog.tsx";
 import { Button } from "@components/UI/Button.tsx";
 import { LockKeyholeOpenIcon } from "lucide-react";
-import { P } from "@components/UI/Typography/P.tsx";
 import { useRefreshKeysDialog } from "./useRefreshKeysDialog.ts";
 
 export interface RefreshKeysDialogProps {
@@ -25,17 +24,19 @@ export const RefreshKeysDialog = ({ open, onOpenChange }: RefreshKeysDialogProps
         <DialogHeader>
           <DialogTitle>Keys Mismatch</DialogTitle>
         </DialogHeader>
-        Your node is unable to send a direct message to this node. This is due to public/private key mismatch.
+        Your node is unable to send a direct message to this node. This is due to the remote node's current public key not matching the previously stored key for this node.
         <ul className="mt-2">
           <li className="flex place-items-center gap-2 items-start">
-            <div className="p-2 bg-slate-500 rounded-lg mt-2">
+            <div className="p-2 bg-slate-500 rounded-lg mt-1">
               <LockKeyholeOpenIcon size={30} className="text-white justify-center" />
             </div>
-            <div className="flex flex-col gap-2" >
-              <P className="font-bold">Refresh this node</P>
-              <p>
-                This will remove the node from the chat and request new keys. The process may take a few moments to complete.
-              </p>
+            <div className="flex flex-col gap-2">
+              <div>
+                <p className="font-bold mb-0.5">Accept New Keys</p>
+                <p>
+                  This will remove the node from device and request new keys.
+                </p>
+              </div>
               <Button
                 variant="default"
                 onClick={handleNodeRemove}

--- a/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx
+++ b/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx
@@ -1,0 +1,60 @@
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@components/UI/Dialog.tsx";
+import { Button } from "@components/UI/Button.tsx";
+import { LockKeyholeOpenIcon } from "lucide-react";
+import { P } from "@components/UI/Typography/P.tsx";
+import { useRefreshKeysDialog } from "./useRefreshKeysDialog.ts";
+
+export interface RefreshKeysDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const RefreshKeysDialog = ({ open, onOpenChange }: RefreshKeysDialogProps) => {
+
+  const { handleCloseDialog, handleNodeRemove } = useRefreshKeysDialog();
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-8 flex flex-col gap-2">
+        <DialogClose onClick={handleCloseDialog} />
+        <DialogHeader>
+          <DialogTitle>Keys Mismatch</DialogTitle>
+        </DialogHeader>
+        Your node is unable to send a direct message to this node. This is due to public/private key mismatch.
+        <ul className="mt-2">
+          <li className="flex place-items-center gap-2 items-start">
+            <div className="p-2 bg-slate-500 rounded-lg mt-2">
+              <LockKeyholeOpenIcon size={30} className="text-white justify-center" />
+            </div>
+            <div className="flex flex-col gap-2" >
+              <P className="font-bold">Refresh this node</P>
+              <p>
+                This will remove the node from the chat and request new keys. The process may take a few moments to complete.
+              </p>
+              <Button
+                variant="default"
+                onClick={handleNodeRemove}
+                className=""
+              >
+                Request New Keys
+              </Button>
+              <Button
+                variant="outline"
+                onClick={handleCloseDialog}
+                className=""
+              >
+                Dismiss
+              </Button>
+            </div>
+          </li>
+        </ul>
+        {/* </DialogDescription> */}
+      </DialogContent>
+    </Dialog >
+  );
+};

--- a/src/components/Dialog/RefreshKeysDialog/useRefreshKeysDialog.test.ts
+++ b/src/components/Dialog/RefreshKeysDialog/useRefreshKeysDialog.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, act } from "@testing-library/react";
+import { useRefreshKeysDialog } from "./useRefreshKeysDialog.ts";
+import { beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { useDevice } from "@core/stores/deviceStore.ts";
+
+vi.mock("@core/stores/appStore.ts", () => ({
+  useAppStore: vi.fn(() => ({ activeChat: "chat-123" })),
+}));
+
+vi.mock("@core/stores/deviceStore.ts", () => ({
+  useDevice: vi.fn(() => ({
+    removeNode: vi.fn(),
+    setDialogOpen: vi.fn(),
+    getNodeError: vi.fn(),
+    clearNodeError: vi.fn(),
+  })),
+}));
+
+describe("useRefreshKeysDialog Hook", () => {
+  let removeNodeMock: Mock;
+  let setDialogOpenMock: Mock;
+  let getNodeErrorMock: Mock;
+  let clearNodeErrorMock: Mock;
+
+  beforeEach(() => {
+    removeNodeMock = vi.fn();
+    setDialogOpenMock = vi.fn();
+    getNodeErrorMock = vi.fn();
+    clearNodeErrorMock = vi.fn();
+
+    (useDevice as Mock).mockReturnValue({
+      removeNode: removeNodeMock,
+      setDialogOpen: setDialogOpenMock,
+      getNodeError: getNodeErrorMock,
+      clearNodeError: clearNodeErrorMock,
+    });
+  });
+
+  it("handleNodeRemove should remove the node and update dialog if there is an error", () => {
+    getNodeErrorMock.mockReturnValue({ node: "node-abc" });
+
+    const { result } = renderHook(() => useRefreshKeysDialog());
+
+    act(() => {
+      result.current.handleNodeRemove();
+    });
+
+    expect(getNodeErrorMock).toHaveBeenCalledWith("chat-123");
+    expect(clearNodeErrorMock).toHaveBeenCalledWith("chat-123");
+    expect(removeNodeMock).toHaveBeenCalledWith("node-abc");
+    expect(setDialogOpenMock).toHaveBeenCalledWith("refreshKeys", false);
+  });
+
+  it("handleNodeRemove should do nothing if there is no error", () => {
+    getNodeErrorMock.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useRefreshKeysDialog());
+
+    act(() => {
+      result.current.handleNodeRemove();
+    });
+
+    expect(removeNodeMock).not.toHaveBeenCalled();
+    expect(setDialogOpenMock).not.toHaveBeenCalled();
+    expect(clearNodeErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("handleCloseDialog should close the dialog", () => {
+    const { result } = renderHook(() => useRefreshKeysDialog());
+
+    act(() => {
+      result.current.handleCloseDialog();
+    });
+
+    expect(setDialogOpenMock).toHaveBeenCalledWith("refreshKeys", false);
+  });
+});

--- a/src/components/Dialog/RefreshKeysDialog/useRefreshKeysDialog.ts
+++ b/src/components/Dialog/RefreshKeysDialog/useRefreshKeysDialog.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { useAppStore } from "@core/stores/appStore.ts";
+import { useDevice } from "@core/stores/deviceStore.ts";
+
+export function useRefreshKeysDialog() {
+  const { removeNode, setDialogOpen, clearNodeError, getNodeError } = useDevice();
+  const { activeChat } = useAppStore();
+
+  const handleNodeRemove = useCallback(() => {
+    const nodeWithError = getNodeError(activeChat);
+    if (!nodeWithError) {
+      return;
+    }
+    clearNodeError(activeChat);
+    handleCloseDialog();;
+    return removeNode(nodeWithError?.node);
+  }, [activeChat, clearNodeError, setDialogOpen, removeNode]);
+
+  const handleCloseDialog = useCallback(() => {
+    setDialogOpen('refreshKeys', false);
+  }, [setDialogOpen])
+
+  return {
+    handleCloseDialog,
+    handleNodeRemove
+  };
+
+}

--- a/src/components/PageComponents/Connect/Serial.tsx
+++ b/src/components/PageComponents/Connect/Serial.tsx
@@ -18,9 +18,7 @@ export const Serial = ({ closeDialog }: TabElementProps) => {
     setSerialPorts(await navigator?.serial.getPorts());
   }, []);
 
-  navigator?.serial?.addEventListener("connect", (event) => {
-    console.log(event);
-
+  navigator?.serial?.addEventListener("connect", () => {
     updateSerialPortList();
   });
   navigator?.serial?.addEventListener("disconnect", () => {
@@ -47,8 +45,6 @@ export const Serial = ({ closeDialog }: TabElementProps) => {
     <div className="flex w-full flex-col gap-2 p-4">
       <div className="flex h-48 flex-col gap-2 overflow-y-auto">
         {serialPorts.map((port, index) => {
-          console.log(port);
-
           const { usbProductId, usbVendorId } = port.getInfo();
           return (
             <Button

--- a/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -15,9 +15,10 @@ const EmptyState = () => (
 );
 
 export const ChannelChat = ({
-  messages,
+  messages = [],
 }: ChannelChatProps) => {
   const { nodes } = useDevice();
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -57,7 +58,7 @@ export const ChannelChat = ({
         className="flex-1 overflow-y-auto pl-4 pr-4 md:pr-44"
       >
         <div className="flex flex-col justify-end min-h-full">
-          {messages.map((message, index) => (
+          {messages?.map((message, index) => (
             <Message
               key={message.id}
               message={message}

--- a/src/components/PageComponents/Messages/Message.tsx
+++ b/src/components/PageComponents/Messages/Message.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import {
   Tooltip,
   TooltipArrow,
@@ -12,15 +13,13 @@ import {
 import { cn } from "@core/utils/cn.ts";
 import { Avatar } from "@components/UI/Avatar.tsx";
 import type { Protobuf } from "@meshtastic/core";
-import { AlertCircle, CheckCircle2, CircleEllipsis } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
-import { useMemo } from "react";
+import { AlertCircle, CheckCircle2, CircleEllipsis, LucideIcon } from "lucide-react";
 
-const MESSAGE_STATES = {
-  ACK: "ack",
-  WAITING: "waiting",
-  FAILED: "failed",
-} as const;
+type MessageStateValue = {
+  state: string;
+  icon: LucideIcon;
+  displayText: string;
+}
 
 type MessageState = MessageWithState["state"];
 
@@ -40,31 +39,36 @@ interface StatusIconProps {
   className?: string;
 }
 
-const STATUS_TEXT_MAP: Record<MessageState, string> = {
-  [MESSAGE_STATES.ACK]: "Message delivered",
-  [MESSAGE_STATES.WAITING]: "Waiting for delivery",
-  [MESSAGE_STATES.FAILED]: "Delivery failed",
+const MESSAGE_STATES: Record<string, MessageStateValue> = {
+  ACK: { state: 'ack', icon: CheckCircle2, displayText: "Message delivered" },
+  WAITING: { state: 'waiting', icon: CircleEllipsis, displayText: "Waiting for delivery" },
+  FAILED: { state: 'failed', icon: AlertCircle, displayText: "Delivery failed" },
 };
 
-const STATUS_ICON_MAP: Record<MessageState, LucideIcon> = {
-  [MESSAGE_STATES.ACK]: CheckCircle2,
-  [MESSAGE_STATES.WAITING]: CircleEllipsis,
-  [MESSAGE_STATES.FAILED]: AlertCircle,
-};
-
-const getStatusText = (state: MessageState): string => STATUS_TEXT_MAP[state];
+const getMessageState = (state: MessageState): MessageStateValue => {
+  switch (state) {
+    case MESSAGE_STATES.ACK.state:
+      return MESSAGE_STATES.ACK;
+    case MESSAGE_STATES.WAITING.state:
+      return MESSAGE_STATES.WAITING;
+    case MESSAGE_STATES.FAILED.state:
+      return MESSAGE_STATES.FAILED;
+    default:
+      return MESSAGE_STATES.FAILED;
+  }
+}
 
 const StatusTooltip = ({ state, children }: StatusTooltipProps) => (
   <TooltipProvider>
     <Tooltip>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
       <TooltipContent
-        className="rounded-md bg-slate-800 px-3 py-1.5 text-sm text-white shadow-md animate-in fade-in-0 zoom-in-95"
+        className="rounded-md bg-slate-800 px-3 py-1.5 text-sm text-white dark:text-white shadow-md animate-in fade-in-0 zoom-in-95"
         side="top"
         align="center"
         sideOffset={5}
       >
-        {getStatusText(state)}
+        {getMessageState(state).displayText ?? "An unknown error occurred"};
         <TooltipArrow className="fill-slate-800" />
       </TooltipContent>
     </Tooltip>
@@ -72,13 +76,17 @@ const StatusTooltip = ({ state, children }: StatusTooltipProps) => (
 );
 
 const StatusIcon = ({ state, className, ...otherProps }: StatusIconProps) => {
-  const isFailed = state === MESSAGE_STATES.FAILED;
+  const msgState = getMessageState(state);
+
+  const isFailed = msgState.state === 'failed'
+
   const iconClass = cn(
     className,
-    "text-slate-500 dark:text-slate-400 w-4 h-4 shrink-0",
+    "text-slate-500 dark:text-slate-400 size-5 shrink-0"
   );
 
-  const Icon = STATUS_ICON_MAP[state];
+  const Icon = msgState.icon;
+
   return (
     <StatusTooltip state={state}>
       <Icon
@@ -90,23 +98,7 @@ const StatusIcon = ({ state, className, ...otherProps }: StatusIconProps) => {
   );
 };
 
-const getMessageTextStyles = (state: MessageState) => {
-  const isAcknowledged = state === MESSAGE_STATES.ACK;
-  const isFailed = state === MESSAGE_STATES.FAILED;
-
-  return cn(
-    "break-words overflow-hidden",
-    isAcknowledged
-      ? "text-slate-900 dark:text-white"
-      : "text-slate-900 dark:text-slate-400",
-    isFailed && "text-red-500 dark:text-red-500",
-  );
-};
-
-const TimeDisplay = ({
-  date,
-  className,
-}: { date: Date; className?: string }) => (
+const TimeDisplay = memo(({ date, className }: { date: Date; className?: string }) => (
   <div className={cn("flex items-center gap-2 shrink-0", className)}>
     <span className="text-xs text-slate-500 dark:text-slate-400 font-mono">
       {date.toLocaleDateString()}
@@ -118,9 +110,9 @@ const TimeDisplay = ({
       })}
     </span>
   </div>
-);
+));
 
-export const Message = ({ lastMsgSameUser, message, sender }: MessageProps) => {
+export const Message = memo(({ lastMsgSameUser, message, sender }: MessageProps) => {
   const { getDevices } = useDeviceStore();
 
   const isDeviceUser = useMemo(
@@ -128,33 +120,47 @@ export const Message = ({ lastMsgSameUser, message, sender }: MessageProps) => {
       getDevices()
         .map((device) => device.nodes.get(device.hardware.myNodeNum)?.num)
         .includes(message.from),
-    [getDevices, message.from],
+    [getDevices, message.from]
   );
+
   const messageUser = sender?.user;
 
-  const messageTextClass = getMessageTextStyles(message.state);
+  const getMessageTextStyles = (state: MessageState) => {
+    const msgState = getMessageState(state);
+    const isAcknowledged = msgState.state === 'ack'
+    const isFailed = msgState.state === 'failed'
+
+    return cn(
+      "break-words overflow-hidden",
+      isAcknowledged
+        ? "text-slate-900 dark:text-white"
+        : "text-slate-900 dark:text-slate-400",
+      isFailed && "text-red-500 dark:text-red-500",
+    );
+  };
+
+  const messageTextClass = useMemo(() => getMessageTextStyles(message.state), [message.state]);
+
 
   return (
     <div className="flex flex-col w-full px-4 justify-start">
       <div
         className={cn(
           "flex flex-col flex-wrap items-start py-1",
-          isDeviceUser && "items-end",
+          isDeviceUser && "items-end"
         )}
       >
         <div className="flex items-center gap-2 mb-2">
-          {!lastMsgSameUser
-            ? (
-              <div className="flex place-items-center gap-2 mb-1">
-                <Avatar text={messageUser?.shortName ?? "UNK"} />
-                <div className="flex flex-col">
-                  <span className="font-medium text-slate-900 dark:text-white truncate">
-                    {messageUser?.longName}
-                  </span>
-                </div>
+          {!lastMsgSameUser && (
+            <div className="flex place-items-center gap-2 mb-1">
+              <Avatar text={messageUser?.shortName ?? "UNK"} />
+              <div className="flex flex-col">
+                <span className="font-medium text-slate-900 dark:text-white truncate">
+                  {messageUser?.longName}
+                </span>
               </div>
-            )
-            : null}
+            </div>
+          )}
         </div>
         <TimeDisplay date={message.rxTime} />
         <div className="flex place-items-center gap-2 pb-2">
@@ -166,4 +172,4 @@ export const Message = ({ lastMsgSameUser, message, sender }: MessageProps) => {
       </div>
     </div>
   );
-};
+});

--- a/src/components/PageComponents/Messages/MessageItem.tsx
+++ b/src/components/PageComponents/Messages/MessageItem.tsx
@@ -1,0 +1,126 @@
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@components/UI/Tooltip.tsx";
+import { useDeviceStore } from "@core/stores/deviceStore.ts";
+import { cn } from "@core/utils/cn.ts";
+import { Avatar } from "@components/UI/Avatar.tsx";
+import { AlertCircle, CheckCircle2, CircleEllipsis } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { ReactNode, useMemo } from "react";
+import { Message, MessageState } from "@core/services/types.ts";
+
+interface MessageProps {
+  lastMsgSameUser: boolean;
+  message: Message;
+}
+
+interface MessageStatus {
+  state: MessageState;
+  displayText: string;
+  icon: LucideIcon;
+}
+
+const MESSAGE_STATUS: Record<MessageState, MessageStatus> = {
+  ack: { state: "ack", displayText: "Message delivered", icon: CheckCircle2 },
+  waiting: { state: "waiting", displayText: "Waiting for delivery", icon: CircleEllipsis },
+  failed: { state: "failed", displayText: "Delivery failed", icon: AlertCircle },
+};
+
+const getMessageStatus = (state: MessageState): MessageStatus =>
+  MESSAGE_STATUS[state] || { state: "failed", displayText: "Unknown error", icon: AlertCircle };
+
+const StatusTooltip = ({ status, children }: { status: MessageStatus; children: ReactNode }) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent
+        className="rounded-md bg-slate-800 px-3 py-1.5 text-sm text-white shadow-md animate-in fade-in-0 zoom-in-95"
+        side="top"
+        align="center"
+        sideOffset={5}
+      >
+        {status.displayText}
+        <TooltipArrow className="fill-slate-800" />
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+const StatusIcon = ({ status, className, ...otherProps }: { status: MessageStatus; className?: string }) => {
+  const isFailed = status.state === "failed";
+  const iconClass = cn("text-slate-500 dark:text-slate-400 w-4 h-4 shrink-0", className);
+  const Icon = status.icon;
+
+  return (
+    <StatusTooltip status={status}>
+      <Icon className={iconClass} {...otherProps} color={isFailed ? "red" : "currentColor"} />
+    </StatusTooltip>
+  );
+};
+
+const getMessageTextStyles = (status: MessageStatus) => {
+  const isAcknowledged = status.state === "ack";
+  const isFailed = status.state === "failed";
+
+  return cn(
+    "break-words overflow-hidden",
+    isAcknowledged ? "text-slate-900 dark:text-white" : "text-slate-900 dark:text-slate-400",
+    isFailed && "text-red-500 dark:text-red-500",
+  );
+};
+
+const TimeDisplay = ({ date, className }: { date: Date; className?: string }) => (
+  <div className={cn("flex items-center gap-2 shrink-0", className)}>
+    <span className="text-xs text-slate-500 dark:text-slate-400 font-mono">{date.toLocaleDateString()}</span>
+    <span className="text-xs text-slate-500 dark:text-slate-400 font-mono">
+      {date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+    </span>
+  </div>
+);
+
+export const MessageItem = ({ lastMsgSameUser, message }: MessageProps) => {
+  const { getDevices } = useDeviceStore();
+
+  const isDeviceUser = useMemo(
+    () =>
+      getDevices()
+        .map((device) => device.nodes.get(device.hardware.myNodeNum)?.num)
+        .includes(message.from),
+    [getDevices, message.from],
+  );
+
+  const messageUser = message?.from
+    ? getDevices().find((device) => device.nodes.has(message.from))?.nodes.get(message.from)
+    : null;
+
+  const messageStatus = getMessageStatus(message.state);
+  const messageTextClass = getMessageTextStyles(messageStatus);
+
+  return (
+    <div className="flex flex-col w-full px-4 justify-start">
+      <div className={cn("flex flex-col flex-wrap items-start py-1", messageTextClass, isDeviceUser && "items-end")}>
+        <div className="flex items-center gap-2 mb-2">
+          {!lastMsgSameUser && (
+            <div className="flex place-items-center gap-2 mb-1">
+              <Avatar text={messageUser?.user?.shortName ?? "UNK"} />
+              <div className="flex flex-col">
+                <span className="font-medium text-slate-900 dark:text-white truncate">
+                  {messageUser?.user?.longName}
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+        <TimeDisplay date={message.date} />
+        <div className="flex place-items-center gap-2 pb-2">
+          <div className={cn(isDeviceUser && "pl-11", messageTextClass)}>{message.message}</div>
+          <StatusIcon status={messageStatus} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/UI/Avatar.tsx
+++ b/src/components/UI/Avatar.tsx
@@ -1,4 +1,5 @@
-import { cn } from "../../core/utils/cn.ts";
+import { cn } from "@core/utils/cn.ts";
+import { LockKeyholeOpenIcon } from 'lucide-react';
 import type React from "react";
 
 type RGBColor = {
@@ -12,6 +13,7 @@ interface AvatarProps {
   text: string;
   size?: "sm" | "lg";
   className?: string;
+  showError?: boolean;
 }
 
 // biome-ignore lint/complexity/noStaticOnlyClass: stop being annoying Biome
@@ -43,6 +45,7 @@ class ColorUtils {
 export const Avatar: React.FC<AvatarProps> = ({
   text,
   size = "sm",
+  showError = false,
   className,
 }) => {
   const sizes = {
@@ -73,12 +76,11 @@ export const Avatar: React.FC<AvatarProps> = ({
   return (
     <div
       className={cn(
-        `
+        `flex
+        relative
         rounded-full 
-        flex 
         items-center 
         justify-center 
-        size-11
         font-semibold`,
         sizes[size],
         className,
@@ -88,6 +90,7 @@ export const Avatar: React.FC<AvatarProps> = ({
         color: textColor,
       }}
     >
+      {showError ? <LockKeyholeOpenIcon className="size-4 absolute bottom-0 right-0 z-10 text-red-500 stroke-3" /> : null}
       <p className="p-1">{initials}</p>
     </div>
   );

--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
         success:
           "bg-green-500 text-white hover:bg-green-600 dark:hover:bg-green-600",
         outline:
-          "bg-transparent border border-slate-200 hover:bg-slate-100 dark:border-slate-400 dark:text-slate-500",
+          "bg-transparent border border-slate-400 hover:bg-slate-100 dark:border-slate-400 dark:text-slate-500",
         subtle:
           "bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-500 dark:text-white dark:hover:bg-slate-400",
         ghost:

--- a/src/core/subscriptions.ts
+++ b/src/core/subscriptions.ts
@@ -117,6 +117,11 @@ export const subscribeAll = (
           device.setNodeError(routingPacket.from, Protobuf.Mesh.Routing_Error[routingPacket?.data?.variant?.value]);
           device.setDialogOpen("refreshKeys", true);
           break;
+        case Protobuf.Mesh.Routing_Error.PKI_UNKNOWN_PUBKEY:
+          console.error(`Routing Error: ${routingPacket.data.variant.value}`);
+          device.setNodeError(routingPacket.from, Protobuf.Mesh.Routing_Error[routingPacket?.data?.variant?.value]);
+          device.setDialogOpen("refreshKeys", true);
+          break;
         default: {
           break;
         }

--- a/src/core/subscriptions.ts
+++ b/src/core/subscriptions.ts
@@ -22,15 +22,15 @@ export const subscribeAll = (
         ) {
           return;
         }
-        console.log(`Routing Error: ${routingPacket.data.variant.value}`);
+        console.info(`Routing Error: ${routingPacket.data.variant.value}`);
         break;
       }
       case "routeReply": {
-        console.log(`Route Reply: ${routingPacket.data.variant.value}`);
+        console.info(`Route Reply: ${routingPacket.data.variant.value}`);
         break;
       }
       case "routeRequest": {
-        console.log(`Route Request: ${routingPacket.data.variant.value}`);
+        console.info(`Route Request: ${routingPacket.data.variant.value}`);
         break;
       }
     }
@@ -70,8 +70,6 @@ export const subscribeAll = (
   });
 
   connection.events.onChannelPacket.subscribe((channel) => {
-    console.log('channel', channel);
-
     device.addChannel(channel);
   });
   connection.events.onConfigPacket.subscribe((config) => {
@@ -81,10 +79,8 @@ export const subscribeAll = (
     device.setModuleConfig(moduleConfig);
   });
 
+
   connection.events.onMessagePacket.subscribe((messagePacket) => {
-
-    console.log('messagePacket', messagePacket);
-
     device.addMessage({
       ...messagePacket,
       state: messagePacket.from !== myNodeNum ? "ack" : "waiting",
@@ -111,8 +107,21 @@ export const subscribeAll = (
 
   connection.events.onQueueStatus.subscribe((queueStatus) => {
     device.setQueueStatus(queueStatus);
-    if (queueStatus.free < 10) {
-      // start queueing messages
+  });
+
+  connection.events.onRoutingPacket.subscribe((routingPacket) => {
+    if (routingPacket.data.variant.case === "errorReason") {
+      switch (routingPacket.data.variant.value) {
+        case Protobuf.Mesh.Routing_Error.NO_CHANNEL:
+          console.error(`Routing Error: ${routingPacket.data.variant.value}`);
+          device.setNodeError(routingPacket.from, Protobuf.Mesh.Routing_Error[routingPacket?.data?.variant?.value]);
+          device.setDialogOpen("refreshKeys", true);
+          break;
+        default: {
+          break;
+        }
+      }
+
     }
   });
 };

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -13,9 +13,10 @@ import { getChannelName } from "@pages/Channels.tsx";
 import { HashIcon, LockIcon, LockOpenIcon } from "lucide-react";
 import { useState } from "react";
 import { MessageInput } from "@components/PageComponents/Messages/MessageInput.tsx";
+import { cn } from "@core/utils/cn.ts";
 
 export const MessagesPage = () => {
-  const { channels, nodes, hardware, messages } = useDevice();
+  const { channels, nodes, hardware, messages, hasNodeError } = useDevice();
   const { activeChat, chatType, setActiveChat, setChatType } = useAppStore();
   const [searchTerm, setSearchTerm] = useState<string>("");
   const filteredNodes = Array.from(nodes.values()).filter((node) => {
@@ -82,6 +83,8 @@ export const MessagesPage = () => {
                 element={
                   <Avatar
                     text={node.user?.shortName ?? node.num.toString()}
+                    className={cn(hasNodeError(node.num) && "text-red-500")}
+                    showError={hasNodeError(node.num)}
                     size="sm"
                   />
                 }
@@ -145,7 +148,6 @@ export const MessagesPage = () => {
             )}
           </div>
 
-          {/* Single message input for both chat types */}
           <div className="shrink-0 p-4 w-full dark:bg-slate-900">
             <MessageInput
               to={messageDestination}

--- a/src/pages/Nodes.tsx
+++ b/src/pages/Nodes.tsx
@@ -21,8 +21,6 @@ export interface DeleteNoteDialogProps {
 
 const NodesPage = (): JSX.Element => {
   const { nodes, hardware, connection } = useDevice();
-  console.log(connection);
-
   const [selectedNode, setSelectedNode] = useState<
     Protobuf.Mesh.NodeInfo | undefined
   >(undefined);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,9 +44,9 @@ export default defineConfig({
   server: {
     port: 3000,
     headers: {
-      'Cross-Origin-Opener-Policy': 'same-origin',
-      'Cross-Origin-Embedder-Policy': 'require-corp',
-    }
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
   },
   optimizeDeps: {
     exclude: ['react-scan']


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This PR introduces the useRefreshKeysDialog hook, which manages the logic for handling node errors and refreshing cryptographic keys when a key mismatch occurs. In order to fully test this PR you will need to have a second node available, update its firmware then from the first node try and chat with this newly updated node. 

## Related Issues
<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->
Fixes #503
#502 
#501
#493 
#488
#485

## Changes Made
<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->
- Created Dialog that offers the user some info and a resolution step when they recieve a`no_channel` error.
- Added a "hasError" prop to the Avatar which will display the red open lock icon shown in the screenshots section, this indicates some kind of error with the node.  This is left in place in case a users decides not to resolve the public key issue, and tries to DM with them again.  
- Removed extra console.log's in the application that were left in the code base (probably by me).


## Testing Done
<!--
Describe how you tested these changes.
-->
Added tests to useRefreshKeysDialog & RefreshKeysDialog

## Screenshots (if applicable)
<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->
<img width="324" alt="lockicon" src="https://github.com/user-attachments/assets/e8db7f1d-1fc5-4c34-a067-67d6bbd1c863" />
<img width="1783" alt="image" src="https://github.com/user-attachments/assets/39b4d92c-ba8b-4f2b-86ed-5ac40c57444c" />
<img width="635" alt="Screenshot 2025-03-16 at 10 50 41 pm" src="https://github.com/user-attachments/assets/27337d57-f6bb-425d-aed0-191a34249ddc" />

<img width="668" alt="Screenshot 2025-03-16 at 10 02 22 pm" src="https://github.com/user-attachments/assets/07c73da9-7a9e-4dec-a006-ce2c83d9a3df" />

## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [X] Code follows project style guidelines
- [X] Tests have been added or updated
- [X] All CI checks pass

## Additional Notes
<!--
Add any other context about the PR here.
-->
This solves the primary issue related to when a user either rotates their public/private key, or upgraded their firmware which causes their public key to change. So if they have DM'ed with other nodes who have stored their previous key, this offers a friendly dialog with one way to resolve the issue by deleting their node and rediscovering it, which will cause their new public key to be stored in their NodeDB.