### PR TITLE
add a label to theme icon

### DIFF
--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTheme } from "../core/hooks/useTheme.ts";
 import { cn } from "../core/utils/cn.ts";
 import { Monitor, Moon, Sun } from "lucide-react";
@@ -10,6 +11,7 @@ export default function ThemeSwitcher({
   className?: string;
 }) {
   const { theme, preference, setPreference } = useTheme();
+  const [isFocused, setIsFocused] = useState(false);
 
   const themeIcons = {
     light: <Sun className="size-5" />,
@@ -24,6 +26,17 @@ export default function ThemeSwitcher({
     setPreference(nextPreference);
   };
 
+  const labelStyle = {
+    display: "block",
+    margin: "0 auto",
+    fontSize: ".65rem",
+    width: "100%",
+    position: "absolute",
+    top: isFocused ? "-2em" : "2em",
+    left: "0",
+    opacity: isFocused ? "100" : "0"
+  };
+
   return (
     <button
       type="button"
@@ -32,10 +45,11 @@ export default function ThemeSwitcher({
         className,
       )}
       onClick={toggleTheme}
-      aria-label={preference === "system"
-        ? `System theme (currently ${theme}). Click to change theme.`
-        : `Current theme: ${theme}. Click to change theme.`}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
+      aria-description={'Current theme'}
     >
+      <span style={labelStyle}>{preference}</span>
       {themeIcons[preference]}
     </button>
   );

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useTheme } from "../core/hooks/useTheme.ts";
 import { cn } from "../core/utils/cn.ts";
 import { Monitor, Moon, Sun } from "lucide-react";
@@ -11,7 +10,6 @@ export default function ThemeSwitcher({
   className?: string;
 }) {
   const { theme, preference, setPreference } = useTheme();
-  const [isFocused, setIsFocused] = useState(false);
 
   const themeIcons = {
     light: <Sun className="size-5" />,
@@ -26,30 +24,19 @@ export default function ThemeSwitcher({
     setPreference(nextPreference);
   };
 
-  const labelStyle = {
-    display: "block",
-    margin: "0 auto",
-    fontSize: ".65rem",
-    width: "100%",
-    position: "absolute",
-    top: isFocused ? "-2em" : "2em",
-    left: "0",
-    opacity: isFocused ? "100" : "0"
-  };
+  const [firstCharOfPreference="", ...restOfPreference] = preference;
 
   return (
     <button
       type="button"
       className={cn(
-        "transition-all duration-300 scale-100 cursor-pointer m-6 p-2",
+        "transition-all duration-300 scale-100 cursor-pointer m-6 p-2 focus:*:data-label:opacity-100",
         className,
       )}
       onClick={toggleTheme}
-      onFocus={() => setIsFocused(true)}
-      onBlur={() => setIsFocused(false)}
-      aria-description={'Current theme'}
+      aria-description={'Change current theme'}
     >
-      <span style={labelStyle}>{preference}</span>
+      <span data-label className="transition-all block absolute w-full mb-auto mt-auto ml-0 mr-0 text-xs left-0 -top-5 opacity-0 rounded-lg">{firstCharOfPreference.toLocaleUpperCase() + restOfPreference.join("")}</span>
       {themeIcons[preference]}
     </button>
   );

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -24,7 +24,7 @@ export default function ThemeSwitcher({
     setPreference(nextPreference);
   };
 
-  const [firstCharOfPreference="", ...restOfPreference] = preference;
+  const [firstCharOfPreference = "", ...restOfPreference] = preference;
 
   return (
     <button
@@ -34,9 +34,15 @@ export default function ThemeSwitcher({
         className,
       )}
       onClick={toggleTheme}
-      aria-description={'Change current theme'}
+      aria-description={"Change current theme"}
     >
-      <span data-label className="transition-all block absolute w-full mb-auto mt-auto ml-0 mr-0 text-xs left-0 -top-5 opacity-0 rounded-lg">{firstCharOfPreference.toLocaleUpperCase() + (restOfPreference ?? []).join("")}</span>
+      <span
+        data-label
+        className="transition-all block absolute w-full mb-auto mt-auto ml-0 mr-0 text-xs left-0 -top-5 opacity-0 rounded-lg"
+      >
+        {firstCharOfPreference.toLocaleUpperCase() +
+          (restOfPreference ?? []).join("")}
+      </span>
       {themeIcons[preference]}
     </button>
   );

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -36,7 +36,7 @@ export default function ThemeSwitcher({
       onClick={toggleTheme}
       aria-description={'Change current theme'}
     >
-      <span data-label className="transition-all block absolute w-full mb-auto mt-auto ml-0 mr-0 text-xs left-0 -top-5 opacity-0 rounded-lg">{firstCharOfPreference.toLocaleUpperCase() + restOfPreference.join("")}</span>
+      <span data-label className="transition-all block absolute w-full mb-auto mt-auto ml-0 mr-0 text-xs left-0 -top-5 opacity-0 rounded-lg">{firstCharOfPreference.toLocaleUpperCase() + (restOfPreference ?? []).join("")}</span>
       {themeIcons[preference]}
     </button>
   );


### PR DESCRIPTION
## Description
Adding visible and accessible name to ThemeSwitcher button

## Changes Made
Added a span inside the ThemeSwitcher button that:
  1. Gives the button an accessible name
  2. Provides a visible text label to the button on focus

## Screenshots (if applicable)
after:
![image](https://github.com/user-attachments/assets/7e92f3c0-a809-4db5-a43a-d06214dd9b76)
![image](https://github.com/user-attachments/assets/2256ff9b-a5da-46a1-9ced-b8f7e9286968)
![image](https://github.com/user-attachments/assets/c763ec63-5a7f-44dc-9201-d40a9aa5e08e)


