### PR TITLE
Refactor useBackupReminder hook

### DIFF
--- a/src/components/KeyBackupReminder.tsx
+++ b/src/components/KeyBackupReminder.tsx
@@ -10,10 +10,6 @@ export const KeyBackupReminder = () => {
       "We recommend backing up your key data regularly. Would you like to back up now?",
     onAccept: () => setDialogOpen("pkiBackup", true),
     enabled: true,
-    cookieOptions: {
-      secure: true,
-      sameSite: "strict",
-    },
   });
   // deno-lint-ignore jsx-no-useless-fragment
   return <></>;

--- a/src/components/KeyBackupReminder.tsx
+++ b/src/components/KeyBackupReminder.tsx
@@ -5,7 +5,6 @@ export const KeyBackupReminder = () => {
   const { setDialogOpen } = useDevice();
 
   useBackupReminder({
-    reminderInDays: 7,
     message:
       "We recommend backing up your key data regularly. Would you like to back up now?",
     onAccept: () => setDialogOpen("pkiBackup", true),

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -5,8 +5,8 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from "./UI/Toast.tsx";
-import { useToast } from "../core/hooks/useToast.ts";
+} from "@components/UI/Toast.tsx";
+import { useToast } from "@core/hooks/useToast.ts";
 
 export function Toaster() {
   const { toasts } = useToast();

--- a/src/core/hooks/useKeyBackupReminder.tsx
+++ b/src/core/hooks/useKeyBackupReminder.tsx
@@ -24,7 +24,10 @@ const STORAGE_KEY = "key_backup_reminder";
 function isReminderExpired(expires?: string): boolean {
   if (!expires) return true;
   const expiryDate = new Date(expires);
-  return isNaN(expiryDate.getTime()) || new Date() >= expiryDate;
+  if (isNaN(expiryDate.getTime())) return true; // Invalid date passed
+
+  const now = new Date();
+  return now.getTime() >= expiryDate.getTime();
 }
 
 export function useBackupReminder({
@@ -70,7 +73,7 @@ export function useBackupReminder({
                 setReminderExpiry(reminderInDays);
               }}
             >
-              Remind me in {reminderInDays} days
+              Remind me in {reminderInDays} day{reminderInDays > 1 ? 's' : ''}
             </Button>
             <Button
               type="button"

--- a/src/core/hooks/useKeyBackupReminder.tsx
+++ b/src/core/hooks/useKeyBackupReminder.tsx
@@ -11,27 +11,27 @@ interface UseBackupReminderOptions {
 }
 
 interface ReminderState {
-  suppressed: boolean;
-  lastShown: string;
+  expires: string;
 }
 
 const TOAST_APPEAR_DELAY = 10_000; // 10 seconds
 const TOAST_DURATION = 30_000; // 30 seconds
-const ON_ACCEPT_REMINDER_DAYS = 365;
+const REMINDER_DAYS_ONE_WEEK = 7;
+const REMINDER_DAYS_ONE_YEAR = 365;
+const REMINDER_DAYS_FOREVER = 3650;
 const STORAGE_KEY = "key_backup_reminder";
 
-function isReminderExpired(lastShown: string): boolean {
-  const lastShownDate = new Date(lastShown);
-  const now = new Date();
-  const daysSinceLastShown = (now.getTime() - lastShownDate.getTime()) / (1000 * 60 * 60 * 24);
-  return daysSinceLastShown >= 7;
+function isReminderExpired(expires?: string): boolean {
+  if (!expires) return true;
+  const expiryDate = new Date(expires);
+  return isNaN(expiryDate.getTime()) || new Date() >= expiryDate;
 }
 
 export function useBackupReminder({
-  reminderInDays = 7,
   enabled,
   message,
   onAccept = () => { },
+  reminderInDays = REMINDER_DAYS_ONE_WEEK,
 }: UseBackupReminderOptions) {
   const { toast } = useToast();
   const toastShownRef = useRef(false);
@@ -40,24 +40,16 @@ export function useBackupReminder({
     null
   );
 
-  // Suppress reminder for 10 years if not specified
-  const suppressReminder = useCallback((days: number = 3563) => {
+  const setReminderExpiry = useCallback((days: number) => {
     const expiryDate = new Date();
     expiryDate.setDate(expiryDate.getDate() + days);
-
-    setReminderState({
-      suppressed: true,
-      lastShown: new Date().toISOString(),
-    });
+    setReminderState({ expires: expiryDate.toISOString() });
   }, [setReminderState]);
 
   useEffect(() => {
     if (!enabled || toastShownRef.current) return;
 
-    const shouldShowReminder =
-      !reminderState?.suppressed || isReminderExpired(reminderState.lastShown);
-
-    if (!shouldShowReminder) return;
+    if (!isReminderExpired(reminderState?.expires)) return;
 
     toastShownRef.current = true;
 
@@ -69,14 +61,13 @@ export function useBackupReminder({
       action: (
         <div className="flex flex-col gap-2">
           <div className="flex gap-2">
-
             <Button
               type="button"
               variant="outline"
               className="p-1"
               onClick={() => {
                 dismiss();
-                suppressReminder(reminderInDays);
+                setReminderExpiry(reminderInDays);
               }}
             >
               Remind me in {reminderInDays} days
@@ -87,42 +78,33 @@ export function useBackupReminder({
               className="p-1"
               onClick={() => {
                 dismiss();
-                suppressReminder();
+                setReminderExpiry(REMINDER_DAYS_FOREVER);
               }}
             >
               Never remind me
             </Button>
           </div>
-          <div className="flex">
-            <Button
-              type="button"
-              variant="default"
-              className="w-full"
-              onClick={() => {
-                onAccept();
-                dismiss();
-                suppressReminder(ON_ACCEPT_REMINDER_DAYS);
-              }}
-            >
-              Back up now
-            </Button>
-          </div>
+          <Button
+            type="button"
+            variant="default"
+            className="w-full"
+            onClick={() => {
+              onAccept();
+              dismiss();
+              setReminderExpiry(REMINDER_DAYS_ONE_YEAR);
+            }}
+          >
+            Back up now
+          </Button>
         </div>
       ),
     });
 
-    return () => {
-      if (!toastShownRef.current) {
-        dismiss();
-      }
-    };
+    return () => dismiss();
   }, [
     enabled,
     message,
     onAccept,
-    reminderInDays,
-    suppressReminder,
-    toast,
-    reminderState,
+
   ]);
-}
+};

--- a/src/core/hooks/useLocalStorage.test.ts
+++ b/src/core/hooks/useLocalStorage.test.ts
@@ -1,0 +1,52 @@
+import { renderHook, act } from '@testing-library/react'
+import useLocalStorage from './useLocalStorage'
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe('useLocalStorage', () => {
+  const key = 'test-key'
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('should initialize with initial value if localStorage is empty', () => {
+    const { result } = renderHook(() => useLocalStorage(key, 'initial'))
+    const [value] = result.current
+    expect(value).toBe('initial')
+  })
+
+  it('should read existing value from localStorage', () => {
+    localStorage.setItem(key, JSON.stringify('stored'))
+    const { result } = renderHook(() => useLocalStorage(key, 'initial'))
+    const [value] = result.current
+    expect(value).toBe('stored')
+  })
+
+  it('should update localStorage when setValue is called', () => {
+    const { result } = renderHook(() => useLocalStorage(key, 'initial'))
+    const [, setValue] = result.current
+
+    act(() => {
+      setValue('updated')
+    })
+
+    expect(localStorage.getItem(key)).toBe(JSON.stringify('updated'))
+    expect(result.current[0]).toBe('updated')
+  })
+
+  it('should remove value from localStorage when removeValue is called', () => {
+    const { result } = renderHook(() => useLocalStorage(key, 'initial'))
+    const [, setValue, removeValue] = result.current
+
+    act(() => {
+      setValue('to-be-removed')
+    })
+
+    act(() => {
+      removeValue()
+    })
+
+    expect(localStorage.getItem(key)).toBeNull()
+    expect(result.current[0]).toBe('initial')
+  })
+})

--- a/src/core/hooks/useToast.test.tsx
+++ b/src/core/hooks/useToast.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook, act } from '@testing-library/react'
+import { useToast } from "@core/hooks/useToast.ts"
+import { Button } from '@components/UI/Button.tsx'
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe('useToast', () => {
+  beforeEach(() => {
+    // Reset toast memory state before each test
+    // our hook uses global memory to store toasts
+    // @ts-expect-error - internal test reset
+    globalThis.memoryState = { toasts: [] }
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should create a toast with title, description, and action', () => {
+    const { result } = renderHook(() => useToast())
+
+    act(() => {
+      result.current.toast({
+        title: 'Backup Reminder',
+        description: 'Don\'t forget to backup!',
+        action: <Button>Backup Now</Button>
+      })
+      vi.runAllTimers()
+    })
+
+    const toast = result.current.toasts[0]
+    expect(result.current.toasts.length).toBe(1)
+    expect(toast.title).toBe('Backup Reminder')
+    expect(toast.description).toBe('Don\'t forget to backup!')
+    expect(toast.action).toBeTruthy()
+    expect(toast.open).toBe(true)
+  })
+  it('should dismiss a toast using returned dismiss function', () => {
+    const { result } = renderHook(() => useToast())
+    vi.useFakeTimers()
+
+    let toastRef: { id: string, dismiss: () => void }
+
+    act(() => {
+      toastRef = result.current.toast({ title: 'Dismiss Me' })
+      vi.runAllTimers() // Flush ADD_TOAST
+    })
+
+    act(() => {
+      toastRef.dismiss()
+    })
+
+    const toast = result.current.toasts.find(t => t.id === toastRef.id)
+    expect(toast?.open).toBe(false)
+
+    vi.useRealTimers()
+  })
+
+
+  it('should allow dismiss via hook dismiss function', () => {
+    const { result } = renderHook(() => useToast())
+    vi.useFakeTimers()
+
+    let toastRef: { id: string }
+
+    act(() => {
+      toastRef = result.current.toast({ title: 'Manual Dismiss' })
+      vi.runAllTimers()
+    })
+
+    act(() => {
+      result.current.dismiss(toastRef.id)
+    })
+
+    const toast = result.current.toasts.find(t => t.id === toastRef.id)
+    expect(toast?.open).toBe(false)
+
+    vi.useRealTimers()
+  })
+
+})

--- a/src/core/hooks/useToast.ts
+++ b/src/core/hooks/useToast.ts
@@ -155,7 +155,7 @@ function toast({ delay = 0, ...props }: Toast) {
         ...props,
         id,
         open: true,
-        onOpenChange: (open) => {
+        onOpenChange: (open: boolean) => {
           if (!open) dismiss();
         },
       },


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This PR refactors the useBackupReminder hook to use localStorage for persistence instead of relying on cookies (js-cookie). This change improves the reliability of storing reminder state, and will allow a single dismiss action to be read across domains (local dev vs live) 

Using cookies limited persistence to the specific domain and environment where the reminder was dismissed. By moving to localStorage, the dismissed state can now persist across local development and live environments (when the same storage is accessible), improving the  developer experience and preventing repeated backup reminders between local development and live.

## Changes Made
<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->
- Replaced the useCookie hook with a custom useLocalStorage hook.
- Persisted the reminder state (suppressed and lastShown values) in localStorage under the key key_backup_reminder.
- Added option to dismiss the reminder forever (10 years).
- Preserved existing functionality:
      Displays the backup reminder toast based on the last shown date and suppression state.
     Allows users to dismiss the reminder forever (10 years), take action, dismiss for one week.

## Testing Done
<!--
Describe how you tested these changes.
-->
Tests have been added for useToast and useLocalStorage hooks, including the Toast component 

## Screenshots (if applicable)
<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->
(the size of the dialog has remained the same fyi)
before:
<img width="409" alt="Screenshot 2025-03-21 at 10 56 14 am" src="https://github.com/user-attachments/assets/df812eb9-8402-4a36-b441-306a5ce65d53" />

after:
<img width="439" alt="Screenshot 2025-03-20 at 2 39 29 pm" src="https://github.com/user-attachments/assets/a7a702e1-18b7-4fcb-8c56-04550e5c2911" />



## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [X] Code follows project style guidelines
- [X] Tests have been added or updated
- [x] All CI checks pass

## Additional Notes
<!--
Add any other context about the PR here.
-->