### PR TITLE
fix: ensured undefined position flags are handled

### DIFF
--- a/src/components/PageComponents/Config/Position.tsx
+++ b/src/components/PageComponents/Config/Position.tsx
@@ -1,8 +1,8 @@
 import {
   type FlagName,
   usePositionFlags,
-} from "../../../core/hooks/usePositionFlags.ts";
-import type { PositionValidation } from "@app/validation/config/position.tsx";
+} from "@core/hooks/usePositionFlags.ts";
+import type { PositionValidation } from "@app/validation/config/position.ts";
 import { create } from "@bufbuild/protobuf";
 import { DynamicForm } from "@components/Form/DynamicForm.tsx";
 import { useDevice } from "@core/stores/deviceStore.ts";
@@ -12,7 +12,7 @@ import { useCallback } from "react";
 export const Position = () => {
   const { config, setWorkingConfig } = useDevice();
   const { flagsValue, activeFlags, toggleFlag, getAllFlags } = usePositionFlags(
-    config?.position.positionFlags ?? 0,
+    config?.position?.positionFlags ?? 0,
   );
 
   const onSubmit = (data: PositionValidation) => {
@@ -74,7 +74,7 @@ export const Position = () => {
               name: "positionFlags",
               value: activeFlags,
               isChecked: (name: string) =>
-                activeFlags.includes(name as FlagName),
+                activeFlags?.includes(name as FlagName) ?? false,
               onValueChange: onPositonFlagChange,
               label: "Position Flags",
               placeholder: "Select position flags...",


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This adds an undefined check to the configuration position flags. It avoids the case where a nil is returned instead of a valid integer.

Fixes #537 Fixes #504 

## Additional Notes
<!--
Add any other context about the PR here.
-->