### PR TITLE
Allow users to DM nodes directly from the map

### DIFF
--- a/src/components/PageComponents/Map/NodeDetail.tsx
+++ b/src/components/PageComponents/Map/NodeDetail.tsx
@@ -54,8 +54,11 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
       <div className="flex gap-2">
         <div className="flex flex-col items-center gap-2 min-w-6 pt-1">
           <Avatar text={shortName} />
-
-          <div>
+          
+          <div onFocusCapture={(e) => {
+            // Required to prevent DM tooltip auto-appearing on creation
+            e.stopPropagation();
+          }}>
             {node.user?.publicKey && node.user?.publicKey.length > 0
               ? (
                 <LockIcon

--- a/src/components/PageComponents/Map/NodeDetail.tsx
+++ b/src/components/PageComponents/Map/NodeDetail.tsx
@@ -55,7 +55,7 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
         <div className="flex flex-col items-center gap-2 min-w-6 pt-1">
           <Avatar text={shortName} />
 
-          <div>            
+          <div>
             {node.user?.publicKey && node.user?.publicKey.length > 0
               ? (
                 <LockIcon

--- a/src/components/PageComponents/Map/NodeDetail.tsx
+++ b/src/components/PageComponents/Map/NodeDetail.tsx
@@ -56,7 +56,6 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
           <Avatar text={shortName} />
 
           <div>            
-
             {node.user?.publicKey && node.user?.publicKey.length > 0
               ? (
                 <LockIcon
@@ -131,7 +130,7 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
               </Subtle>
             </div>
           )}
-          
+
           <div className="flex gap-2 items-center">
             {node.user?.shortName && <div>"{node.user?.shortName}"</div>}
             {node.user?.id && <div>{node.user?.id}</div>}

--- a/src/components/PageComponents/Map/NodeDetail.tsx
+++ b/src/components/PageComponents/Map/NodeDetail.tsx
@@ -16,31 +16,51 @@ import {
   Dot,
   LockIcon,
   LockOpenIcon,
+  MessageSquareIcon,
   MountainSnow,
   Star,
 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@radix-ui/react-tooltip";
+import { useAppStore } from "@core/stores/appStore.ts";
+import { useDevice } from "@core/stores/deviceStore.ts";
 
 export interface NodeDetailProps {
   node: ProtobufType.Mesh.NodeInfo;
 }
 
 export const NodeDetail = ({ node }: NodeDetailProps) => {
+  const { setChatType, setActiveChat } = useAppStore();
+  const { setActivePage } = useDevice();
   const name = node.user?.longName || `!${numberToHexUnpadded(node.num)}`;
+  const shortName = node.user?.shortName ?? "UNK";
   const hwModel = node.user?.hwModel ?? 0;
   const hardwareType =
     Protobuf.Mesh.HardwareModel[hwModel]?.replaceAll("_", " ") ?? `${hwModel}`;
+
+  function handleDirectMessage() {
+    setChatType("direct");
+    setActiveChat(node.num);
+    setActivePage("messages");
+  }
 
   return (
     <div className="dark:text-slate-900 p-1">
       <div className="flex gap-2">
         <div className="flex flex-col items-center gap-2 min-w-6 pt-1">
-          <Avatar text={node.user?.shortName ?? "UNK"} />
+          <Avatar text={shortName} />
 
-          <div>
+          <div>            
+
             {node.user?.publicKey && node.user?.publicKey.length > 0
               ? (
                 <LockIcon
-                  className="text-green-600"
+                  className="text-green-600 mb-1.5"
                   size={12}
                   strokeWidth={3}
                   aria-label="Public Key Enabled"
@@ -48,19 +68,42 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
               )
               : (
                 <LockOpenIcon
-                  className="text-yellow-500"
+                  className="text-yellow-500 mb-1.5"
                   size={12}
                   strokeWidth={3}
                   aria-label="No Public Key"
                 />
               )}
-          </div>
 
-          <Star
-            fill={node.isFavorite ? "black" : "none"}
-            size={15}
-            aria-label={node.isFavorite ? "Favorite" : "Not a Favorite"}
-          />
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <MessageSquareIcon 
+                    size={14}
+                    onClick={handleDirectMessage}
+                    className="cursor-pointer hover:text-blue-500"
+                    title="Send Message"
+                  />
+                </TooltipTrigger>
+                <TooltipPortal>
+                  <TooltipContent
+                    className="rounded-md bg-slate-800 px-3 py-1.5 text-sm text-white shadow-md animate-in fade-in-0 zoom-in-95"
+                    side="top"
+                    align="center"
+                    sideOffset={5}
+                  >
+                    Direct Message {shortName}
+                  </TooltipContent>
+                </TooltipPortal>
+              </Tooltip>
+            </TooltipProvider>
+
+            <Star
+              fill={node.isFavorite ? "black" : "none"}
+              size={15}
+              aria-label={node.isFavorite ? "Favorite" : "Not a Favorite"}
+            />
+          </div>
         </div>
 
         <div>
@@ -70,7 +113,7 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
 
           {!!node.deviceMetrics?.batteryLevel && (
             <div
-              className="flex items-center gap-1"
+              className="flex items-center gap-1 mt-0.5"
               title={`${node.deviceMetrics?.voltage?.toPrecision(3) ?? "Unknown"
                 } volts`}
             >
@@ -88,7 +131,7 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
               </Subtle>
             </div>
           )}
-
+          
           <div className="flex gap-2 items-center">
             {node.user?.shortName && <div>"{node.user?.shortName}"</div>}
             {node.user?.id && <div>{node.user?.id}</div>}


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

This PR implements a simple UX shortcut allowing users to open a DM to any node directly from the map view.

## Related Issues
<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

This PR implements #535 

## Changes Made
<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

- Added Direct Message Icon, properly aligned with other icons and text. Ensured cursor appropriately changes on hover indicating a clickable object.
- Implemented tooltip on hover using existing @radix-ui/react-tooltip library
- Copied existing logic/code from the node list for spawning a DM via `handleDirectMessage`

## Testing Done

Logically, I've validated that this does not disrupt internal state. I can still go back to the map or node list and DM any node after entering this state from the map. I am unable to invoke a broken state after navigating to a node's DM page from the map. Visually, see screenshots and comments below. Also note that dark mode does not alter the map view or node popup.

## Screenshots (if applicable)
<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

![image](https://github.com/user-attachments/assets/cffb3398-1226-4a35-8aa2-c23050730fc8)


On hover:
![image](https://github.com/user-attachments/assets/d519fd41-b9d2-452a-bf68-48a20f7d713a)

Visually, I've tested this with various nodes containing more and less information, overall the icons are not too jarring in either scenario: It may be worth consolidating or reconfiguring these horizontally under the node name at some point, but for now this works well with the vast majority of nodes on the map.
![image](https://github.com/user-attachments/assets/6ab730f9-fe88-4471-8d92-eea314682d31)
![image](https://github.com/user-attachments/assets/3f0961f0-c04f-4052-848a-710b462da48f)


## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [x] Code follows project style guidelines
- [x] Documentation has been updated or added
- [x] Tests have been added or updated
- [x] All CI checks pass
- [x] Dependent changes have been merged

## Additional Notes
<!--
Add any other context about the PR here.
-->