### PR TITLE
feat: added tzdef to device config

### DIFF
--- a/src/components/Form/FormInput.tsx
+++ b/src/components/Form/FormInput.tsx
@@ -7,7 +7,7 @@ import type { LucideIcon } from "lucide-react";
 import { Eye, EyeOff } from "lucide-react";
 import type { ChangeEventHandler } from "react";
 import { useState } from "react";
-import { Controller, type FieldValues } from "react-hook-form";
+import { useController, type FieldValues } from "react-hook-form";
 
 export interface InputFieldProps<T> extends BaseFormBuilderProps<T> {
   type: "text" | "number" | "password";
@@ -17,6 +17,12 @@ export interface InputFieldProps<T> extends BaseFormBuilderProps<T> {
     prefix?: string;
     suffix?: string;
     step?: number;
+    fieldLength?: {
+      min?: number;
+      max?: number;
+      currentValueLength?: number;
+      showCharacterCount?: boolean;
+    },
     action?: {
       icon: LucideIcon;
       onClick: () => void;
@@ -29,42 +35,59 @@ export function GenericInput<T extends FieldValues>({
   disabled,
   field,
 }: GenericFormElementProps<T, InputFieldProps<T>>) {
+  const { fieldLength, ...restProperties } = field.properties || {};
+
   const [passwordShown, setPasswordShown] = useState(false);
+  const [currentLength, setCurrentLength] = useState<number>(fieldLength?.currentValueLength || 0);
+
+  const { field: controllerField } = useController({
+    name: field.name,
+    control,
+  });
+
   const togglePasswordVisiblity = () => {
     setPasswordShown(!passwordShown);
   };
 
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+
+    if (field.properties?.fieldLength?.max && newValue.length > field.properties?.fieldLength?.max) {
+      return;
+    }
+    setCurrentLength(newValue.length);
+
+    if (field.inputChange) field.inputChange(e);
+
+    controllerField.onChange(field.type === "number" ? Number.parseFloat(newValue).toString() : newValue);
+  };
+
+
   return (
-    <Controller
-      name={field.name}
-      control={control}
-      render={({ field: { value, onChange, ...rest } }) => (
-        <Input
-          type={field.type === "password" && passwordShown
-            ? "text"
-            : field.type}
-          action={field.type === "password"
+    <div className="relative w-full">
+      <Input
+        type={field.type === "password" && passwordShown ? "text" : field.type}
+        action={
+          field.type === "password"
             ? {
               icon: passwordShown ? EyeOff : Eye,
               onClick: togglePasswordVisiblity,
             }
-            : undefined}
-          step={field.properties?.step}
-          value={field.type === "number" ? Number.parseFloat(value) : value}
-          id={field.name}
-          onChange={(e) => {
-            if (field.inputChange) field.inputChange(e);
-            onChange(
-              field.type === "number"
-                ? Number.parseFloat(e.target.value)
-                : e.target.value,
-            );
-          }}
-          {...field.properties}
-          {...rest}
-          disabled={disabled}
-        />
+            : undefined
+        }
+        step={field.properties?.step}
+        value={field.type === "number" ? String(controllerField.value) : controllerField.value}
+        id={field.name}
+        onChange={handleInputChange}
+        {...restProperties}
+        disabled={disabled}
+      />
+
+      {fieldLength?.showCharacterCount && fieldLength?.max && (
+        <div className="absolute inset-y-0 right-0 flex items-center pr-3 text-sm text-slate-500 dark:text-slate-400">
+          {currentLength ?? fieldLength?.currentValueLength}/{fieldLength?.max}
+        </div>
       )}
-    />
+    </div>
   );
 }

--- a/src/components/PageComponents/Config/Device/index.tsx
+++ b/src/components/PageComponents/Config/Device/index.tsx
@@ -83,6 +83,19 @@ export const Device = () => {
               description: "Disable triple click",
             },
             {
+              type: 'text',
+              name: 'tzdef',
+              label: 'POSIX Timezone',
+              description: 'The POSIX timezone string for the device',
+              properties: {
+                fieldLength: {
+                  max: 64,
+                  currentValueLength: config.device?.tzdef?.length,
+                  showCharacterCount: true,
+                }
+              },
+            },
+            {
               type: "toggle",
               name: "ledHeartbeatDisabled",
               label: "LED Heartbeat Disabled",


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This PR adds the timezone field to the device config page. The protobuf accepts this value as a string which must be POSIX compliant. 

## Related Issues
<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->
This has been added based on a user request.

## Changes Made
<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->
- Added tzdef field to Device config page 
- Constrained field length to maximum of 64 characters to match the Android implementation. 
- Added properties to input field to to allow for character counts built into the FormInput component. 


## Testing Done
<!--
Describe how you tested these changes.
-->
Writing tests are hard.

## Screenshots (if applicable)
<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->
<img width="1514" alt="Screenshot 2025-03-27 at 12 39 10 pm" src="https://github.com/user-attachments/assets/cb71529c-f0a6-40c3-ad17-63cc0a84dafc" />
<img width="1524" alt="Screenshot 2025-03-27 at 8 42 36 pm" src="https://github.com/user-attachments/assets/08859c35-16af-4d57-b7f9-9988d5efa0e9" />


