### PR TITLE
Cleaner Device Loading UX

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,8 @@ import { SidebarButton } from "@components/UI/Sidebar/sidebarButton.tsx";
 import { Subtle } from "@components/UI/Typography/Subtle.tsx";
 import { useDevice } from "@core/stores/deviceStore.ts";
 import type { Page } from "@core/stores/deviceStore.ts";
+import { Spinner } from "@components/UI/Spinner.tsx";
+
 import {
   BatteryMediumIcon,
   CpuIcon,
@@ -67,46 +69,55 @@ export const Sidebar = ({ children }: SidebarProps) => {
   return showSidebar
     ? (
       <div className="min-w-[280px] max-w-min flex-col overflow-y-auto border-r-[0.5px] bg-background-primary border-slate-300 dark:border-slate-400">
-        <div className="flex justify-between px-8 pt-6">
-          <div>
-            <span className="text-lg font-medium">
-              {myNode?.user?.shortName ?? "UNK"}
-            </span>
-            <Subtle>{myNode?.user?.longName ?? "UNK"}</Subtle>
+        {myNode === undefined ? (
+          <div className="flex flex-col items-center justify-center px-8 py-6">
+            <Spinner />
+            <Subtle className="mt-2">Loading device info...</Subtle>
           </div>
-          <button
-            type="button"
-            className="transition-all hover:text-accent"
-            onClick={() => setDialogOpen("deviceName", true)}
-          >
-            <EditIcon size={16} />
-          </button>
-          <button type="button" onClick={() => setShowSidebar(false)}>
-            <SidebarCloseIcon size={24} />
-          </button>
-        </div>
-        <div className="px-8 pb-6">
-          <div className="flex items-center">
-            <BatteryMediumIcon size={24} viewBox="0 0 28 24" />
-            <Subtle>
-              {myNode?.deviceMetrics?.batteryLevel
-                ? myNode?.deviceMetrics?.batteryLevel > 100
-                  ? "Charging"
-                  : `${myNode?.deviceMetrics?.batteryLevel}%`
-                : "UNK"}
-            </Subtle>
-          </div>
-          <div className="flex items-center">
-            <ZapIcon size={24} viewBox="0 0 36 24" />
-            <Subtle>
-              {myNode?.deviceMetrics?.voltage?.toPrecision(3) ?? "UNK"} volts
-            </Subtle>
-          </div>
-          <div className="flex items-center">
-            <CpuIcon size={24} viewBox="0 0 36 24" />
-            <Subtle>v{myMetadata?.firmwareVersion ?? "UNK"}</Subtle>
-          </div>
-        </div>
+        ) : (
+          <>
+            <div className="flex justify-between px-8 pt-6">
+              <div>
+                <span className="text-lg font-medium">
+                  {myNode.user?.shortName ?? "UNK"}
+                </span>
+                <Subtle>{myNode.user?.longName ?? "UNK"}</Subtle>
+              </div>
+              <button
+                type="button"
+                className="transition-all hover:text-accent"
+                onClick={() => setDialogOpen("deviceName", true)}
+              >
+                <EditIcon size={16} />
+              </button>
+              <button type="button" onClick={() => setShowSidebar(false)}>
+                <SidebarCloseIcon size={24} />
+              </button>
+            </div>
+            <div className="px-8 pb-6">
+              <div className="flex items-center">
+                <BatteryMediumIcon size={24} viewBox="0 0 28 24" />
+                <Subtle>
+                  {myNode.deviceMetrics?.batteryLevel
+                    ? myNode.deviceMetrics.batteryLevel > 100
+                      ? "Charging"
+                      : `${myNode.deviceMetrics.batteryLevel}%`
+                    : "UNK"}
+                </Subtle>
+              </div>
+              <div className="flex items-center">
+                <ZapIcon size={24} viewBox="0 0 36 24" />
+                <Subtle>
+                  {myNode.deviceMetrics?.voltage?.toPrecision(3) ?? "UNK"} volts
+                </Subtle>
+              </div>
+              <div className="flex items-center">
+                <CpuIcon size={24} viewBox="0 0 36 24" />
+                <Subtle>v{myMetadata?.firmwareVersion ?? "UNK"}</Subtle>
+              </div>
+            </div>
+          </>
+        )}
 
         <SidebarSection label="Navigation">
           {pages.map((link) => (
@@ -115,9 +126,12 @@ export const Sidebar = ({ children }: SidebarProps) => {
               label={link.name}
               Icon={link.icon}
               onClick={() => {
-                setActivePage(link.page);
+                if (myNode !== undefined) {
+                  setActivePage(link.page);
+                }
               }}
               active={link.page === activePage}
+              disabled={myNode === undefined}
             />
           ))}
         </SidebarSection>

--- a/src/components/UI/Sidebar/sidebarButton.tsx
+++ b/src/components/UI/Sidebar/sidebarButton.tsx
@@ -7,6 +7,7 @@ export interface SidebarButtonProps {
   Icon?: LucideIcon;
   element?;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
 export const SidebarButton = ({
@@ -15,12 +16,14 @@ export const SidebarButton = ({
   Icon,
   element,
   onClick,
+  disabled = false,
 }: SidebarButtonProps) => (
   <Button
     onClick={onClick}
     variant={active ? "subtle" : "ghost"}
     size="sm"
     className="flex gap-2 w-full"
+    disabled={disabled}
   >
     {Icon && <Icon size={16} />}
     {element && element}


### PR DESCRIPTION
## Description

Currently, the UX flow for adding a device is confusing. The UNK defaults populate despite the device being "Connected", with no visual indication that the page is actively fetching current config from the device. Additionally, if you start clicking around during this flow, it's pretty easy to brick the app:

![Before](https://github.com/user-attachments/assets/63521ff9-3c3b-4ec1-b638-87a87beb9d20)

This change adds a loading visual, and disables the sidebar while initial device information is being fetched. This is visually intuitive, and prevents the app from entering an unexpected state:

![After](https://github.com/user-attachments/assets/bfb0229f-bb6b-4d91-a521-4f8d789e1d17)

Light Mode:

![After-Light](https://github.com/user-attachments/assets/cfdfe0c8-d389-4e97-8e05-af3c251f971b)

## Related Issues

None that I know of, I just wanted to polish this up a bit.

## Changes Made
<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->
- Added undefined check for `myNode` in the sidebar.
- Show existing <Spinner> component if myNode is undefined.
- Pass disabled prop to SidebarButton and disable if myNode is undefined.

## Testing Done
I've attempted to load a valid device, an invalid device (bad URL), a serial device, and a bluetooth device and in all cases the default behavior will keep the popup open until an initial connection can be made. Currently a user can still exit that popup and open the device page, in which the user will see this new state. Before, they would indefinitely see the default UNK values. In a future PR, I'd like to detect the https timeout and automatically remove the UNK device.

![2025-03-28 22 58 08](https://github.com/user-attachments/assets/0693d8d5-be43-44b5-a160-cf7c530d43db)

## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [x] Code follows project style guidelines
- [x] Documentation has been updated or added
- [x] Tests have been added or updated
- [x] All CI checks pass
- [x] Dependent changes have been merged