### PR TITLE
fix: update node details page to use message store

### DIFF
--- a/src/components/PageComponents/Map/NodeDetail.tsx
+++ b/src/components/PageComponents/Map/NodeDetail.tsx
@@ -27,15 +27,15 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@radix-ui/react-tooltip";
-import { useAppStore } from "@core/stores/appStore.ts";
 import { useDevice } from "@core/stores/deviceStore.ts";
+import { MessageType, useMessageStore } from "@core/stores/messageStore.ts";
 
 export interface NodeDetailProps {
   node: ProtobufType.Mesh.NodeInfo;
 }
 
 export const NodeDetail = ({ node }: NodeDetailProps) => {
-  const { setChatType, setActiveChat } = useAppStore();
+  const { setChatType, setActiveChat } = useMessageStore();
   const { setActivePage } = useDevice();
   const name = node.user?.longName || `!${numberToHexUnpadded(node.num)}`;
   const shortName = node.user?.shortName ?? "UNK";
@@ -44,7 +44,7 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
     Protobuf.Mesh.HardwareModel[hwModel]?.replaceAll("_", " ") ?? `${hwModel}`;
 
   function handleDirectMessage() {
-    setChatType("direct");
+    setChatType(MessageType.Direct);
     setActiveChat(node.num);
     setActivePage("messages");
   }
@@ -54,7 +54,7 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
       <div className="flex gap-2">
         <div className="flex flex-col items-center gap-2 min-w-6 pt-1">
           <Avatar text={shortName} />
-          
+
           <div onFocusCapture={(e) => {
             // Required to prevent DM tooltip auto-appearing on creation
             e.stopPropagation();
@@ -80,11 +80,10 @@ export const NodeDetail = ({ node }: NodeDetailProps) => {
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger>
-                  <MessageSquareIcon 
+                  <MessageSquareIcon
                     size={14}
                     onClick={handleDirectMessage}
                     className="cursor-pointer hover:text-blue-500"
-                    title="Send Message"
                   />
                 </TooltipTrigger>
                 <TooltipPortal>

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -77,7 +77,7 @@ export const MessagesPage = () => {
                 key={otherNode.num}
                 label={otherNode.user?.longName ??
                   `!${numberToHexUnpadded(otherNode.num)}`}
-                active={activeChat === otherNode.num && chatType === "direct"}
+                active={activeChat === otherNode.num && chatType === MessageType.Direct}
                 onClick={() => {
                   setChatType(MessageType.Direct);
                   setActiveChat(otherNode.num);

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -153,7 +153,6 @@ export const MessagesPage = () => {
 
           <div className="shrink-0 p-4 w-full dark:bg-slate-900">
             <MessageInput
-              from={activeChat}
               to={currentChat.type === MessageType.Direct ? activeChat : MessageType.Broadcast}
               channel={currentChat.type === MessageType.Direct ? Types.ChannelNumber.Primary : currentChat.id}
               maxBytes={200}


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This fixes an merge conflict that was left in the code. It was using the older style useAppStore when in fact the page should have used `messageStore`.