### PR TITLE
fix: ensured node number on loading screen cant be negative.

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -60,7 +60,7 @@ export const Sidebar = ({ children }: SidebarProps) => {
       page: "channels",
     },
     {
-      name: `Nodes (${nodes.size - 1})`,
+      name: `Nodes (${Math.max(nodes.size - 1, 0)})`,
       icon: UsersIcon,
       page: "nodes",
     },


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This PR fixes a small UI bug where the number of nodes in the sidebar initially appear as a negative number.  

## Related Issues
<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->
Fixes an issue recorded via Discord. 

## Changes Made
<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->
- Used Math.max to ensure 0 is used if the value is initially -1 

## Screenshots (if applicable)
<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->
<img width="290" alt="Screenshot 2025-04-10 at 12 19 24 pm" src="https://github.com/user-attachments/assets/5f549ccf-1dc2-42d4-a9e0-4d4eb2ad49db" />


## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All CI checks pass
- [X] Dependent changes have been merged

## Additional Notes
<!--
Add any other context about the PR here.
-->