### PR TITLE
fix: keep js and css assets in same output directory

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
   define: {
     'import.meta.env.VITE_COMMIT_HASH': JSON.stringify(hash),
   },
+  build: {
+    emptyOutDir: true,
+    assetsDir: './',
+  },
   resolve: {
     alias: {
       '@app': path.resolve(process.cwd(), './src'),


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This PR specifically addresses an issue that has existed for some time within the ESP32 HTTP web server. It isn't possible to serve assets stored in a sub-directory from the bundled web-ui on those devices. This fix addresses that shortcoming of the esp32 web server. 

## Changes Made
<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->
- Modified Vite's config to keep all built assets in a single directory, which simplfies how files are served for the ESP32 and other platforms that are effected by this issue. 
- 
- 
- 

## Testing Done
<!--
Describe how you tested these changes.
-->
Tested by accessing webUI after building server. 

## Screenshots (if applicable)
<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [X] Code follows project style guidelines
- [X ] Documentation has been updated or added
- [ X] Tests have been added or updated
- [ X] All CI checks pass

## Additional Notes
<!--
Add any other context about the PR here.
-->
Thanks to @todd-herbert @vidplace7 for their hard work in troubleshooting and determining how to best fix this issue. 