### PR TITLE
fix: Adjust table odd/even colors

### DIFF
--- a/src/components/generic/Table/index.tsx
+++ b/src/components/generic/Table/index.tsx
@@ -146,8 +146,8 @@ export const Table = ({ headings, rows }: TableProps) => {
             <tr
               key={rowKey}
               className={`
-                bg-white dark:bg-white/10
-                odd:bg-slate-800/70 dark:even:bg-slate-900/70
+                bg-white dark:bg-slate-900
+                odd:bg-slate-200/40 dark:odd:bg-slate-800/40
               `}
             >
               {row.map((item, cellIndex) => {


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
Fixes color mismatch between dark/light mode introduced in PR#604


## Changes Made
- Adjusted colors

## Testing Done


## Screenshots (if applicable)
Old:
![Screenshot From 2025-05-04 23-09-50](https://github.com/user-attachments/assets/53bd80e2-abc4-4b25-9416-df2ef0b36196)

New:
![Screenshot From 2025-05-04 23-10-19](https://github.com/user-attachments/assets/bc45894f-fbf8-4218-98d4-09c50e32a696)



## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [X] Code follows project style guidelines

## Additional Notes
<!--
Add any other context about the PR here.
-->