### PR TITLE
fix #607: Do not show Web Serial / Web Bluetooth warning for HTTP

### DIFF
--- a/src/components/Dialog/NewDeviceDialog.tsx
+++ b/src/components/Dialog/NewDeviceDialog.tsx
@@ -155,7 +155,7 @@ export const NewDeviceDialog = ({
           {tabs.map((tab) => (
             <TabsContent key={tab.label} value={tab.label}>
               <fieldset disabled={tab.isDisabled}>
-                {tab.isDisabled
+                {(tab.label !== "HTTP" && tab.isDisabled)
                   ? <ErrorMessage missingFeatures={unsupported} />
                   : null}
                 <tab.element


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
No longer show Web Serial / Web Bluetooth warning for HTTP connections in progress

## Related Issues
Issue #607 

## Changes Made
- Add check for `tab.label !== "HTTP"`

## Testing Done
Using Safari on macOS and Firefox on Fedora

## Screenshots (if applicable)
Connection in progress

<img width="593" alt="Screenshot 2025-05-05 at 00 03 39" src="https://github.com/user-attachments/assets/333c3566-4ee1-4b6a-8c0b-b474a07d241c" />


## Checklist
- [X] Code follows project style guidelines

## Additional Notes
<!--
Add any other context about the PR here.
-->