### PR TITLE
Fix node list sorting, dark mode text colors

### DIFF
--- a/src/components/Dialog/NewDeviceDialog.tsx
+++ b/src/components/Dialog/NewDeviceDialog.tsx
@@ -135,7 +135,7 @@ export const NewDeviceDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogClose />
         <DialogHeader>
           <DialogTitle>Connect New Device</DialogTitle>

--- a/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
+++ b/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
@@ -65,7 +65,7 @@ export const NodeDetailsDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogClose />
         <DialogHeader>
           <DialogTitle>

--- a/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
+++ b/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
@@ -128,7 +128,7 @@ export const NodeDetailsDialog = ({
 
               {device.deviceMetrics && (
                 <div className="text-slate-900 dark:text-slate-100 bg-slate-100 dark:bg-slate-800 p-3 rounded-lg mt-3">
-                  <p className="text-lg font-semibold text-slate-900 dark:text-slate-0">
+                  <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">
                     Device Metrics:
                   </p>
                   {deviceMetricsMap.map(

--- a/src/components/Dialog/NodeOptionsDialog.tsx
+++ b/src/components/Dialog/NodeOptionsDialog.tsx
@@ -75,7 +75,7 @@ export const NodeOptionsDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogClose />
         <DialogHeader>
           <DialogTitle>{`${longName} (${shortName})`}</DialogTitle>

--- a/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx
+++ b/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx
@@ -41,7 +41,10 @@ export const RefreshKeysDialog = (
   };
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-8 flex flex-col gap-2">
+      <DialogContent
+        className="max-w-8 flex flex-col gap-2"
+        aria-describedby={undefined}
+      >
         <DialogClose onClick={handleCloseDialog} />
         <DialogHeader>
           <DialogTitle>{text.title}</DialogTitle>
@@ -77,7 +80,6 @@ export const RefreshKeysDialog = (
             </div>
           </li>
         </ul>
-        {/* </DialogDescription> */}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/PageComponents/Messages/TraceRoute.tsx
+++ b/src/components/PageComponents/Messages/TraceRoute.tsx
@@ -27,7 +27,7 @@ const RoutePath = (
   return (
     <span
       id={title}
-      className="ml-4 border-l-2 border-l-background-primary pl-2 text-slate-900 dark:text-slate-900"
+      className="ml-4 border-l-2 pl-2 border-l-slate-900 text-slate-900 dark:text-slate-100 dark:border-l-slate-100"
     >
       <p className="font-semibold">{title}</p>
       <p>{startNode?.user?.longName}</p>

--- a/src/components/generic/Table/index.test.tsx
+++ b/src/components/generic/Table/index.test.tsx
@@ -40,25 +40,46 @@ describe("Generic Table", () => {
 
   // A simplified version of the rows in pages/Nodes.tsx for testing purposes
   const mockDevicesWithShortNameAndConnection = [
-    { user: { shortName: "TST1" }, hopsAway: 1, lastHeard: Date.now() + 1000 },
-    { user: { shortName: "TST2" }, hopsAway: 0, lastHeard: Date.now() + 4000 },
-    { user: { shortName: "TST3" }, hopsAway: 4, lastHeard: Date.now() },
-    { user: { shortName: "TST4" }, hopsAway: 3, lastHeard: Date.now() + 2000 },
+    {
+      user: { shortName: "TST1" },
+      hopsAway: 1,
+      lastHeard: Date.now() + 1000,
+      viaMqtt: false,
+    },
+    {
+      user: { shortName: "TST2" },
+      hopsAway: 0,
+      lastHeard: Date.now() + 4000,
+      viaMqtt: true,
+    },
+    {
+      user: { shortName: "TST3" },
+      hopsAway: 4,
+      lastHeard: Date.now(),
+      viaMqtt: false,
+    },
+    {
+      user: { shortName: "TST4" },
+      hopsAway: 3,
+      lastHeard: Date.now() + 2000,
+      viaMqtt: true,
+    },
   ];
 
   const mockRows = mockDevicesWithShortNameAndConnection.map((node) => [
     <h1 data-testshortname key={node.user.shortName}>{node.user.shortName}</h1>,
-    <React.Fragment key={node.user.shortName}>
+    <Mono key="lastHeard" data-testheard>
       <TimeAgo timestamp={node.lastHeard * 1000} />
-    </React.Fragment>,
+    </Mono>,
     <Mono key="hops" data-testhops>
       {node.lastHeard !== 0
-        ? node.hopsAway === 0
+        ? node.viaMqtt === false && node.hopsAway === 0
           ? "Direct"
           : `${node.hopsAway?.toString()} ${
-            node.hopsAway > 1 ? "hops" : "hop"
+            node.hopsAway ?? 0 > 1 ? "hops" : "hop"
           } away`
         : "-"}
+      {node.viaMqtt === true ? ", via MQTT" : ""}
     </Mono>,
   ]);
 

--- a/src/components/generic/Table/index.test.tsx
+++ b/src/components/generic/Table/index.test.tsx
@@ -4,7 +4,6 @@ import { Table } from "@components/generic/Table/index.tsx";
 import { TimeAgo } from "@components/generic/TimeAgo.tsx";
 import { Mono } from "@components/generic/Mono.tsx";
 // @ts-types="react"
-import React from "react";
 
 describe("Generic Table", () => {
   it("Can render an empty table.", () => {

--- a/src/components/generic/Table/index.tsx
+++ b/src/components/generic/Table/index.tsx
@@ -62,16 +62,16 @@ export const Table = ({ headings, rows }: TableProps) => {
     const elementB = getElement(b[columnIndex]);
 
     if (sortColumn === "Last Heard") {
-      const aTimestamp = elementA?.props?.timestamp ?? 0;
-      const bTimestamp = elementB?.props?.timestamp ?? 0;
+      const aTimestamp = elementA?.props?.children?.props?.timestamp ?? 0;
+      const bTimestamp = elementB?.props?.children?.props?.timestamp ?? 0;
       if (aTimestamp < bTimestamp) return sortOrder === "asc" ? -1 : 1;
       if (aTimestamp > bTimestamp) return sortOrder === "asc" ? 1 : -1;
       return 0;
     }
 
     if (sortColumn === "Connection") {
-      const aHopsStr = elementA?.props?.children;
-      const bHopsStr = elementB?.props?.children;
+      const aHopsStr = elementA?.props?.children[0];
+      const bHopsStr = elementB?.props?.children[0];
       const aNumHops = numericHops(aHopsStr);
       const bNumHops = numericHops(bHopsStr);
       if (aNumHops < bNumHops) return sortOrder === "asc" ? -1 : 1;


### PR DESCRIPTION
## Description
Sorting was not working for `Connection` and `Last Heard`, now fixed.
Colors adjusted for traceroute return dialog and node info dialog.

## Related Issues

## Changes Made
- Sorting logic was comparing wrong (nonexistent) element for columns `Connection` and `Last Heard`. This has been adjusted.
- Traceroute response text color changed to `slate-100` for dark mode
- Device metrics header text color changed to `slate-100` for dark mode
- Added a few instances of `aria-describedby={undefined}` where Dialogs were created without `<DialogDescription>`

## Testing Done
Tested locally

## Screenshots (if applicable)
New look:
![Screenshot From 2025-05-07 21-38-26](https://github.com/user-attachments/assets/049ec39f-818e-46ff-94e0-faaaff808843)
![Screenshot From 2025-05-07 21-37-26](https://github.com/user-attachments/assets/1700c1c5-a23a-4f54-90d2-62ed5776e482)


## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [x] Code follows project style guidelines
- [X] All CI checks pass
- [X] Dependent changes have been merged

## Additional Notes
<!--
Add any other context about the PR here.
-->