### PR TITLE
Add check for undefined hopsAway

### DIFF
--- a/src/pages/Nodes.tsx
+++ b/src/pages/Nodes.tsx
@@ -79,7 +79,6 @@ const NodesPage = (): JSX.Element => {
     },
     [hardware.myNodeNum],
   );
-
   return (
     <>
       <PageLayout
@@ -125,14 +124,14 @@ const NodesPage = (): JSX.Element => {
                 {node.user?.longName ?? numberToHexUnpadded(node.num)}
               </h1>,
               <Mono key="hops" className="w-16">
-                {node.lastHeard !== 0 && typeof node.hopsAway !== "undefined"
-                  ? node.viaMqtt === false && node.hopsAway === 0
+                {node.hopsAway !== undefined
+                  ? node?.viaMqtt === false && node.hopsAway === 0
                     ? "Direct"
                     : `${node.hopsAway?.toString()} ${
                       node.hopsAway ?? 0 > 1 ? "hops" : "hop"
                     } away`
                   : "-"}
-                {node.viaMqtt === true ? ", via MQTT" : ""}
+                {node?.viaMqtt === true ? ", via MQTT" : ""}
               </Mono>,
               <Mono key="lastHeard">
                 {node.lastHeard === 0

--- a/src/pages/Nodes.tsx
+++ b/src/pages/Nodes.tsx
@@ -125,7 +125,7 @@ const NodesPage = (): JSX.Element => {
                 {node.user?.longName ?? numberToHexUnpadded(node.num)}
               </h1>,
               <Mono key="hops" className="w-16">
-                {node.lastHeard !== 0
+                {node.lastHeard !== 0 && typeof node.hopsAway !== "undefined"
                   ? node.viaMqtt === false && node.hopsAway === 0
                     ? "Direct"
                     : `${node.hopsAway?.toString()} ${


### PR DESCRIPTION
## Description
This small PR changes `hopsAway` table field from "undefined hops away" when `hopsAway` is undefined and shows same as when `lastHeard === 0`. While issue #351 was no longer directly relevant, it can be closed when this is merged.


## Related Issues
Issue #351 

## Changes Made
- Added additional conditional

## Testing Done
Tested against nodes where lastHeard !== 0, but hopsAway was undefined.

## Screenshots (if applicable)
Previously:
<img width="375" alt="Screenshot 2025-05-11 at 14 04 55" src="https://github.com/user-attachments/assets/5d9fcd43-3a63-4edc-b771-eebe93434c52" />

After this change:
<img width="315" alt="Screenshot 2025-05-11 at 14 05 32" src="https://github.com/user-attachments/assets/2fd3b327-9c1f-45d0-b736-fdcaa0928309" />



## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [X] Code follows project style guidelines
- [X] All CI checks pass

## Additional Notes
<!--
Add any other context about the PR here.
-->