### PR TITLE
Feature: Admin PKI fields

### DIFF
--- a/src/components/Form/FormToggle.tsx
+++ b/src/components/Form/FormToggle.tsx
@@ -3,11 +3,11 @@ import type {
   GenericFormElementProps,
 } from "@components/Form/DynamicForm.tsx";
 import { Switch } from "@components/UI/Switch.tsx";
-import type { ChangeEvent } from "react";
 import { Controller, type FieldValues } from "react-hook-form";
 
 export interface ToggleFieldProps<T> extends BaseFormBuilderProps<T> {
   type: "toggle";
+  inputChange?: (value: boolean) => void;
 }
 
 export function ToggleInput<T extends FieldValues>({
@@ -15,16 +15,6 @@ export function ToggleInput<T extends FieldValues>({
   disabled,
   field,
 }: GenericFormElementProps<T, ToggleFieldProps<T>>) {
-  const onChangeHandler = (e: (event: ChangeEvent) => void) => {
-    return (value: boolean) => {
-      e({
-        target: {
-          value: value,
-        },
-      } as unknown as ChangeEvent);
-    };
-  };
-
   return (
     <Controller
       name={field.name}
@@ -32,7 +22,10 @@ export function ToggleInput<T extends FieldValues>({
       render={({ field: { value, onChange, ...rest } }) => (
         <Switch
           checked={value}
-          onCheckedChange={onChangeHandler(onChange)}
+          onCheckedChange={(v) => {
+            onChange(v);
+            field.inputChange?.(v);
+          }}
           id={field.name}
           disabled={disabled}
           {...field.properties}

--- a/src/components/PageComponents/Config/Security/Security.tsx
+++ b/src/components/PageComponents/Config/Security/Security.tsx
@@ -41,9 +41,9 @@ export const Security = () => {
     privateKeyDialogOpen: false,
   });
 
-  const stateRef = useRef(state);
+  const adminKeysRef = useRef(state);
   useEffect(() => {
-    stateRef.current = state;
+    adminKeysRef.current = state;
   }, [state]);
 
   const validateKey = (
@@ -97,7 +97,7 @@ export const Security = () => {
       return;
     }
 
-    const current = stateRef.current;
+    const current = adminKeysRef.current;
 
     setWorkingConfig(
       create(Protobuf.Config.ConfigSchema, {

--- a/src/components/PageComponents/Config/Security/securityReducer.tsx
+++ b/src/components/PageComponents/Config/Security/securityReducer.tsx
@@ -7,8 +7,6 @@ export function securityReducer(
   switch (action.type) {
     case "SET_PRIVATE_KEY":
       return { ...state, privateKey: action.payload };
-    case "TOGGLE_PRIVATE_KEY_VISIBILITY":
-      return { ...state, privateKeyVisible: !state.privateKeyVisible };
     case "SET_PRIVATE_KEY_BIT_COUNT":
       return { ...state, privateKeyBitCount: action.payload };
     case "SET_PUBLIC_KEY":
@@ -24,6 +22,8 @@ export function securityReducer(
         publicKey: action.payload.publicKey,
         privateKeyDialogOpen: false,
       };
+    case "SET_TOGGLE":
+      return { ...state, [action.field]: action.payload };
     default:
       return state;
   }

--- a/src/components/PageComponents/Config/Security/securityReducer.tsx
+++ b/src/components/PageComponents/Config/Security/securityReducer.tsx
@@ -9,18 +9,12 @@ export function securityReducer(
       return { ...state, privateKey: action.payload };
     case "TOGGLE_PRIVATE_KEY_VISIBILITY":
       return { ...state, privateKeyVisible: !state.privateKeyVisible };
-    case "TOGGLE_ADMIN_KEY_VISIBILITY":
-      return { ...state, adminKeyVisible: !state.adminKeyVisible };
     case "SET_PRIVATE_KEY_BIT_COUNT":
       return { ...state, privateKeyBitCount: action.payload };
     case "SET_PUBLIC_KEY":
       return { ...state, publicKey: action.payload };
-    case "SET_ADMIN1_KEY":
-      return { ...state, adminKey1: action.payload };
-    case "SET_ADMIN2_KEY":
-      return { ...state, adminKey2: action.payload };
-    case "SET_ADMIN3_KEY":
-      return { ...state, adminKey3: action.payload };
+    case "SET_ADMIN_KEY":
+      return { ...state, adminKey: action.payload };
     case "SHOW_PRIVATE_KEY_DIALOG":
       return { ...state, privateKeyDialogOpen: action.payload };
     case "REGENERATE_PRIV_PUB_KEY":

--- a/src/components/PageComponents/Config/Security/securityReducer.tsx
+++ b/src/components/PageComponents/Config/Security/securityReducer.tsx
@@ -15,8 +15,12 @@ export function securityReducer(
       return { ...state, privateKeyBitCount: action.payload };
     case "SET_PUBLIC_KEY":
       return { ...state, publicKey: action.payload };
-    case "SET_ADMIN_KEY":
-      return { ...state, adminKey: action.payload };
+    case "SET_ADMIN1_KEY":
+      return { ...state, adminKey1: action.payload };
+    case "SET_ADMIN2_KEY":
+      return { ...state, adminKey2: action.payload };
+    case "SET_ADMIN3_KEY":
+      return { ...state, adminKey3: action.payload };
     case "SHOW_PRIVATE_KEY_DIALOG":
       return { ...state, privateKeyDialogOpen: action.payload };
     case "REGENERATE_PRIV_PUB_KEY":
@@ -25,11 +29,6 @@ export function securityReducer(
         privateKey: action.payload.privateKey,
         publicKey: action.payload.publicKey,
         privateKeyDialogOpen: false,
-      };
-    case "REGENERATE_ADMIN_KEY":
-      return {
-        ...state,
-        adminKey: action.payload.adminKey,
       };
     default:
       return state;

--- a/src/components/PageComponents/Config/Security/types.ts
+++ b/src/components/PageComponents/Config/Security/types.ts
@@ -1,26 +1,19 @@
 export interface SecurityState {
   privateKey: string;
   privateKeyVisible: boolean;
-  adminKeyVisible: boolean;
-  adminKey2Visible: boolean;
-  adminKey3Visible: boolean;
+  adminKeyVisible: [boolean, boolean, boolean];
   privateKeyBitCount: number;
   publicKey: string;
-  adminKey1: string;
-  adminKey2: string;
-  adminKey3: string;
+  adminKey: [string, string, string];
   privateKeyDialogOpen: boolean;
 }
 
 export type SecurityAction =
   | { type: "SET_PRIVATE_KEY"; payload: string }
   | { type: "TOGGLE_PRIVATE_KEY_VISIBILITY" }
-  | { type: "TOGGLE_ADMIN_KEY_VISIBILITY" }
   | { type: "SET_PRIVATE_KEY_BIT_COUNT"; payload: number }
   | { type: "SET_PUBLIC_KEY"; payload: string }
-  | { type: "SET_ADMIN1_KEY"; payload: string }
-  | { type: "SET_ADMIN2_KEY"; payload: string }
-  | { type: "SET_ADMIN3_KEY"; payload: string }
+  | { type: "SET_ADMIN_KEY"; payload: [string, string, string] }
   | { type: "SHOW_PRIVATE_KEY_DIALOG"; payload: boolean }
   | {
     type: "REGENERATE_PRIV_PUB_KEY";

--- a/src/components/PageComponents/Config/Security/types.ts
+++ b/src/components/PageComponents/Config/Security/types.ts
@@ -1,3 +1,6 @@
+import { type MessageInitShape } from "@bufbuild/protobuf";
+import { Protobuf } from "@meshtastic/core";
+
 export interface SecurityState {
   privateKey: string;
   privateKeyVisible: boolean;
@@ -6,16 +9,27 @@ export interface SecurityState {
   publicKey: string;
   adminKey: [string, string, string];
   privateKeyDialogOpen: boolean;
+  isManaged: boolean;
+  adminChannelEnabled: boolean;
+  debugLogApiEnabled: boolean;
+  serialEnabled: boolean;
 }
 
 export type SecurityAction =
   | { type: "SET_PRIVATE_KEY"; payload: string }
-  | { type: "TOGGLE_PRIVATE_KEY_VISIBILITY" }
   | { type: "SET_PRIVATE_KEY_BIT_COUNT"; payload: number }
   | { type: "SET_PUBLIC_KEY"; payload: string }
   | { type: "SET_ADMIN_KEY"; payload: [string, string, string] }
   | { type: "SHOW_PRIVATE_KEY_DIALOG"; payload: boolean }
+  | { type: "SET_TOGGLE"; payload: boolean; field: string }
   | {
     type: "REGENERATE_PRIV_PUB_KEY";
     payload: { privateKey: string; publicKey: string };
   };
+
+export type SecurityConfigInit = Extract<
+  MessageInitShape<
+    typeof Protobuf.Config.ConfigSchema
+  >["payloadVariant"],
+  { case: "security" }
+>["value"];

--- a/src/components/PageComponents/Config/Security/types.ts
+++ b/src/components/PageComponents/Config/Security/types.ts
@@ -2,10 +2,13 @@ export interface SecurityState {
   privateKey: string;
   privateKeyVisible: boolean;
   adminKeyVisible: boolean;
+  adminKey2Visible: boolean;
+  adminKey3Visible: boolean;
   privateKeyBitCount: number;
-  adminKeyBitCount: number;
   publicKey: string;
-  adminKey: string;
+  adminKey1: string;
+  adminKey2: string;
+  adminKey3: string;
   privateKeyDialogOpen: boolean;
 }
 
@@ -15,10 +18,11 @@ export type SecurityAction =
   | { type: "TOGGLE_ADMIN_KEY_VISIBILITY" }
   | { type: "SET_PRIVATE_KEY_BIT_COUNT"; payload: number }
   | { type: "SET_PUBLIC_KEY"; payload: string }
-  | { type: "SET_ADMIN_KEY"; payload: string }
+  | { type: "SET_ADMIN1_KEY"; payload: string }
+  | { type: "SET_ADMIN2_KEY"; payload: string }
+  | { type: "SET_ADMIN3_KEY"; payload: string }
   | { type: "SHOW_PRIVATE_KEY_DIALOG"; payload: boolean }
   | {
     type: "REGENERATE_PRIV_PUB_KEY";
     payload: { privateKey: string; publicKey: string };
-  }
-  | { type: "REGENERATE_ADMIN_KEY"; payload: { adminKey: string } };
+  };

--- a/src/validation/config/security.ts
+++ b/src/validation/config/security.ts
@@ -7,9 +7,6 @@ export class SecurityValidation implements
     Protobuf.Config.Config_SecurityConfig,
     | keyof Message
     | "adminKey"
-    | "adminKey1"
-    | "adminKey2"
-    | "adminKey3"
     | "privateKey"
     | "publicKey"
   > {
@@ -17,13 +14,7 @@ export class SecurityValidation implements
   adminChannelEnabled: boolean;
 
   @IsString()
-  adminKey1: string;
-
-  @IsString()
-  adminKey2: string;
-
-  @IsString()
-  adminKey3: string;
+  adminKey: [string, string, string];
 
   @IsBoolean()
   bluetoothLoggingEnabled: boolean;

--- a/src/validation/config/security.ts
+++ b/src/validation/config/security.ts
@@ -5,13 +5,25 @@ import { IsBoolean, IsString } from "class-validator";
 export class SecurityValidation implements
   Omit<
     Protobuf.Config.Config_SecurityConfig,
-    keyof Message | "adminKey" | "privateKey" | "publicKey"
+    | keyof Message
+    | "adminKey"
+    | "adminKey1"
+    | "adminKey2"
+    | "adminKey3"
+    | "privateKey"
+    | "publicKey"
   > {
   @IsBoolean()
   adminChannelEnabled: boolean;
 
   @IsString()
-  adminKey: string;
+  adminKey1: string;
+
+  @IsString()
+  adminKey2: string;
+
+  @IsString()
+  adminKey3: string;
 
   @IsBoolean()
   bluetoothLoggingEnabled: boolean;


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
The remaining two admin key fields have been added and at least one valid PKI field is required when setting managed mode.

## Related Issues
#315 - Add ability to add all 3 PKI admin keys
#355 - Warn users from selecting managed node 

## Changes Made
- Removed generate key button for admin key fields
- Added two more fields
- Moved toggles for managed mode and legacy admin mode below PKI fields.
- Managed toggle now requires at least one valid admin key field.
- Refactored so that onChange is not called twice which would result in states not being set as expected.

## Testing Done
Limited testing with RAK device on 2.6.4.b89355f Beta, more testing needed.

## Screenshots (if applicable)
<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->
<img width="907" alt="Screenshot 2025-05-15 at 13 19 26" src="https://github.com/user-attachments/assets/cfca0efd-4a28-468a-a965-753c24b05ea7" />


## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [X] Code follows project style guidelines
- [X] All CI checks pass
- [X] Dependent changes have been merged
## Additional Notes
<!--
Add any other context about the PR here.
-->