### PR TITLE
Fix Avatar text wrap

### DIFF
--- a/src/components/UI/Avatar.tsx
+++ b/src/components/UI/Avatar.tsx
@@ -136,7 +136,7 @@ export const Avatar = ({
           </TooltipProvider>
         )
         : null}
-      <p className="p-1">
+      <p className="p-1 text-nowrap">
         {initials}
       </p>
     </div>


### PR DESCRIPTION
<!--
Thank you for your contribution to our project! Please fill out the following template to help reviewers understand your changes.
-->

## Description
This minor PR adjusts the Avatar component to make sure `text-wrap: nowrap` is set to the shortName.

## Related Issues
Fixes #624

## Changes Made
- Added Tailwind className `text-nowrap` to the text element.

## Testing Done
<!--
Describe how you tested these changes.
-->

## Screenshots (if applicable)
Now:
<img width="157" alt="Screenshot 2025-05-27 at 10 18 17" src="https://github.com/user-attachments/assets/0265e741-9044-4853-8fde-6c2ffa3b1974" />
<img width="176" alt="Screenshot 2025-05-27 at 10 18 15" src="https://github.com/user-attachments/assets/cae0004a-9a7b-48cd-8a46-6a21427dc5df" />

Previously:
<img width="345" alt="Screenshot 2025-05-26 at 18 49 14" src="https://github.com/user-attachments/assets/351147ec-50bd-473d-b95b-41831eab78fe" />


## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All CI checks pass
- [X] Dependent changes have been merged

## Additional Notes
<!--
Add any other context about the PR here.
-->