### PR TITLE
fix: Crowdin upload sources action

### DIFF
--- a/.github/workflows/crowdin-upload-sources.yml
+++ b/.github/workflows/crowdin-upload-sources.yml
@@ -5,9 +5,9 @@ on:
     # Monitor all .json files within the /src/i18n/locales/en/ directory.
     # This ensures the workflow triggers if any the English namespace files are modified on the main branch.
     paths:
-      - '/src/i18n/locales/en/**/*.json' 
-    branches: [ main ]
-  workflow_dispatch:     # Allow manual triggering
+      - "/src/i18n/locales/en/*.json"
+    branches: [main]
+  workflow_dispatch: # Allow manual triggering
 
 jobs:
   synchronize-with-crowdin:
@@ -20,13 +20,13 @@ jobs:
       - name: Upload sources with Crowdin
         uses: crowdin/github-action@v2
         with:
-          base_url: 'https://meshtastic.crowdin.com/api/v2'
-          config: 'crowdin.yml' 
-          upload_sources: true   
-          upload_translations: false 
-          download_translations: false 
-          crowdin_branch_name: 'main'  
-                                      
+          base_url: "https://meshtastic.crowdin.com/api/v2"
+          config: "crowdin.yml"
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          crowdin_branch_name: "main"
+
         env:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["bradlc.vscode-tailwindcss", "biomejs.biome"]
+  "recommendations": ["bradlc.vscode-tailwindcss", "denoland.vscode-deno"]
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
Seems like the upload to crowdin action is not triggered as expected. All source files are located in `/src/i18n/locales/en/*.json` and not `/src/i18n/locales/en/**/*.json`.
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

The recommended vscode extension "biome" was also replaced by deno.
## Related Issues

## Changes Made
- Changed paths from `/src/i18n/locales/en/**/*.json` to `/src/i18n/locales/en/*.json`
- Replaced biome with deno in vscode recommendations

## Testing Done
Untested

## Screenshots (if applicable)

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
