### PR TITLE
Prevented i18n package from escaping text

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -8,16 +8,18 @@
 
     <link rel="manifest" href="site.webmanifest" />
     <link rel="mask-icon" href="logo_black.svg" color="#67ea94" />
-    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+    <link
+      rel="stylesheet"
+      href="https://rsms.me/inter/inter.css"
+      crossorigin="anonymous"
+    />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@xz/fonts@1/serve/cascadia-code.min.css"
+      crossorigin="anonymous"
     />
     <meta name="theme-color" content="#67ea94" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Meshtastic Web Client" />
     <title>Meshtastic Web</title>
   </head>

--- a/packages/web/public/i18n/locales/en/dialog.json
+++ b/packages/web/public/i18n/locales/en/dialog.json
@@ -178,6 +178,6 @@
   "managedMode": {
     "confirmUnderstanding": "Yes, I know what I'm doing",
     "title": "Are you sure?",
-    "description": "Enabling Managed Mode blocks client applications (including the web client) from writing configurations to a radio. Once enabled, radio configurations can <bold>only</bold> be changed through Remote Admin messages. This setting is not required for remote node administration."
+    "description": "Enabling Managed Mode blocks client applications (including the web client) from writing configurations to a radio. Once enabled, radio configurations can only be changed through Remote Admin messages. This setting is not required for remote node administration."
   }
 }

--- a/packages/web/src/components/Dialog/LocationResponseDialog.tsx
+++ b/packages/web/src/components/Dialog/LocationResponseDialog.tsx
@@ -47,6 +47,7 @@ export const LocationResponseDialog = ({
         <DialogHeader>
           <DialogTitle>
             {t("locationResponse.title", {
+              interpolation: { escapeValue: false },
               identifier: `${longName} (${shortName})`,
             })}
           </DialogTitle>

--- a/packages/web/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
+++ b/packages/web/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
@@ -169,6 +169,7 @@ export const NodeDetailsDialog = ({
         <DialogHeader>
           <DialogTitle>
             {t("nodeDetails.title", {
+              interpolation: { escapeValue: false },
               identifier: `${node.user?.longName ?? t("unknown.shortName")} (${
                 node.user?.shortName ?? t("unknown.shortName")
               })`,

--- a/packages/web/src/components/Dialog/PKIBackupDialog.tsx
+++ b/packages/web/src/components/Dialog/PKIBackupDialog.tsx
@@ -50,6 +50,7 @@ export const PkiBackupDialog = ({
           <head>
             <title>${
         t("pkiBackup.header", {
+          interpolation: { escapeValue: false },
           shortName: getMyNode()?.user?.shortName ?? t("unknown.shortName"),
           longName: getMyNode()?.user?.longName ?? t("unknown.longName"),
         })
@@ -63,6 +64,7 @@ export const PkiBackupDialog = ({
           <body>
             <h1>${
         t("pkiBackup.header", {
+          interpolation: { escapeValue: false },
           shortName: getMyNode()?.user?.shortName ?? t("unknown.shortName"),
           longName: getMyNode()?.user?.longName ?? t("unknown.longName"),
         })
@@ -103,6 +105,7 @@ export const PkiBackupDialog = ({
     const link = document.createElement("a");
     link.href = url;
     link.download = t("pkiBackup.fileName", {
+      interpolation: { escapeValue: false },
       shortName: getMyNode()?.user?.shortName ?? t("unknown.shortName"),
       longName: getMyNode()?.user?.longName ?? t("unknown.longName"),
     });

--- a/packages/web/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx
+++ b/packages/web/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx
@@ -10,7 +10,7 @@ import { LockKeyholeOpenIcon } from "lucide-react";
 import { useRefreshKeysDialog } from "./useRefreshKeysDialog.ts";
 import { useDevice } from "@core/stores/deviceStore.ts";
 import { useTranslation } from "react-i18next";
-import { useMessageStore } from "../../../core/stores/messageStore/index.ts";
+import { useMessageStore } from "@core/stores/messageStore/index.ts";
 
 export interface RefreshKeysDialogProps {
   open: boolean;
@@ -35,6 +35,7 @@ export const RefreshKeysDialog = (
 
   const text = {
     title: t("refreshKeys.title", {
+      interpolation: { escapeValue: false },
       identifier: nodeWithError?.user?.longName ?? "",
     }),
     description: `${t("refreshKeys.description.unableToSendDmPrefix")}${

--- a/packages/web/src/core/dto/NodeNumToNodeInfoDTO.ts
+++ b/packages/web/src/core/dto/NodeNumToNodeInfoDTO.ts
@@ -8,14 +8,11 @@ class NodeInfoFactory {
     const last4 = userIdHex.slice(-4);
     const longName = `Meshtastic ${last4}`;
     const shortName = last4;
-    const hwModel = Protobuf.Mesh.HardwareModel.UNSET;
 
     return create(Protobuf.Mesh.UserSchema, {
       id: userId,
-      longName: longName,
-      shortName: shortName,
-      hwModel: hwModel,
-      isLicensed: false,
+      longName: longName.toString(),
+      shortName: shortName.toString(),
     });
   }
 

--- a/packages/web/src/pages/Messages.tsx
+++ b/packages/web/src/pages/Messages.tsx
@@ -308,6 +308,7 @@ export const MessagesPage = () => {
     <PageLayout
       label={`${
         t("page.title", {
+          interpolation: { escapeValue: false },
           chatName: isBroadcast && currentChannel
             ? getChannelName(currentChannel)
             : isDirect && otherNode

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -49,6 +49,8 @@ export default defineConfig({
   server: {
     port: 3000,
     headers: {
+      "content-security-policy":
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data: https://rsms.me https://cdn.jsdelivr.net; img-src 'self' data:; font-src 'self' data: https://rsms.me https://cdn.jsdelivr.net; worker-src 'self' blob:; object-src 'none'; base-uri 'self';",
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "require-corp",
     },

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -12,6 +12,9 @@ try {
   hash = "DEV";
 }
 
+const CONTENT_SECURITY_POLICY =
+  "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data: https://rsms.me https://cdn.jsdelivr.net; img-src 'self' data:; font-src 'self' data: https://rsms.me https://cdn.jsdelivr.net; worker-src 'self' blob:; object-src 'none'; base-uri 'self';";
+
 export default defineConfig({
   plugins: [
     react(),

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -49,8 +49,7 @@ export default defineConfig({
   server: {
     port: 3000,
     headers: {
-      "content-security-policy":
-        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data: https://rsms.me https://cdn.jsdelivr.net; img-src 'self' data:; font-src 'self' data: https://rsms.me https://cdn.jsdelivr.net; worker-src 'self' blob:; object-src 'none'; base-uri 'self';",
+      "content-security-policy": CONTENT_SECURITY_POLICY,
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "require-corp",
     },


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request introduces several changes to improve security, fix localization issues, and enhance code quality in the `packages/web` module. The most significant updates include adding a content security policy, fixing localization interpolation settings, and ensuring consistent type handling for node information.

### Security Enhancements:
* [`packages/web/vite.config.ts`](diffhunk://#diff-e8d91d82c7259277d60af79aecaad3089aca989f92ed4e26e2b25d1d4f4b5ab3R52-R53): Added a comprehensive `content-security-policy` header to restrict script, style, image, font, and worker sources, improving security against potential vulnerabilities.
* [`packages/web/index.html`](diffhunk://#diff-5c0e1d6a0de94ea1723b573b1e0ed0100423b33a3fcefea81d8bfbc67b113010L11-R22): Updated external stylesheet links to include the `crossorigin="anonymous"` attribute for better security and modified the `viewport` meta tag for improved compatibility.

### Localization Fixes:
* Various files (`LocationResponseDialog.tsx`, `NodeDetailsDialog.tsx`, `PKIBackupDialog.tsx`, `RefreshKeysDialog.tsx`, `Messages.tsx`): Fixed missing `interpolation: { escapeValue: false }` in translation calls to prevent unnecessary escaping of HTML entities in localized strings. [[1]](diffhunk://#diff-6ab301b143ad040558a4d07ea13f35bccbd8399a148f83380fffa7db3d24f085R50) [[2]](diffhunk://#diff-197331721ea5584f98fb29553194d7d2b44165cfeb68946fe90b74d48d134f44R172) [[3]](diffhunk://#diff-bca7811aa1c171bc17537beedf60e5d619ada33eff4333d000811b987e002831R53) [[4]](diffhunk://#diff-bca7811aa1c171bc17537beedf60e5d619ada33eff4333d000811b987e002831R67) [[5]](diffhunk://#diff-bca7811aa1c171bc17537beedf60e5d619ada33eff4333d000811b987e002831R108) [[6]](diffhunk://#diff-050d63e23f40a9088f2516c0e8004c3aaaf4ce89334ac0f80b069b700f2ae322R38) [[7]](diffhunk://#diff-edd299b07c7a7ca7ecf9942495cdc68c607fd3a40cac408244cf069307f7ed5fR311)

### Code Quality Improvements:
* [`packages/web/src/core/dto/NodeNumToNodeInfoDTO.ts`](diffhunk://#diff-d4d293e5f704ed4d033d276ef84d46474799cea57967e8f632ad38528b892b8aL11-R15): Removed unused `hwModel` property and ensured `longName` and `shortName` are explicitly converted to strings for consistency.

### Minor Text Adjustments:
* [`packages/web/public/i18n/locales/en/dialog.json`](diffhunk://#diff-b456ab7d7f486ecb6bc7f4ffe6623bfff14cd8f405ceb80a6b05b4f0a9a24ee7L181-R181): Fixed formatting in the "description" field of the Managed Mode dialog to remove unnecessary `<bold>` tags.

### Dependency Path Cleanup:
* [`packages/web/src/components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx`](diffhunk://#diff-050d63e23f40a9088f2516c0e8004c3aaaf4ce89334ac0f80b069b700f2ae322L13-R13): Updated the import path for `useMessageStore` to use the `@core` alias for consistency across the codebase.

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->
Fixes #689 

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->
BEFORE: 
See image in bug

AFTER:
<img width="569" height="59" alt="image" src="https://github.com/user-attachments/assets/6b13ce33-2e28-4cb4-b188-9a7057d28482" />


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
