### PR TITLE
fix: include additional info in nightly container tag name 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
           path: ${{ steps.setup-deno.outputs.deno-cache-path }}
           key: deno-cache-${{ runner.os }}-${{ hashFiles('**/deno.lock') }}
           restore-keys: |
-            deno-cache-${{ runner.os }}- 
+            deno-cache-${{ runner.os }}-* 
 
       # - name: Run tests
       #   working-directory: packages/web

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,7 @@ jobs:
           containerfiles: |
             ./infra/Containerfile
           image: ${{ github.event.repository.full_name }}
-          tags: nightly-${{ steps.get_release.outputs.tag }}-${{ github.sha }}
+          tags: nightly:${{ steps.get_release.outputs.tag }}:${{ github.sha }}
 
 
           oci: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 jobs:
-  build-and-package:
+  nightly-build-and-push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,13 +20,21 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Cache Deno dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.setup-deno.outputs.deno-cache-path }}
+          key: deno-cache-${{ runner.os }}-${{ hashFiles('**/deno.lock') }}
+          restore-keys: |
+            deno-cache-${{ runner.os }}- 
+
+      # - name: Run tests
+      #   working-directory: packages/web
+      #   run: deno task test
+
       - name: Install Dependencies
         working-directory: packages/web
         run: deno install
-
-      - name: Run tests
-        working-directory: packages/web
-        run: deno task test
 
       - name: Build Package
         working-directory: packages/web
@@ -42,6 +50,19 @@ jobs:
           name: build
           path: packages/web/dist/build.tar
 
+      - name: Get latest release version
+        id: get_release
+        run: |
+          LATEST_TAG=$(curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r ".tag_name")
+          # Fallback to a default if no release is found
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="2.6.0"
+          fi
+          echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -51,8 +72,10 @@ jobs:
         with:
           containerfiles: |
             ./infra/Containerfile
-          image: ${{github.event.repository.full_name}}
-          tags: nightly ${{ github.sha }}
+          image: ${{ github.event.repository.full_name }}
+          tags: nightly-${{ steps.get_release.outputs.tag }}-${{ github.sha }}
+
+
           oci: true
           platforms: linux/amd64, linux/arm64
 
@@ -68,3 +91,4 @@ jobs:
 
       - name: Print image url
         run: echo "Image pushed to ${{ steps.push-to-registry.outputs.registry-paths }}"
+


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request updates the nightly workflow configuration in `.github/workflows/nightly.yml` to improve caching, enhance tagging for nightly builds, and streamline the workflow steps. The most important changes include renaming the job, adding caching for Deno dependencies, dynamically fetching the latest release version for tagging, and updating the image tags to include the release version.

### Dynamic Tagging:

* **Fetching Latest Release Version**: Added a step to dynamically fetch the latest release version from GitHub's API, with a fallback to a default version (`2.6.0`) if no release is found. This ensures accurate versioning for nightly builds.

* **Updated Image Tags**: Modified the image tagging format to include the fetched release version (`nightly:${{ steps.get_release.outputs.tag }}:${{ github.sha }}`), providing more informative tags for nightly builds.

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->
Fixes #700 

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
