### PR TITLE
24hr Clock Support

### DIFF
--- a/packages/web/src/components/PageComponents/Messages/MessageItem.tsx
+++ b/packages/web/src/components/PageComponents/Messages/MessageItem.tsx
@@ -51,7 +51,7 @@ interface MessageItemProps {
 }
 
 export const MessageItem = ({ message }: MessageItemProps) => {
-  const { getNode } = useDevice();
+  const { config, getNode } = useDevice();
   const { getMyNodeNum } = useMessageStore();
   const { t, i18n } = useTranslation("messages");
 
@@ -132,7 +132,7 @@ export const MessageItem = ({ message }: MessageItemProps) => {
       messageDate?.toLocaleTimeString(locale, {
         hour: "numeric",
         minute: "2-digit",
-        hour12: true,
+        hour12: config?.display?.use12hClock ?? true,
       }) ?? "",
     [messageDate, locale],
   );


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
Respects the `config.display.use12hClock` setting when displaying timestamps on messages

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Related Issues
#665 

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

- changed the `hour12` MessageItem field to respect the `config.display.use12hrClock` setting

## Testing Done

<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [ ] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
