### PR TITLE
add current tagged version to footer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "meshtastic-web",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.1",
+        "@meshtastic/protobufs": "npm:@jsr/meshtastic__protobufs",
         "ste-simple-events": "^3.0.11",
         "tslog": "^4.9.3",
       },
@@ -18,7 +19,6 @@
       "name": "@meshtastic/core",
       "version": "2.6.5",
       "dependencies": {
-        "@meshtastic/protobufs": "npm:@jsr/meshtastic__protobufs",
         "crc": "npm:crc@^4.3.2",
       },
     },
@@ -28,7 +28,7 @@
     },
     "packages/transport-http": {
       "name": "@meshtastic/transport-http",
-      "version": "0.2.1",
+      "version": "0.2.2",
     },
     "packages/transport-node": {
       "name": "@meshtastic/transport-node",
@@ -36,14 +36,14 @@
     },
     "packages/transport-web-bluetooth": {
       "name": "@meshtastic/transport-web-bluetooth",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "devDependencies": {
         "@types/web-bluetooth": "npm:@types/web-bluetooth@^0.0.20",
       },
     },
     "packages/transport-web-serial": {
       "name": "@meshtastic/transport-web-serial",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@types/w3c-web-serial": "npm:@types/w3c-web-serial@^1.0.7",
       },

--- a/packages/web/src/components/UI/Footer.tsx
+++ b/packages/web/src/components/UI/Footer.tsx
@@ -1,13 +1,11 @@
 import { cn } from "@core/utils/cn.ts";
-import { Trans, useTranslation } from "react-i18next";
+import { Trans } from "react-i18next";
 
 type FooterProps = {
   className?: string;
 };
 
 const Footer = ({ className, ...props }: FooterProps) => {
-  const { t } = useTranslation();
-
   return (
     <footer
       className={cn(
@@ -16,11 +14,15 @@ const Footer = ({ className, ...props }: FooterProps) => {
       )}
       {...props}
     >
-      <div className="justify-start px-2">
+      <div className="px-2">
         <span className="font-semibold text-gray-500/40 dark:text-gray-400/40">
-          {t("footer.commitSha", {
-            sha: String(import.meta.env.VITE_COMMIT_HASH)?.toUpperCase(),
-          })}
+          {String(import.meta.env.VITE_VERSION)?.toUpperCase()}
+        </span>
+        <span className="font-semibold text-gray-500/40 dark:text-gray-400/40 mx-2">
+          -
+        </span>
+        <span className="font-semibold text-gray-500/40 dark:text-gray-400/40">
+          {`#${String(import.meta.env.VITE_COMMIT_HASH)?.toUpperCase()}`}
         </span>
       </div>
       <p className="ml-auto mr-auto text-gray-500 dark:text-gray-400">

--- a/packages/web/vite-env.d.ts
+++ b/packages/web/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly env: {
     readonly VITE_COMMIT_HASH: string;
+    readonly VITE_VERSION: string;
   };
 }
 

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -6,11 +6,20 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 let hash = "";
+let version = "v0.0.0";
 try {
   hash = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
 } catch (error) {
   console.error("Error getting git hash:", error);
   hash = "DEV";
+}
+
+try {
+  version = execSync("git describe --tags --abbrev=0", {
+    encoding: "utf8",
+  }).trim();
+} catch (error) {
+  console.error("Error getting git version:", error);
 }
 
 const CONTENT_SECURITY_POLICY =
@@ -37,6 +46,7 @@ export default defineConfig({
   },
   define: {
     "import.meta.env.VITE_COMMIT_HASH": JSON.stringify(hash),
+    "import.meta.env.VITE_VERSION": JSON.stringify(version),
   },
   build: {
     emptyOutDir: true,


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request introduces changes to the `Footer` component and the Vite configuration to enhance versioning and display the application version and commit hash in the UI. The most important changes include removing unused translation functionality, updating the `Footer` to show the version and commit hash, and modifying the Vite configuration to retrieve and define these values.

### Updates to `Footer` component:

* Updated the `Footer` to display the application version (`VITE_VERSION`) and commit hash (`VITE_COMMIT_HASH`) directly, formatted with additional styling. (`packages/web/src/components/UI/Footer.tsx`, [packages/web/src/components/UI/Footer.tsxL19-R25](diffhunk://#diff-86b055f42ec6c5683b3e5c9f6c5c25939aaa38660d4d186e446073623185e7a8L19-R25))

### Changes to Vite configuration:

* Added logic to retrieve the latest Git tag for versioning (`VITE_VERSION`) using `git describe --tags --abbrev=0`. This complements the existing logic for retrieving the commit hash (`VITE_COMMIT_HASH`). (`packages/web/vite.config.ts`, [packages/web/vite.config.tsR9-R24](diffhunk://#diff-e8d91d82c7259277d60af79aecaad3089aca989f92ed4e26e2b25d1d4f4b5ab3R9-R24))
* Defined `import.meta.env.VITE_VERSION` in the Vite configuration to make the version accessible in the application. (`packages/web/vite.config.ts`, [packages/web/vite.config.tsR49](diffhunk://#diff-e8d91d82c7259277d60af79aecaad3089aca989f92ed4e26e2b25d1d4f4b5ab3R49))

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

I know someone had asked for this in the UI. So adding it as its a pretty quick fix. 


## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->
<img width="233" height="51" alt="image" src="https://github.com/user-attachments/assets/b4dcd575-c9c3-4a28-9b11-d78f450b9e14" />


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
