### PR TITLE
Readd device num to serial page

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,14 +14,14 @@
 
 	"homepage": "https://meshtastic.org",
 	"scripts": {
-		"build": "bunx --bun vite build",
+		"build": "vite build",
 		"build:analyze": "BUNDLE_ANALYZE=true bun run build",
 		"check": "biome check src/",
 		"check:fix": "biome check --write src/",
-		"dev": "bunx --bun vite",
-		"test": "bunx --bun vitest",
+		"dev": "vite",
+		"test": "vitest",
 		"ts:check": "bun run tsc --noEmit",
-		"preview": "bunx --bun vite preview",
+		"preview": "vite preview",
 		"generate:routes": "bun @tanstack/router-cli generate --outDir src/ routes --rootRoutePath /",
 		"package": "gzipper c -i html,js,css,png,ico,svg,json,webmanifest,txt dist dist/output && tar -cvf dist/build.tar -C ./dist/output/ ."
 	},

--- a/packages/web/src/components/PageComponents/Connect/Serial.tsx
+++ b/packages/web/src/components/PageComponents/Connect/Serial.tsx
@@ -52,7 +52,7 @@ export const Serial = ({ closeDialog }: TabElementProps) => {
       disabled={connectionInProgress}
     >
       <div className="flex h-48 flex-col gap-2 overflow-y-auto">
-        {serialPorts.map((port) => {
+        {serialPorts.map((port, idx) => {
           const { usbProductId, usbVendorId } = port.getInfo();
           const vendor = usbVendorId ?? t("unknown.shortName");
           const product = usbProductId ?? t("unknown.shortName");
@@ -70,6 +70,7 @@ export const Serial = ({ closeDialog }: TabElementProps) => {
               {t("newDeviceDialog.serialConnection.deviceIdentifier", {
                 vendorId: vendor,
                 productId: product,
+                index: idx,
               })}
             </Button>
           );


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request includes updates to the `packages/web` project that streamline scripts in `package.json` and enhance the handling of serial port information in the `Serial` component. The most important changes involve removing the use of `bunx` in scripts and adding an index parameter to improve device identification.

### Enhancements to the `Serial` component:

* [`packages/web/src/components/PageComponents/Connect/Serial.tsx`](diffhunk://#diff-c3cf2710116f42460921a91d1fe8d45b26d47edfccdbba56ce85ada1e42bc872L55-R55): Updated the `serialPorts.map` callback to include an `idx` parameter, enabling the use of the index for additional context.
* [`packages/web/src/components/PageComponents/Connect/Serial.tsx`](diffhunk://#diff-c3cf2710116f42460921a91d1fe8d45b26d47edfccdbba56ce85ada1e42bc872R73): Added the `index` parameter to the translation object for device identifiers, improving clarity when multiple devices are connected.


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X ] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
