### PR TITLE
Fix route destination mapping and unknown node display in traceroute dialogs

### DIFF
--- a/packages/web/src/components/Dialog/TracerouteResponseDialog.tsx
+++ b/packages/web/src/components/Dialog/TracerouteResponseDialog.tsx
@@ -30,7 +30,7 @@ export const TracerouteResponseDialog = ({
   const routeBack: number[] = traceroute?.data.routeBack ?? [];
   const snrTowards = (traceroute?.data.snrTowards ?? []).map((snr) => snr / 4);
   const snrBack = (traceroute?.data.snrBack ?? []).map((snr) => snr / 4);
-  const from = getNode(traceroute?.from ?? 0);
+  const from = getNode(traceroute?.to ?? 0); // The origin of the traceroute = the "to" node of the mesh packet
   const fromLongName =
     from?.user?.longName ??
     (from ? `!${numberToHexUnpadded(from?.num)}` : t("unknown.shortName"));
@@ -40,7 +40,7 @@ export const TracerouteResponseDialog = ({
       ? `${numberToHexUnpadded(from?.num).substring(0, 4)}`
       : t("unknown.shortName"));
 
-  const toUser = getNode(traceroute?.to ?? 0);
+  const toUser = getNode(traceroute?.from ?? 0); // The destination of the traceroute = the "from" node of the mesh packet
 
   if (!toUser || !from) {
     return null;

--- a/packages/web/src/components/PageComponents/Messages/TraceRoute.tsx
+++ b/packages/web/src/components/PageComponents/Messages/TraceRoute.tsx
@@ -41,7 +41,7 @@ const RoutePath = ({ title, from, to, path, snr }: RoutePathProps) => {
         <span key={getNode(hop)?.num ?? hop}>
           <p>
             {getNode(hop)?.user?.longName ??
-              `${t("traceRoute.nodeUnknownPrefix")}${numberToHexUnpadded(hop)}`}
+              `${t("unknown.longName")} (!${numberToHexUnpadded(hop)})`}
           </p>
           <p>
             ↓ {snr?.[i + 1] ?? t("unknown.num")}


### PR DESCRIPTION
## Description
Corrects the mapping of 'from' and 'to' nodes in TracerouteResponseDialog to reflect the actual origin and destination of traceroute packets. Also updates TraceRoute to display unknown if long name is not available, improving clarity for unknown nodes.

## Related Issues

## Changes Made
- Corrected the mapping of 'from' and 'to' nodes in TracerouteResponseDialog
- Updated TraceRoute to display unknown if long name is not available.

## Testing Done


## Screenshots (if applicable)
Example of previous node name / label

<img width="536" height="235" alt="Screenshot 2025-07-20 at 23 08 01" src="https://github.com/user-attachments/assets/1685765d-c0fd-49e0-a1c5-2364d1b9a994" />

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
