### PR TITLE
Fix HTTP transport initial connect attempt target

### DIFF
--- a/packages/transport-http/src/transport.ts
+++ b/packages/transport-http/src/transport.ts
@@ -12,7 +12,9 @@ export class TransportHTTP implements Types.Transport {
     tls?: boolean,
   ): Promise<TransportHTTP> {
     const connectionUrl = `${tls ? "https" : "http"}://${address}`;
-    await fetch(`${connectionUrl}/json/report`);
+    await fetch(`${connectionUrl}/api/v1/toradio`, {
+      method: "OPTIONS",
+    });
     await Promise.resolve();
     return new TransportHTTP(connectionUrl);
   }


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
This minor PR changes the intial connect attempt target from a GET request to `/json/report` to an OPTIONS request to `/api/v1/toradio`, since the `/json/report` endpoint only exists on the esp32 platform. 

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made
- Changed request path to `/api/v1/toradio` and request method to OPTIONS

## Testing Done
Tested with node on esp32 and linux-native/meshtasticd platform

<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
