### PR TITLE
Fix #715 - Change chatId validation schema

### DIFF
--- a/packages/web/src/routes.tsx
+++ b/packages/web/src/routes.tsx
@@ -14,7 +14,7 @@ import {
   redirect,
 } from "@tanstack/react-router";
 import type { useTranslation } from "react-i18next";
-import { z } from "zod";
+import { z } from "zod/v4";
 import { App } from "./App.tsx";
 
 interface AppContext {
@@ -55,23 +55,6 @@ const messagesRoute = createRoute({
   },
 });
 
-const chatIdSchema = z.string().refine(
-  (val) => {
-    const num = Number(val);
-    if (Number.isNaN(num) || !Number.isInteger(num)) {
-      return false;
-    }
-
-    const isChannelId = num >= 0 && num <= 10;
-    const isNodeId = num >= 1000000000 && num <= 9999999999;
-
-    return isChannelId || isNodeId;
-  },
-  {
-    message: "Chat ID must be a channel (0-10) or a valid node ID.",
-  },
-);
-
 export const messagesWithParamsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/messages/$type/$chatId",
@@ -83,7 +66,7 @@ export const messagesWithParamsRoute = createRoute({
         message: 'Type must be "direct" or "broadcast".',
       })
       .parse(params.type),
-    chatId: chatIdSchema.parse(params.chatId),
+    chatId: z.coerce.number().int().min(0).max(4294967294).parse(params.chatId), // max is 0xffffffff - 1
   }),
 });
 


### PR DESCRIPTION

<!--
Thank you for your contribution to our project!
-->

## Description
This PR changes the validation schema for the routing input chatId, allowing all id's from 0 to 4294967294 (`0xffffffff` - 1).

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Related Issues
Fixes #715

## Changes Made
- Updated the Zod validation schema

## Testing Done

<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
