### PR TITLE
Send heartbeat package to keep serial alive

### DIFF
--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -1,7 +1,6 @@
-import { Logger } from "tslog";
-
 import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import * as Protobuf from "@meshtastic/protobufs";
+import { Logger } from "tslog";
 
 import { Constants } from "./constants.ts";
 import type { Destination, PacketMetadata, Transport } from "./types.ts";
@@ -39,6 +38,8 @@ export class MeshDevice {
   public events: EventSystem;
 
   public xModem: Xmodem;
+
+  private _heartbeatIntervalId: ReturnType<typeof setInterval> | undefined;
 
   constructor(transport: Transport, configId?: number) {
     this.log = new Logger({
@@ -742,6 +743,18 @@ export class MeshDevice {
   }
 
   /**
+   * Initializes the heartbeat interval, which sends a heartbeat ping every interval milliseconds.
+   */
+  public setHeartbeatInterval(interval: number): void {
+    if (this._heartbeatIntervalId) {
+      clearInterval(this._heartbeatIntervalId);
+    }
+    this._heartbeatIntervalId = setInterval(() => {
+      this.heartbeat();
+    }, interval);
+  }
+
+  /**
    * Sends a trace route packet to the designated node
    */
   public async traceRoute(destination: number): Promise<number> {
@@ -798,6 +811,11 @@ export class MeshDevice {
   /**  Disconnects from the device **/
   public async disconnect(): Promise<void> {
     this.log.debug(Emitter[Emitter.Disconnect], "🔌 Disconnecting from device");
+
+    if (this._heartbeatIntervalId !== undefined) {
+      clearInterval(this._heartbeatIntervalId);
+    }
+
     this.complete();
     await this.transport.toDevice.close();
   }

--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -746,7 +746,7 @@ export class MeshDevice {
    * Initializes the heartbeat interval, which sends a heartbeat ping every interval milliseconds.
    */
   public setHeartbeatInterval(interval: number): void {
-    if (this._heartbeatIntervalId) {
+    if (this._heartbeatIntervalId !== undefined) {
       clearInterval(this._heartbeatIntervalId);
     }
     this._heartbeatIntervalId = setInterval(() => {

--- a/packages/core/src/utils/queue.ts
+++ b/packages/core/src/utils/queue.ts
@@ -44,6 +44,16 @@ export class Queue {
           if (this.queue.findIndex((qi) => qi.id === item.id) !== -1) {
             this.remove(item.id);
             const decoded = fromBinary(Protobuf.Mesh.ToRadioSchema, item.data);
+
+            if (
+              decoded.payloadVariant.case === "heartbeat" ||
+              decoded.payloadVariant.case === "wantConfigId"
+            ) {
+              // heartbeat and wantConfigId packets are not acknowledged by the device, assume success after timeout
+              resolve(item.id);
+              return;
+            }
+
             console.warn(
               `Packet ${item.id} of type ${decoded.payloadVariant.case} timed out`,
             );

--- a/packages/web/src/components/PageComponents/Connect/BLE.tsx
+++ b/packages/web/src/components/PageComponents/Connect/BLE.tsx
@@ -36,6 +36,10 @@ export const BLE = ({ closeDialog }: TabElementProps) => {
     setSelectedDevice(id);
     device.addConnection(connection);
     subscribeAll(device, connection, messageStore);
+
+    const HEARTBEAT_INTERVAL = 5*60*1000;
+    connection.setHeartbeatInterval(HEARTBEAT_INTERVAL);
+
     closeDialog();
   };
 

--- a/packages/web/src/components/PageComponents/Connect/Serial.tsx
+++ b/packages/web/src/components/PageComponents/Connect/Serial.tsx
@@ -43,6 +43,9 @@ export const Serial = ({ closeDialog }: TabElementProps) => {
     device.addConnection(connection);
     subscribeAll(device, connection, messageStore);
 
+    const HEARTBEAT_INTERVAL = 5*60*1000;
+    connection.setHeartbeatInterval(HEARTBEAT_INTERVAL);
+
     closeDialog();
   };
 


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
This PR adds heartbeat messages sent to the device in order to keep the serial connection alive.

This PR contains changes to both web and core packages.

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Related Issues
Fixes #679 
<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made
- _packages/web/_: Added call to `connection.heartbeat()` every 5 minutes right after connect in BLE.tsx
- _packages/web/_: Added call to `connection.heartbeat()` every 5 minutes right after connect in Serial.tsx
- _packages/core/_: Updated queue.tsx so that the two toRadio packets `heartbeat` and `wantConfigId`, where the device firmware doesn't respond with a queue status resolve after 60s instead of throwing timeout errors.

## Testing Done
Tested using serial and BLE, stable for 5+ hours.
<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
