### PR TITLE
crowdin github actions - update directory paths for source files

### DIFF
--- a/.github/workflows/crowdin-upload-sources.yml
+++ b/.github/workflows/crowdin-upload-sources.yml
@@ -5,7 +5,7 @@ on:
     # Monitor all .json files within the /i18n/locales/en/ directory.
     # This ensures the workflow triggers if any the English namespace files are modified on the main branch.
     paths:
-      - "/i18n/locales/en/*.json"
+      - "/packages/web/public/i18n/locales/en/*.json"
     branches: [main]
   workflow_dispatch: # Allow manual triggering
 

--- a/packages/web/crowdin.yml
+++ b/packages/web/crowdin.yml
@@ -6,5 +6,5 @@ base_url: "https://meshtastic.crowdin.com/api/v2"
 preserve_hierarchy: true
 
 files:
-  - source: "/i18n/locales/en/*.json"
-    translation: "/i18n/locales/%locale%/%original_file_name%"
+  - source: "/public/i18n/locales/en/*.json"
+    translation: "/public/i18n/locales/%locale%/%original_file_name%"


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request updates paths related to internationalization (i18n) files to reflect a new directory structure. The changes ensure that workflows and configurations correctly reference the updated file locations.

### Updates to i18n file paths:

* [`.github/workflows/crowdin-upload-sources.yml`](diffhunk://#diff-35a63a29afa1690ec7362f59a7a611891c67a67e8136550eaf68094b76d51f59L8-R8): Updated the workflow to monitor `.json` files in the new `packages/web/public/i18n/locales/en/` directory instead of the old `i18n/locales/en/` directory.
* [`packages/web/crowdin.yml`](diffhunk://#diff-12e5b269217f57d68fbbac1081b949eef1f23dfce5d25ecc127f4bfd20757c24L9-R10): Adjusted the `source` and `translation` paths to align with the new directory structure, changing from `i18n/locales` to `public/i18n/locales`.


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [X ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
