### PR TITLE
Transport disconnect method

### DIFF
--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -818,6 +818,7 @@ export class MeshDevice {
 
     this.complete();
     await this.transport.toDevice.close();
+    await this.transport.disconnect();
   }
 
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,7 @@ export type DeviceOutput = Packet | DebugLog;
 export interface Transport {
   toDevice: WritableStream<Uint8Array>;
   fromDevice: ReadableStream<DeviceOutput>;
+  disconnect(): Promise<void>;
 }
 
 export interface QueueItem {

--- a/packages/transport-deno/src/transport.ts
+++ b/packages/transport-deno/src/transport.ts
@@ -4,6 +4,7 @@ import { Utils } from "@meshtastic/core";
 export class TransportDeno implements Types.Transport {
   private _toDevice: WritableStream<Uint8Array>;
   private _fromDevice: ReadableStream<Types.DeviceOutput>;
+  private connection: Deno.Conn | undefined;
 
   public static async create(hostname: string): Promise<TransportDeno> {
     const connection = await Deno.connect({
@@ -14,10 +15,11 @@ export class TransportDeno implements Types.Transport {
   }
 
   constructor(connection: Deno.Conn) {
-    Utils.toDeviceStream.readable.pipeTo(connection.writable);
+    this.connection = connection;
+    Utils.toDeviceStream.readable.pipeTo(this.connection.writable);
 
     this._toDevice = Utils.toDeviceStream.writable;
-    this._fromDevice = connection.readable.pipeThrough(
+    this._fromDevice = this.connection.readable.pipeThrough(
       Utils.fromDeviceStream(),
     );
   }
@@ -28,5 +30,11 @@ export class TransportDeno implements Types.Transport {
 
   get fromDevice(): ReadableStream<Types.DeviceOutput> {
     return this._fromDevice;
+  }
+
+  disconnect(): Promise<void> {
+    this.connection.close();
+    this.connection = undefined;
+    return Promise.resolve();
   }
 }

--- a/packages/transport-http/src/transport.ts
+++ b/packages/transport-http/src/transport.ts
@@ -7,6 +7,7 @@ export class TransportHTTP implements Types.Transport {
   private receiveBatchRequests: boolean;
   private fetchInterval: number;
   private fetching: boolean;
+  private interval: number | undefined;
 
   public static async create(
     address: string,
@@ -40,7 +41,7 @@ export class TransportHTTP implements Types.Transport {
       },
     });
 
-    setInterval(async () => {
+    this.interval = setInterval(async () => {
       if (this.fetching) {
         // We still have the previous request open
         return;
@@ -99,5 +100,14 @@ export class TransportHTTP implements Types.Transport {
 
   get fromDevice(): ReadableStream<Types.DeviceOutput> {
     return this._fromDevice;
+  }
+
+  disconnect() : Promise<void> {
+    this.fetching = false;
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+    this.interval = undefined;
+    return Promise.resolve();
   }
 }

--- a/packages/transport-node/src/transport.ts
+++ b/packages/transport-node/src/transport.ts
@@ -6,6 +6,7 @@ import { Utils } from "@meshtastic/core";
 export class TransportNode implements Types.Transport {
   private readonly _toDevice: WritableStream<Uint8Array>;
   private readonly _fromDevice: ReadableStream<Types.DeviceOutput>;
+  private socket: Socket | undefined;
 
   /**
    * Creates and connects a new TransportNode instance.
@@ -36,7 +37,8 @@ export class TransportNode implements Types.Transport {
    * @param connection - An active Node.js net.Socket connection.
    */
   constructor(connection: Socket) {
-    connection.on("error", (err) => {
+    this.socket = connection;
+    this.socket.on("error", (err) => {
       console.error("Socket connection error:", err);
     });
 
@@ -56,7 +58,7 @@ export class TransportNode implements Types.Transport {
       .pipeTo(Writable.toWeb(connection) as WritableStream<Uint8Array>)
       .catch((err) => {
         console.error("Error piping data to socket:", err);
-        connection.destroy(err as Error);
+        this.socket.destroy(err as Error);
       });
   }
 
@@ -72,5 +74,11 @@ export class TransportNode implements Types.Transport {
    */
   public get fromDevice(): ReadableStream<Types.DeviceOutput> {
     return this._fromDevice;
+  }
+
+  disconnect() {
+    this.socket.destroy();
+    this.socket = undefined;
+    return Promise.resolve();
   }
 }

--- a/packages/transport-web-bluetooth/src/transport.ts
+++ b/packages/transport-web-bluetooth/src/transport.ts
@@ -9,6 +9,7 @@ export class TransportWebBluetooth implements Types.Transport {
   private toRadioCharacteristic: BluetoothRemoteGATTCharacteristic;
   private fromRadioCharacteristic: BluetoothRemoteGATTCharacteristic;
   private fromNumCharacteristic: BluetoothRemoteGATTCharacteristic;
+  private gattServer: BluetoothRemoteGATTServer;
 
   static ToRadioUuid = "f75c76d2-129e-4dad-a1dd-7866124401e7";
   static FromRadioUuid = "2c55e69e-4993-11ed-b878-0242ac120002";
@@ -65,6 +66,7 @@ export class TransportWebBluetooth implements Types.Transport {
       toRadioCharacteristic,
       fromRadioCharacteristic,
       fromNumCharacteristic,
+      gattServer,
     );
   }
 
@@ -72,10 +74,12 @@ export class TransportWebBluetooth implements Types.Transport {
     toRadioCharacteristic: BluetoothRemoteGATTCharacteristic,
     fromRadioCharacteristic: BluetoothRemoteGATTCharacteristic,
     fromNumCharacteristic: BluetoothRemoteGATTCharacteristic,
+    gattServer: BluetoothRemoteGATTServer,
   ) {
     this.toRadioCharacteristic = toRadioCharacteristic;
     this.fromRadioCharacteristic = fromRadioCharacteristic;
     this.fromNumCharacteristic = fromNumCharacteristic;
+    this.gattServer = gattServer;
 
     this._fromDevice = new ReadableStream({
       start: (ctrl) => {
@@ -132,5 +136,10 @@ export class TransportWebBluetooth implements Types.Transport {
         data: new Uint8Array(value.buffer),
       });
     }
+  }
+
+  disconnect() : Promise<void> {
+    this.gattServer.disconnect();
+    return Promise.resolve();
   }
 }

--- a/packages/transport-web-serial/src/transport.ts
+++ b/packages/transport-web-serial/src/transport.ts
@@ -4,6 +4,7 @@ import { Utils } from "@meshtastic/core";
 export class TransportWebSerial implements Types.Transport {
   private _toDevice: WritableStream<Uint8Array>;
   private _fromDevice: ReadableStream<Types.DeviceOutput>;
+  private connection: SerialPort;
 
   public static async create(baudRate?: number): Promise<TransportWebSerial> {
     const port = await navigator.serial.requestPort();
@@ -24,6 +25,8 @@ export class TransportWebSerial implements Types.Transport {
       throw new Error("Stream not accessible");
     }
 
+    this.connection = connection;
+
     Utils.toDeviceStream.readable.pipeTo(connection.writable);
 
     this._toDevice = Utils.toDeviceStream.writable;
@@ -38,5 +41,9 @@ export class TransportWebSerial implements Types.Transport {
 
   get fromDevice(): ReadableStream<Types.DeviceOutput> {
     return this._fromDevice;
+  }
+
+  disconnect() {
+    return this.connection.close();
   }
 }


### PR DESCRIPTION
## Description

This adds a `disconnect` method to all transports that returns a Promise. The promise resolves once the transport has disconnected.

## Changes Made

- Add a `disconnect(): Promise<void>` method to the `Transport` interface
- Implement a `disconnect` method in all transports
- Includes #752 as that is related work

## Testing Done

So far untested.