### PR TITLE
Replace exports for Node.js

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -66,14 +66,6 @@ jobs:
 
               cd $dir
 
-              # Build and publish to npm if package.json exists
-              if [ -f "package.json" ]; then
-                echo "Building and publishing $dir to npm..."
-                pnpm install
-                pnpm run build:npm
-                pnpm run publish:npm || echo "npm publish failed for $dir"
-              fi
-
               pnpm run prepare:jsr
 
               # Publish to JSR if jsr.json exists
@@ -82,10 +74,18 @@ jobs:
                 deno publish || echo "JSR publish failed for $dir"
               fi
 
+              # Build and publish to npm if package.json exists
+              if [ -f "package.json" ]; then
+                echo "Building and publishing $dir to npm..."
+                pnpm install
+                pnpm run build:npm
+                # Use the JS Module file as export instead of the TypeScript file
+                sed -i 's/\".\/mod.ts\"/\".\/dist\/mod.mjs\"/g' "package.json"
+                pnpm run publish:npm || echo "npm publish failed for $dir"
+              fi
+
               cd - > /dev/null
             else
               echo "Skipping $dir"
             fi
           done
-
-    


### PR DESCRIPTION
Currently the Meshtastic packages [as published on NPM](https://www.npmjs.com/search?q=%40meshtastic) don't work on Node.js.

Running `import { MeshDevice } from '@meshtastic/core';` (or any other of the modules) causes:
```
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently unsupported for files under node_modules, for "/Users/bergie/Projects/signalk-meshtastic/node_modules/@meshtastic/core/mod.ts"
```

This is caused by the exports statement in `package.json`:
```
"exports": {
    ".": "./mod.ts"
  },
```

This PR modifies the statement in-flight to:
```
   "exports": {
      ".": "./dist/mod.mjs"
   },
```