### PR TITLE
Methods for setting/removing fixed position

### DIFF
--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -406,6 +406,26 @@ export class MeshDevice {
   }
 
   /**
+   * Remove the fixed position of a device
+   */
+  public async removeFixedPosition(): Promise<number> {
+    const removePositionMessage = create(Protobuf.Admin.AdminMessageSchema, {
+      payloadVariant: {
+        case: 'removeFixedPosition',
+        value: true,
+      },
+    });
+    return await this.sendPacket(
+      toBinary(Protobuf.Admin.AdminMessageSchema, removePositionMessage),
+      Protobuf.Portnums.PortNum.ADMIN_APP,
+      "self",
+      0,
+      true,
+      false,
+    );
+  }
+
+  /**
    * Gets specified channel information from the radio
    */
   public async getChannel(index: number): Promise<number> {

--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -388,7 +388,7 @@ export class MeshDevice {
   ): Promise<number> {
     const setPositionMessage = create(Protobuf.Admin.AdminMessageSchema, {
       payloadVariant: {
-        case: 'setFixedPosition',
+        case: "setFixedPosition",
         value: create(Protobuf.Mesh.PositionSchema, {
           latitudeI: Math.floor(latitude / 1e-7),
           longitudeI: Math.floor(longitude / 1e-7),
@@ -411,7 +411,7 @@ export class MeshDevice {
   public async removeFixedPosition(): Promise<number> {
     const removePositionMessage = create(Protobuf.Admin.AdminMessageSchema, {
       payloadVariant: {
-        case: 'removeFixedPosition',
+        case: "removeFixedPosition",
         value: true,
       },
     });

--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -379,6 +379,33 @@ export class MeshDevice {
   }
 
   /**
+   * Sets the fixed position of a device. Can be used to
+   * position GPS-less devices.
+   */
+  public async setFixedPosition(
+    latitude: number,
+    longitude: number,
+  ): Promise<number> {
+    const setPositionMessage = create(Protobuf.Admin.AdminMessageSchema, {
+      payloadVariant: {
+        case: 'setFixedPosition',
+        value: create(Protobuf.Mesh.PositionSchema, {
+          latitudeI: Math.floor(latitude / 1e-7),
+          longitudeI: Math.floor(longitude / 1e-7),
+        }),
+      },
+    });
+    return await this.sendPacket(
+      toBinary(Protobuf.Admin.AdminMessageSchema, setPositionMessage),
+      Protobuf.Portnums.PortNum.ADMIN_APP,
+      "self",
+      0,
+      true,
+      false,
+    );
+  }
+
+  /**
    * Gets specified channel information from the radio
    */
   public async getChannel(index: number): Promise<number> {


### PR DESCRIPTION
## Description

Provides a method for setting a [fixed position](https://meshtastic.org/docs/configuration/radio/position/#fixed-position) on the connected Meshtastic device. Useful for devices without GPS.

Will help with #87


## Testing Done

Method was ported from signalk-meshtastic.
