### PR TITLE
Catch packet decoding errors

### DIFF
--- a/packages/core/src/utils/transform/decodePacket.ts
+++ b/packages/core/src/utils/transform/decodePacket.ts
@@ -24,7 +24,7 @@ export const decodePacket = (device: MeshDevice) =>
           break;
         }
         case "packet": {
-          let decodedMessage;
+          let decodedMessage: Protobuf.Mesh.FromRadio;
           try {
             decodedMessage = fromBinary(
               Protobuf.Mesh.FromRadioSchema,

--- a/packages/core/src/utils/transform/decodePacket.ts
+++ b/packages/core/src/utils/transform/decodePacket.ts
@@ -43,7 +43,15 @@ export const decodePacket = (device: MeshDevice) =>
           /** @todo Add map here when `all=true` gets fixed. */
           switch (decodedMessage.payloadVariant.case) {
             case "packet": {
-              device.handleMeshPacket(decodedMessage.payloadVariant.value);
+              try {
+                device.handleMeshPacket(decodedMessage.payloadVariant.value);
+              } catch (e) {
+                device.log.error(
+                  Types.Emitter[Types.Emitter.HandleFromRadio],
+                  "⚠️  Unable to handle mesh packet",
+                  e,
+                );
+              }
               break;
             }
 

--- a/packages/core/src/utils/transform/decodePacket.ts
+++ b/packages/core/src/utils/transform/decodePacket.ts
@@ -24,10 +24,20 @@ export const decodePacket = (device: MeshDevice) =>
           break;
         }
         case "packet": {
-          const decodedMessage = fromBinary(
-            Protobuf.Mesh.FromRadioSchema,
-            chunk.data,
-          );
+          let decodedMessage;
+          try {
+            decodedMessage = fromBinary(
+              Protobuf.Mesh.FromRadioSchema,
+              chunk.data,
+            );
+          } catch (e) {
+            device.log.error(
+              Types.Emitter[Types.Emitter.HandleFromRadio],
+              "⚠️  Received undecodable packet",
+              e,
+            );
+            break;
+          }
           device.events.onFromRadio.dispatch(decodedMessage);
 
           /** @todo Add map here when `all=true` gets fixed. */


### PR DESCRIPTION
## Description

Unhandled errors thrown inside packet transform will cause connection to the node to be closed.

This addresses two such cases:
* Occasional errors decoding a packet coming from serial transport
* If packet is for a custom or unknown app, routing will throw an error

## Related Issues

Works around #808

## Changes Made

Added catch-and-log for these two cases.