### PR TITLE
Connection robustness improvements

### DIFF
--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -64,6 +64,11 @@ export class MeshDevice {
         this.isConfigured = true;
       } else if (status === DeviceStatusEnum.DeviceConfiguring) {
         this.isConfigured = false;
+      } else if (status === DeviceStatusEnum.DeviceDisconnected) {
+        if (this._heartbeatIntervalId !== undefined) {
+          clearInterval(this._heartbeatIntervalId);
+        }
+        this.complete();
       }
     });
 

--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -775,7 +775,13 @@ export class MeshDevice {
       },
     });
 
-    return this.sendRaw(toBinary(Protobuf.Mesh.ToRadioSchema, toRadio));
+    return this.sendRaw(toBinary(Protobuf.Mesh.ToRadioSchema, toRadio))
+      .catch((e) => {
+        if (this.deviceStatus === DeviceStatusEnum.DeviceDisconnected) {
+          throw new Error('Device connection lost');
+        }
+        throw e;
+      });
   }
 
   /**

--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -775,13 +775,14 @@ export class MeshDevice {
       },
     });
 
-    return this.sendRaw(toBinary(Protobuf.Mesh.ToRadioSchema, toRadio))
-      .catch((e) => {
+    return this.sendRaw(toBinary(Protobuf.Mesh.ToRadioSchema, toRadio)).catch(
+      (e) => {
         if (this.deviceStatus === DeviceStatusEnum.DeviceDisconnected) {
-          throw new Error('Device connection lost');
+          throw new Error("Device connection lost");
         }
         throw e;
-      });
+      },
+    );
   }
 
   /**
@@ -810,8 +811,8 @@ export class MeshDevice {
     this._heartbeatIntervalId = setInterval(() => {
       this.heartbeat().catch((err) => {
         this.log.error(
-          Emitter[Emitter.Ping], 
-          `⚠️ Unable to send heartbeat: ${err.message}`
+          Emitter[Emitter.Ping],
+          `⚠️ Unable to send heartbeat: ${err.message}`,
         );
       });
     }, interval);

--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -808,7 +808,7 @@ export class MeshDevice {
       clearInterval(this._heartbeatIntervalId);
     }
     this._heartbeatIntervalId = setInterval(() => {
-      this.heartbeat();
+      this.heartbeat().catch(() => {});
     }, interval);
   }
 

--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -808,7 +808,12 @@ export class MeshDevice {
       clearInterval(this._heartbeatIntervalId);
     }
     this._heartbeatIntervalId = setInterval(() => {
-      this.heartbeat().catch(() => {});
+      this.heartbeat().catch((err) => {
+        this.log.error(
+          Emitter[Emitter.Ping], 
+          `⚠️ Unable to send heartbeat: ${err.message}`
+        );
+      });
     }, interval);
   }
 

--- a/packages/core/src/utils/queue.ts
+++ b/packages/core/src/utils/queue.ts
@@ -117,7 +117,10 @@ export class Queue {
             await writer.write(item.data);
             item.sent = true;
           } catch (error) {
-            if (error?.code === 'ECONNRESET' || error?.code === 'ERR_INVALID_STATE') {
+            if (
+              error?.code === "ECONNRESET" ||
+              error?.code === "ERR_INVALID_STATE"
+            ) {
               writer.releaseLock();
               this.lock = false;
               throw error;

--- a/packages/core/src/utils/queue.ts
+++ b/packages/core/src/utils/queue.ts
@@ -117,6 +117,11 @@ export class Queue {
             await writer.write(item.data);
             item.sent = true;
           } catch (error) {
+            if (error?.code === 'ECONNRESET') {
+              writer.releaseLock();
+              this.lock = false;
+              throw error;
+            }
             console.error(`Error sending packet ${item.id}`, error);
           }
         }

--- a/packages/core/src/utils/queue.ts
+++ b/packages/core/src/utils/queue.ts
@@ -117,7 +117,7 @@ export class Queue {
             await writer.write(item.data);
             item.sent = true;
           } catch (error) {
-            if (error?.code === 'ECONNRESET') {
+            if (error?.code === 'ECONNRESET' || error?.code === 'ERR_INVALID_STATE') {
               writer.releaseLock();
               this.lock = false;
               throw error;

--- a/packages/core/src/utils/transform/toDevice.ts
+++ b/packages/core/src/utils/transform/toDevice.ts
@@ -1,16 +1,18 @@
 /**
  * Pads packets with appropriate framing information before writing to the output stream.
  */
-export const toDeviceStream: TransformStream<Uint8Array, Uint8Array> =
-  new TransformStream<Uint8Array, Uint8Array>({
-    transform(chunk: Uint8Array, controller): void {
-      const bufLen = chunk.length;
-      const header = new Uint8Array([
-        0x94,
-        0xc3,
-        (bufLen >> 8) & 0xff,
-        bufLen & 0xff,
-      ]);
-      controller.enqueue(new Uint8Array([...header, ...chunk]));
-    },
-  });
+export const toDeviceStream: () => TransformStream<Uint8Array, Uint8Array> =
+  () => {
+    return new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk: Uint8Array, controller): void {
+        const bufLen = chunk.length;
+        const header = new Uint8Array([
+          0x94,
+          0xc3,
+          (bufLen >> 8) & 0xff,
+          bufLen & 0xff,
+        ]);
+        controller.enqueue(new Uint8Array([...header, ...chunk]));
+      },
+    });
+  };

--- a/packages/transport-deno/src/transport.ts
+++ b/packages/transport-deno/src/transport.ts
@@ -16,9 +16,10 @@ export class TransportDeno implements Types.Transport {
 
   constructor(connection: Deno.Conn) {
     this.connection = connection;
-    Utils.toDeviceStream.readable.pipeTo(this.connection.writable);
+    const toDeviceStream = Utils.toDeviceStream();
+    toDeviceStream.readable.pipeTo(this.connection.writable);
 
-    this._toDevice = Utils.toDeviceStream.writable;
+    this._toDevice = toDeviceStream.writable;
     this._fromDevice = this.connection.readable.pipeThrough(
       Utils.fromDeviceStream(),
     );

--- a/packages/transport-http/src/transport.ts
+++ b/packages/transport-http/src/transport.ts
@@ -76,6 +76,7 @@ export class TransportHTTP implements Types.Transport {
               Types.DeviceStatusEnum.DeviceDisconnected,
               this.isTimeoutOrAbort(error) ? "write-timeout" : "write-error",
             );
+            return;
           }
           throw error;
         }
@@ -165,6 +166,7 @@ export class TransportHTTP implements Types.Transport {
           Types.DeviceStatusEnum.DeviceDisconnected,
           this.isTimeoutOrAbort(error) ? "write-timeout" : "write-error",
         );
+        return;
       }
       throw error;
     }

--- a/packages/transport-node-serial/src/transport.test.ts
+++ b/packages/transport-node-serial/src/transport.test.ts
@@ -67,8 +67,9 @@ function stubCoreTransforms() {
     });
 
   // Utils.toDeviceStream is a getter
+  const transform = Utils.toDeviceStream();
   vi.spyOn(Utils, "toDeviceStream", "get").mockReturnValue(
-    toDevice as unknown as typeof Utils.toDeviceStream,
+    toDevice as unknown as typeof transform,
   );
 
   vi.spyOn(Utils, "fromDeviceStream").mockImplementation(

--- a/packages/transport-node-serial/src/transport.test.ts
+++ b/packages/transport-node-serial/src/transport.test.ts
@@ -53,11 +53,12 @@ class FakeSerialPort extends Duplex {
 }
 
 function stubCoreTransforms() {
-  const toDevice = new TransformStream<Uint8Array, Uint8Array>({
-    transform(chunk, controller) {
-      controller.enqueue(chunk);
-    },
-  });
+  const toDevice = () =>
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        controller.enqueue(chunk);
+      },
+    });
 
   const fromDeviceFactory = () =>
     new TransformStream<Uint8Array, Types.DeviceOutput>({
@@ -67,7 +68,7 @@ function stubCoreTransforms() {
     });
 
   // Utils.toDeviceStream is a getter
-  const transform = Utils.toDeviceStream();
+  const transform = Utils.toDeviceStream;
   vi.spyOn(Utils, "toDeviceStream", "get").mockReturnValue(
     toDevice as unknown as typeof transform,
   );

--- a/packages/transport-node-serial/src/transport.ts
+++ b/packages/transport-node-serial/src/transport.ts
@@ -112,9 +112,10 @@ export class TransportNodeSerial implements Types.Transport {
     });
 
     // Stream for data going FROM the application TO the Meshtastic device.
-    this._toDevice = Utils.toDeviceStream.writable;
+    const toDeviceTransform = Utils.toDeviceStream();
+    this._toDevice = toDeviceTransform.writable;
 
-    this.pipePromise = Utils.toDeviceStream.readable
+    this.pipePromise = toDeviceTransform.readable
       .pipeTo(Writable.toWeb(port) as WritableStream<Uint8Array>, {
         signal: controller.signal,
       })

--- a/packages/transport-node/src/transport.test.ts
+++ b/packages/transport-node/src/transport.test.ts
@@ -67,8 +67,9 @@ function stubCoreTransforms() {
       },
     });
 
+  const transform = Utils.toDeviceStream();
   vi.spyOn(Utils, "toDeviceStream", "get").mockReturnValue(
-    toDevice as unknown as typeof Utils.toDeviceStream,
+    toDevice as unknown as typeof transform,
   );
 
   vi.spyOn(Utils, "fromDeviceStream").mockImplementation(

--- a/packages/transport-node/src/transport.test.ts
+++ b/packages/transport-node/src/transport.test.ts
@@ -54,11 +54,12 @@ class FakeSocket extends Duplex {
 }
 
 function stubCoreTransforms() {
-  const toDevice = new TransformStream<Uint8Array, Uint8Array>({
-    transform(chunk, controller) {
-      controller.enqueue(chunk);
-    },
-  });
+  const toDevice = () =>
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        controller.enqueue(chunk);
+      },
+    });
 
   const fromDeviceFactory = () =>
     new TransformStream<Uint8Array, Types.DeviceOutput>({
@@ -67,7 +68,7 @@ function stubCoreTransforms() {
       },
     });
 
-  const transform = Utils.toDeviceStream();
+  const transform = Utils.toDeviceStream;
   vi.spyOn(Utils, "toDeviceStream", "get").mockReturnValue(
     toDevice as unknown as typeof transform,
   );

--- a/packages/transport-node/src/transport.ts
+++ b/packages/transport-node/src/transport.ts
@@ -187,9 +187,7 @@ export class TransportNode implements Types.Transport {
       if (this.pipePromise) {
         await this.pipePromise;
       }
-
-      this.socket?.removeAllListeners();
-      this.socket?.end();
+      this.socket?.destroy();
     } finally {
       this.socket = undefined;
       this.closingByUser = false;

--- a/packages/transport-node/src/transport.ts
+++ b/packages/transport-node/src/transport.ts
@@ -148,7 +148,7 @@ export class TransportNode implements Types.Transport {
     });
 
     // Stream for data going FROM the application TO the Meshtastic device.
-    const toDeviceTransform = Utils.toDeviceStream;
+    const toDeviceTransform = Utils.toDeviceStream();
     this._toDevice = toDeviceTransform.writable;
 
     this.pipePromise = toDeviceTransform.readable

--- a/packages/transport-node/src/transport.ts
+++ b/packages/transport-node/src/transport.ts
@@ -29,7 +29,11 @@ export class TransportNode implements Types.Transport {
    * @param timeout - TCP socket timeout in milliseconds (defaults to 60000).
    * @returns A promise that resolves with a connected TransportNode instance.
    */
-  public static create(hostname: string, port = 4403, timeout = 60000): Promise<TransportNode> {
+  public static create(
+    hostname: string,
+    port = 4403,
+    timeout = 60000,
+  ): Promise<TransportNode> {
     return new Promise((resolve, reject) => {
       const socket = new Socket();
 
@@ -72,10 +76,7 @@ export class TransportNode implements Types.Transport {
       if (this.closingByUser) {
         return; // suppress close-derived disconnect in user flow
       }
-      this.emitStatus(
-        Types.DeviceStatusEnum.DeviceDisconnected,
-        "socket-end",
-      );
+      this.emitStatus(Types.DeviceStatusEnum.DeviceDisconnected, "socket-end");
       this.socket?.removeAllListeners();
       this.socket?.destroy();
     });
@@ -207,7 +208,7 @@ export class TransportNode implements Types.Transport {
         data: { status: next, reason },
       });
     } catch (e) {
-      console.error('Enqueue fail', e);
+      console.error("Enqueue fail", e);
     }
   }
 }

--- a/packages/transport-web-serial/src/transport.test.ts
+++ b/packages/transport-web-serial/src/transport.test.ts
@@ -18,9 +18,10 @@ function stubCoreTransforms() {
       },
     });
 
+  const transform = Utils.toDeviceStream();
   const restoreTo = vi
     .spyOn(Utils, "toDeviceStream", "get")
-    .mockReturnValue(toDevice as unknown as typeof Utils.toDeviceStream);
+    .mockReturnValue(toDevice as unknown as typeof transform);
 
   const restoreFrom = vi
     .spyOn(Utils, "fromDeviceStream")

--- a/packages/transport-web-serial/src/transport.test.ts
+++ b/packages/transport-web-serial/src/transport.test.ts
@@ -4,11 +4,12 @@ import { runTransportContract } from "../../../tests/utils/transportContract.ts"
 import { TransportWebSerial } from "./transport.ts";
 
 function stubCoreTransforms() {
-  const toDevice = new TransformStream<Uint8Array, Uint8Array>({
-    transform(chunk, controller) {
-      controller.enqueue(chunk);
-    },
-  });
+  const toDevice = () =>
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        controller.enqueue(chunk);
+      },
+    });
 
   // maps raw bytes -> DeviceOutput.packet
   const fromDeviceFactory = () =>
@@ -18,7 +19,7 @@ function stubCoreTransforms() {
       },
     });
 
-  const transform = Utils.toDeviceStream();
+  const transform = Utils.toDeviceStream;
   const restoreTo = vi
     .spyOn(Utils, "toDeviceStream", "get")
     .mockReturnValue(toDevice as unknown as typeof transform);

--- a/packages/transport-web-serial/src/transport.ts
+++ b/packages/transport-web-serial/src/transport.ts
@@ -58,7 +58,8 @@ export class TransportWebSerial implements Types.Transport {
     const abortController = this.abortController;
 
     // Set up the pipe with abort signal for clean cancellation
-    this.pipePromise = Utils.toDeviceStream.readable
+    const toDeviceTransform = Utils.toDeviceStream();
+    this.pipePromise = toDeviceTransform.readable
       .pipeTo(connection.writable, { signal: this.abortController.signal })
       .catch((err) => {
         // Ignore expected rejection when we cancel it via the AbortController.
@@ -73,7 +74,7 @@ export class TransportWebSerial implements Types.Transport {
         );
       });
 
-    this._toDevice = Utils.toDeviceStream.writable;
+    this._toDevice = toDeviceTransform.writable;
 
     // Wrap + capture controller to inject status packets
     this._fromDevice = new ReadableStream<Types.DeviceOutput>({
@@ -199,7 +200,8 @@ export class TransportWebSerial implements Types.Transport {
       const abortController = this.abortController;
 
       // Re-establish the pipe connection
-      this.pipePromise = Utils.toDeviceStream.readable
+      const toDeviceTransform = Utils.toDeviceStream();
+      this.pipePromise = toDeviceTransform.readable
         .pipeTo(this.connection.writable, {
           signal: this.abortController.signal,
         })


### PR DESCRIPTION
## Description

This PR improves connection lifecycle handling. Especially:

* Lost connection to device clears any leftover enqueued packets or a running heartbeat
* Failed `configure()` due to a cut connection produces a clearer error message
* In case of lost TCP connection (Node.js only?), queue processing throws instead of running to an endless console.log loop
* `Utils.toDeviceStream` was a singleton. This was at the heart of our reconnection problems. Switched to a function that always gives you a new instance

## Related Issues

Follow-up on #790 

## Testing Done

Lots of testing with a local node and manually triggered reboots.
