### PR TITLE
Fix default filter behaviour

### DIFF
--- a/packages/web/src/components/generic/Filter/useFilterNode.test.ts
+++ b/packages/web/src/components/generic/Filter/useFilterNode.test.ts
@@ -180,4 +180,56 @@ describe("useFilterNode", () => {
       expect(isFilterDirty(modified)).toBe(true);
     });
   });
+
+  describe("default-boundary semantics", () => {
+    const node = createMockNode();
+
+    it("lastHeard: end at default max means 'any age'", () => {
+      const {
+        lastHeard: [lastHeardMin, lastHeardMax],
+      } = defaultFilterValues;
+      const veryOld = { ...node, lastHeard: lastHeardMax + 1 }; // older than slider max
+      expect(
+        nodeFilter(veryOld, { lastHeard: [lastHeardMin, lastHeardMax] }),
+      ).toBe(true); // open upper
+      expect(
+        nodeFilter(veryOld, { lastHeard: [lastHeardMin, lastHeardMax - 1] }),
+      ).toBe(false); // now bounded
+    });
+
+    it("snr: max at default means no upper bound", () => {
+      const {
+        snr: [snrMin, snrMax],
+      } = defaultFilterValues;
+      const hiSnr = { ...node, snr: snrMax + 1 }; // above slider max
+      expect(nodeFilter(hiSnr, { snr: [snrMin, snrMax] })).toBe(true); // open upper
+      expect(nodeFilter(hiSnr, { snr: [snrMin, snrMax - 1] })).toBe(false); // bounded
+    });
+
+    it("snr: min at default means no lower bound", () => {
+      const {
+        snr: [snrMin, snrMax],
+      } = defaultFilterValues;
+      const loSnr = { ...node, snr: snrMin - 1 }; // below slider min
+      expect(nodeFilter(loSnr, { snr: [snrMin, snrMax] })).toBe(true); // open lower
+      expect(nodeFilter(loSnr, { snr: [snrMin + 1, snrMax] })).toBe(false); // bounded
+    });
+
+    it("voltage: max at default means no upper bound", () => {
+      const {
+        voltage: [voltageMin, voltageMax],
+      } = defaultFilterValues;
+      const hiV = {
+        ...node,
+        deviceMetrics: {
+          ...node.deviceMetrics!,
+          voltage: voltageMax + 1,
+        },
+      } satisfies Protobuf.Mesh.NodeInfo;
+      expect(nodeFilter(hiV, { voltage: [voltageMin, voltageMax] })).toBe(true); // open upper
+      expect(
+        nodeFilter(hiV, { voltage: [voltageMin, voltageMax - 0.01] }),
+      ).toBe(false); // bounded
+    });
+  });
 });

--- a/packages/web/src/components/generic/Filter/useFilterNode.ts
+++ b/packages/web/src/components/generic/Filter/useFilterNode.ts
@@ -127,7 +127,12 @@ export function useFilterNode() {
       }
 
       const snr = node.snr ?? -20;
-      if (snr < filterState.snr[0] || snr > filterState.snr[1]) {
+      if (
+        (snr < filterState.snr[0] &&
+          filterState.snr[0] !== defaultFilterValues.snr[0]) ||
+        (snr > filterState.snr[1] &&
+          filterState.snr[1] !== defaultFilterValues.snr[1])
+      ) {
         return false;
       }
 
@@ -158,7 +163,8 @@ export function useFilterNode() {
       const voltage = node.deviceMetrics?.voltage ?? 0;
       if (
         voltage < filterState.voltage[0] ||
-        voltage > filterState.voltage[1]
+        (voltage > filterState.voltage[1] &&
+          filterState.voltage[1] !== defaultFilterValues.voltage[1])
       ) {
         return false;
       }


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
This PR fixes #668 by adjusting filter default-boundary behaviour for SNR and voltage fields. Previously, default range boundaries were bounded and not open, resulting in nodes with <-20dB or >10dB SNR and >5V voltage to be excluded.
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Related Issues
Fixes #668
<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made
- Updated useFilterNode.ts to use open boundaries if range boundary is equal to default boundary.
- Updated FilterControl with refactored labelContent component to show this by inserting "<" or ">" for relevant range boundaries.
- Updated tests to check that boundaries are open when expected.

## Testing Done
Updated automatic tests
Tested manually
<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)
<img width="362" height="696" alt="Screenshot From 2025-09-01 00-01-41" src="https://github.com/user-attachments/assets/6aa1eebd-0720-4c32-8af3-150f1cd526ef" />

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
