### PR TITLE
Fix rename seperator again

### DIFF
--- a/packages/web/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
+++ b/packages/web/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
@@ -16,7 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@components/UI/Dialog.tsx";
-import { Separator } from "@components/UI/Separator";
+import { Separator } from "@components/UI/Separator.tsx";
 import {
   Tooltip,
   TooltipArrow,

--- a/packages/web/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
+++ b/packages/web/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
@@ -16,7 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@components/UI/Dialog.tsx";
-import { Separator } from "@components/UI/Seperator.tsx";
+import { Separator } from "@components/UI/Separator";
 import {
   Tooltip,
   TooltipArrow,

--- a/packages/web/src/components/Dialog/RebootDialog.tsx
+++ b/packages/web/src/components/Dialog/RebootDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "@components/UI/Dialog.tsx";
 import { Input } from "@components/UI/Input.tsx";
 import { Label } from "@components/UI/Label.tsx";
-import { Separator } from "@components/UI/Separator";
+import { Separator } from "@components/UI/Separator.tsx";
 import { useDevice } from "@core/stores";
 import { ClockIcon, OctagonXIcon, RefreshCwIcon } from "lucide-react";
 import { useState } from "react";

--- a/packages/web/src/components/Dialog/RebootDialog.tsx
+++ b/packages/web/src/components/Dialog/RebootDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "@components/UI/Dialog.tsx";
 import { Input } from "@components/UI/Input.tsx";
 import { Label } from "@components/UI/Label.tsx";
-import { Separator } from "@components/UI/Seperator.tsx";
+import { Separator } from "@components/UI/Separator";
 import { useDevice } from "@core/stores";
 import { ClockIcon, OctagonXIcon, RefreshCwIcon } from "lucide-react";
 import { useState } from "react";

--- a/packages/web/src/components/PageComponents/Map/NodeDetail.tsx
+++ b/packages/web/src/components/PageComponents/Map/NodeDetail.tsx
@@ -2,7 +2,7 @@ import BatteryStatus from "@components/BatteryStatus.tsx";
 import { Mono } from "@components/generic/Mono.tsx";
 import { TimeAgo } from "@components/generic/TimeAgo.tsx";
 import { Avatar } from "@components/UI/Avatar.tsx";
-import { Separator } from "@components/UI/Seperator.tsx";
+import { Separator } from "@components/UI/Separator";
 import { Heading } from "@components/UI/Typography/Heading.tsx";
 import { Subtle } from "@components/UI/Typography/Subtle.tsx";
 import { formatQuantity } from "@core/utils/string.ts";

--- a/packages/web/src/components/PageComponents/Map/NodeDetail.tsx
+++ b/packages/web/src/components/PageComponents/Map/NodeDetail.tsx
@@ -2,7 +2,7 @@ import BatteryStatus from "@components/BatteryStatus.tsx";
 import { Mono } from "@components/generic/Mono.tsx";
 import { TimeAgo } from "@components/generic/TimeAgo.tsx";
 import { Avatar } from "@components/UI/Avatar.tsx";
-import { Separator } from "@components/UI/Separator";
+import { Separator } from "@components/UI/Separator.tsx";
 import { Heading } from "@components/UI/Typography/Heading.tsx";
 import { Subtle } from "@components/UI/Typography/Subtle.tsx";
 import { formatQuantity } from "@core/utils/string.ts";

--- a/packages/web/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/packages/web/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -1,5 +1,5 @@
 import { MessageItem } from "@components/PageComponents/Messages/MessageItem.tsx";
-import { Separator } from "@components/UI/Seperator";
+import { Separator } from "@components/UI/Separator";
 import type { Message } from "@core/stores/messageStore/types.ts";
 import type { TFunction } from "i18next";
 import { InboxIcon } from "lucide-react";

--- a/packages/web/src/components/UI/Separator.tsx
+++ b/packages/web/src/components/UI/Separator.tsx
@@ -3,7 +3,7 @@ import * as SeparatorPrimitive from "@radix-ui/react-separator";
 import * as React from "react";
 
 const Separator = React.forwardRef<
-  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentRef<typeof SeparatorPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
 >(
   (

--- a/packages/web/src/pages/Dashboard/index.tsx
+++ b/packages/web/src/pages/Dashboard/index.tsx
@@ -1,6 +1,6 @@
 import LanguageSwitcher from "@components/LanguageSwitcher.tsx";
 import { Button } from "@components/UI/Button.tsx";
-import { Separator } from "@components/UI/Seperator.tsx";
+import { Separator } from "@components/UI/Separator";
 import { Heading } from "@components/UI/Typography/Heading.tsx";
 import { Subtle } from "@components/UI/Typography/Subtle.tsx";
 import { useAppStore, useDeviceStore, useNodeDBStore } from "@core/stores";

--- a/packages/web/src/pages/Dashboard/index.tsx
+++ b/packages/web/src/pages/Dashboard/index.tsx
@@ -1,6 +1,6 @@
 import LanguageSwitcher from "@components/LanguageSwitcher.tsx";
 import { Button } from "@components/UI/Button.tsx";
-import { Separator } from "@components/UI/Separator";
+import { Separator } from "@components/UI/Separator.tsx";
 import { Heading } from "@components/UI/Typography/Heading.tsx";
 import { Subtle } from "@components/UI/Typography/Subtle.tsx";
 import { useAppStore, useDeviceStore, useNodeDBStore } from "@core/stores";


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
Reapply Seperator -> Separator PR #823 with new instance renamed.
PR #824 introduced another "Seperator" instance which meant PR #823 failed.
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

## Testing Done

<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
