### PR TITLE
Added lint rule to enforce importing with extensions

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,8 @@
       },
       "correctness": {
         "noUnusedVariables": "error",
-        "noUnusedImports": "error"
+        "noUnusedImports": "error",
+        "useImportExtensions": "error"
       }
     }
   },

--- a/packages/transport-http/src/transport.test.ts
+++ b/packages/transport-http/src/transport.test.ts
@@ -7,8 +7,8 @@ import {
   type MockInstance,
   vi,
 } from "vitest";
-import { runTransportContract } from "../../../tests/utils/transportContract";
-import { TransportHTTP } from "./transport";
+import { runTransportContract } from "../../../tests/utils/transportContract.ts";
+import { TransportHTTP } from "./transport.ts";
 
 let abortTimeoutSpy: MockInstance | undefined;
 beforeEach(() => {

--- a/packages/transport-node-serial/src/transport.test.ts
+++ b/packages/transport-node-serial/src/transport.test.ts
@@ -2,8 +2,8 @@ import { Duplex } from "node:stream";
 import { Types, Utils } from "@meshtastic/core";
 import type { SerialPort } from "serialport";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runTransportContract } from "../../../tests/utils/transportContract";
-import { TransportNodeSerial } from "./transport";
+import { runTransportContract } from "../../../tests/utils/transportContract.ts";
+import { TransportNodeSerial } from "./transport.ts";
 
 function isStatusEvent(
   output: Types.DeviceOutput | undefined,

--- a/packages/transport-node/src/transport.test.ts
+++ b/packages/transport-node/src/transport.test.ts
@@ -2,8 +2,8 @@ import type { Socket } from "node:net";
 import { Duplex } from "node:stream";
 import { Types, Utils } from "@meshtastic/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runTransportContract } from "../../../tests/utils/transportContract";
-import { TransportNode } from "./transport";
+import { runTransportContract } from "../../../tests/utils/transportContract.ts";
+import { TransportNode } from "./transport.ts";
 
 function isStatusEvent(
   out: Types.DeviceOutput | undefined,

--- a/packages/transport-web-bluetooth/src/transport.test.ts
+++ b/packages/transport-web-bluetooth/src/transport.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, vi } from "vitest";
-import { runTransportContract } from "../../../tests/utils/transportContract";
-import { TransportWebBluetooth } from "./transport";
+import { runTransportContract } from "../../../tests/utils/transportContract.ts";
+import { TransportWebBluetooth } from "./transport.ts";
 
 class MiniEmitter {
   private listeners = new Map<string, Set<(e: Event) => void>>();

--- a/packages/transport-web-serial/src/transport.test.ts
+++ b/packages/transport-web-serial/src/transport.test.ts
@@ -1,7 +1,7 @@
 import { Types, Utils } from "@meshtastic/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runTransportContract } from "../../../tests/utils/transportContract";
-import { TransportWebSerial } from "./transport";
+import { runTransportContract } from "../../../tests/utils/transportContract.ts";
+import { TransportWebSerial } from "./transport.ts";
 
 function stubCoreTransforms() {
   const toDevice = new TransformStream<Uint8Array, Uint8Array>({

--- a/packages/web/src/core/stores/nodeDBStore/index.ts
+++ b/packages/web/src/core/stores/nodeDBStore/index.ts
@@ -5,7 +5,7 @@ import { Protobuf, type Types } from "@meshtastic/core";
 import { produce } from "immer";
 import { create as createStore, type StateCreator } from "zustand";
 import { type PersistOptions, persist } from "zustand/middleware";
-import type { NodeError, NodeErrorType, ProcessPacketParams } from "./types";
+import type { NodeError, NodeErrorType, ProcessPacketParams } from "./types.ts";
 
 const CURRENT_STORE_VERSION = 0;
 const NODEDB_RETENTION_NUM = 10;

--- a/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.ts
+++ b/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.ts
@@ -16,7 +16,7 @@ vi.mock("idb-keyval", () => ({
 // import a fresh copy of the store module (because the store is created at import time)
 async function freshStore() {
   vi.resetModules();
-  const mod = await import("../nodeDBStore");
+  const mod = await import("../nodeDBStore/index.ts");
   return mod;
 }
 

--- a/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.ts
+++ b/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.ts
@@ -16,7 +16,7 @@ vi.mock("idb-keyval", () => ({
 // import a fresh copy of the store module (because the store is created at import time)
 async function freshStore() {
   vi.resetModules();
-  const mod = await import("../nodeDBStore/index.ts");
+  const mod = await import("./index.ts");
   return mod;
 }
 

--- a/packages/web/src/core/stores/utils/indexDB.test.ts
+++ b/packages/web/src/core/stores/utils/indexDB.test.ts
@@ -1,6 +1,6 @@
 import * as idb from "idb-keyval";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createStorage } from "./indexDB";
+import { createStorage } from "./indexDB.ts";
 
 type PersistStorage<T> = ReturnType<typeof createStorage<T>>;
 


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This small PR adds a lint rule improvement to ensure users comply with our established practice of adding file extension at the end of imported files. 

## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

- Added `useImportExtensions` to biome linter rule which enforces that imports at the top of the file require file extensions. 


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
