### PR TITLE
Reduced release workflow complexity, added conditional image upload

### DIFF
--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -81,10 +81,6 @@ jobs:
         working-directory: packages/web
         run: pnpm run build
 
-      - name: Build web package
-        working-directory: packages/web
-        run: pnpm run build
-
       - name: Create Web App Release Archive
         working-directory: packages/web
         run: pnpm run package
@@ -116,22 +112,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Compute image tags
-        id: tags
-        shell: bash
-        run: |
-          if [ "${{ steps.meta.outputs.push_latest }}" = "true" ]; then
-            echo "list=latest, ${{ steps.meta.outputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "list=${{ steps.meta.outputs.tag }}" >> "$GITHUB_OUTPUT"
-          fi
-            TAGS="latest, ${{ steps.meta.outputs.tag }}"
-          else
-            TAGS="${{ steps.meta.outputs.tag }}"
-          fi
-          echo "list=$TAGS" >> "$GITHUB_OUTPUT"
-          echo "Using image tags: $TAGS"
-
       - name: Build Container Image
         id: build-container
         uses: redhat-actions/buildah-build@v2
@@ -139,12 +119,13 @@ jobs:
           containerfiles: |
             ./packages/web/infra/Containerfile
           image: ${{ env.REGISTRY_IMAGE }}
-          tags: ${{ steps.tags.outputs.list }}
+          tags: latest,${{ steps.meta.outputs.tag }}
           oci: true
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64,linux/arm64
 
       - name: Push Container to GHCR
         id: push-to-registry
+        if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-container.outputs.image }}
@@ -154,4 +135,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output Image URL
+        if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         run: echo "🖼️ Image pushed to ${{ steps.push-to-registry.outputs.registry-paths }}"
+
+      - name: Explain no image URL
+        if: ${{ !(github.event_name == 'release' && github.event.release.prerelease == false) }}
+        run: echo "ℹ️ No image pushed (this was a prerelease or manual run)."


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request updates the `release-web.yml` GitHub Actions workflow to streamline the build and release process for the web app. The main changes remove redundant build steps, simplify image tag computation, and clarify output messaging based on the release type.

**Workflow simplification and reliability:**

* Removed a redundant `pnpm run build` step in the `web` package to avoid unnecessary duplicate builds.
* Simplified Docker image tag computation by directly specifying tags as `latest,${{ steps.meta.outputs.tag }}` in the `buildah-build` step, and removed the custom `Compute image tags` step.

**Conditional release behavior:**

* Added conditions to only push container images and output the image URL when the workflow is triggered by a non-prerelease GitHub release event, ensuring prereleases or manual runs do not publish images. [[1]](diffhunk://#diff-5c28a943e504547a8208c46cd870b8852ea52bc6aa9ea26eff0c9619f4270ecaL119-R128) [[2]](diffhunk://#diff-5c28a943e504547a8208c46cd870b8852ea52bc6aa9ea26eff0c9619f4270ecaR138-R143)
* Added a new step to output a clear message when no image is pushed, improving transparency for prerelease or manual workflow runs.

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [ ] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
