### PR TITLE
Allow default overrideFrequency

### DIFF
--- a/packages/web/public/i18n/locales/en/common.json
+++ b/packages/web/public/i18n/locales/en/common.json
@@ -113,7 +113,7 @@
       "key": "Key is required."
     },
     "invalidOverrideFreq": {
-      "number": "Invalid format, expected between 430-930 MHz."
+      "number": "Invalid format, expected a value in the range 430-930 MHz or 0 (use default)."
     }
   },
   "yes": "Yes",

--- a/packages/web/public/i18n/locales/en/common.json
+++ b/packages/web/public/i18n/locales/en/common.json
@@ -113,7 +113,7 @@
       "key": "Key is required."
     },
     "invalidOverrideFreq": {
-      "number": "Invalid format, expected a value in the range 430-930 MHz or 0 (use default)."
+      "number": "Invalid format, expected a value in the range 410-930 MHz or 0 (use default)."
     }
   },
   "yes": "Yes",

--- a/packages/web/src/validation/config/lora.ts
+++ b/packages/web/src/validation/config/lora.ts
@@ -20,7 +20,7 @@ export const LoRaValidationSchema = z.object({
   sx126xRxBoostedGain: z.boolean(),
   overrideFrequency: z.coerce
     .number()
-    .refine((val) => val >= 410 && val <= 930, {
+    .refine((val) => val === 0 || (val >= 410 && val <= 930), {
       message: "formValidation.invalidOverrideFreq.number",
     }),
   ignoreIncoming: z.coerce.number().array(),


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
Recent changes to overrideFrequency introduced an issue where 0 was not a valid input. This PR addresses that.
<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made
- Allow `overrideFrequency == 0`

## Testing Done
Tested locally, behaves as expected
<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
