### PR TITLE
Improvements to node filtering and storage

### DIFF
--- a/packages/web/public/i18n/locales/en/nodes.json
+++ b/packages/web/public/i18n/locales/en/nodes.json
@@ -46,11 +46,11 @@
     "connectionStatus": {
       "direct": "Direct",
       "away": "away",
-      "unknown": "-",
+      "unknown": "Unknown",
       "viaMqtt": ", via MQTT"
     },
     "lastHeardStatus": {
-      "never": "Never"
+      "unknown": "Unknown"
     }
   },
 

--- a/packages/web/public/i18n/locales/en/nodes.json
+++ b/packages/web/public/i18n/locales/en/nodes.json
@@ -46,11 +46,7 @@
     "connectionStatus": {
       "direct": "Direct",
       "away": "away",
-      "unknown": "Unknown",
       "viaMqtt": ", via MQTT"
-    },
-    "lastHeardStatus": {
-      "unknown": "Unknown"
     }
   },
 

--- a/packages/web/public/i18n/locales/en/ui.json
+++ b/packages/web/public/i18n/locales/en/ui.json
@@ -182,7 +182,7 @@
     "label": "Unknown number of hops"
   },
   "showUnheard": {
-    "label": "Never heard"
+    "label": "Unknown last heard"
   },
   "language": {
     "label": "Language",

--- a/packages/web/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
+++ b/packages/web/src/components/Dialog/NodeDetailsDialog/NodeDetailsDialog.tsx
@@ -174,7 +174,10 @@ export const NodeDetailsDialog = ({
     {
       key: "voltage",
       label: t("nodeDetails.voltage"),
-      value: node.deviceMetrics?.voltage,
+      value:
+        typeof node.deviceMetrics?.voltage === "number"
+          ? Math.abs(node.deviceMetrics?.voltage)
+          : undefined,
       format: (val: number) => `${val.toFixed(2)}V`,
     },
   ];

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -205,7 +205,10 @@ export const Sidebar = ({ children }: SidebarProps) => {
             }
             deviceMetrics={{
               batteryLevel: myNode.deviceMetrics?.batteryLevel,
-              voltage: myNode.deviceMetrics?.voltage,
+              voltage:
+                typeof myNode.deviceMetrics?.voltage === "number"
+                  ? Math.abs(myNode.deviceMetrics?.voltage)
+                  : undefined,
             }}
           />
         )}

--- a/packages/web/src/components/UI/Slider.tsx
+++ b/packages/web/src/components/UI/Slider.tsx
@@ -50,6 +50,8 @@ export function Slider({
     onValueCommit?.(newValue);
   };
 
+  const thumbIds = currentValue.map((_, idx) => `${internalId}-thumb-${idx}`); // Unique IDs for each thumb, pregenerated to please the linter
+
   return (
     <SliderPrimitive.Root
       className={cn(
@@ -79,14 +81,14 @@ export function Slider({
           )}
         />
       </SliderPrimitive.Track>
-      {currentValue.map((_) => (
+      {currentValue.map((_, idx) => (
         <SliderPrimitive.Thumb
-          key={`${internalId}-thumb`}
+          key={thumbIds[idx]}
           className={cn(
             "block w-4 h-4 rounded-full bg-white border border-slate-400 shadow-md",
             thumbClassName,
           )}
-          aria-label={`Thumb ${internalId}`}
+          aria-label={`Thumb ${idx + 1}`}
         />
       ))}
     </SliderPrimitive.Root>

--- a/packages/web/src/components/generic/Filter/useFilterNode.ts
+++ b/packages/web/src/components/generic/Filter/useFilterNode.ts
@@ -67,25 +67,33 @@ export function useFilterNode() {
         ...filterOverrides,
       };
 
-      if (!node.user) {
-        return false;
-      }
-
       const nodeName = filterState.nodeName.toLowerCase();
-      if (
-        nodeName &&
-        !(
-          node.user?.shortName.toLowerCase().includes(nodeName) ||
-          node.user?.longName.toLowerCase().includes(nodeName) ||
-          node.num.toString().includes(nodeName) ||
-          numberToHexUnpadded(node.num).includes(nodeName.replace(/!/g, ""))
-        )
-      ) {
-        return false;
+      if (nodeName) {
+        const short = node.user?.shortName?.toLowerCase() ?? "";
+        const long = node.user?.longName?.toLowerCase() ?? "";
+        const numStr = node.num.toString();
+        const hex = numberToHexUnpadded(node.num);
+
+        if (
+          !short.includes(nodeName) &&
+          !long.includes(nodeName) &&
+          !numStr.includes(nodeName) &&
+          !hex.includes(nodeName.replace(/!/g, ""))
+        ) {
+          return false;
+        }
       }
 
       const hops = node.hopsAway ?? 7;
-      if (hops < filterState.hopsAway[0] || hops > filterState.hopsAway[1]) {
+      if (
+        (node.hopsAway === undefined &&
+          !shallowEqualArray(
+            filterState.hopsAway,
+            defaultFilterValues.hopsAway,
+          )) || // If hops are unknown, hide node if state is not default
+        hops < filterState.hopsAway[0] ||
+        hops > filterState.hopsAway[1]
+      ) {
         return false;
       }
 
@@ -96,8 +104,13 @@ export function useFilterNode() {
         return false;
       }
 
-      const secondsAgo = Date.now() / 1000 - (node.lastHeard ?? 0);
+      const secondsAgo = Math.max(0, Date.now() / 1000 - (node.lastHeard ?? 0));
       if (
+        (node.lastHeard === 0 &&
+          !shallowEqualArray(
+            filterState.lastHeard,
+            defaultFilterValues.lastHeard,
+          )) || // If lastHeard is unknown (0), hide node if state is not default
         secondsAgo < filterState.lastHeard[0] ||
         (secondsAgo > filterState.lastHeard[1] &&
           filterState.lastHeard[1] !== defaultFilterValues.lastHeard[1])
@@ -128,6 +141,8 @@ export function useFilterNode() {
 
       const snr = node.snr ?? -20;
       if (
+        (node.snr === undefined &&
+          !shallowEqualArray(filterState.snr, defaultFilterValues.snr)) ||
         (snr < filterState.snr[0] &&
           filterState.snr[0] !== defaultFilterValues.snr[0]) ||
         (snr > filterState.snr[1] &&
@@ -138,6 +153,11 @@ export function useFilterNode() {
 
       const channelUtilization = node.deviceMetrics?.channelUtilization ?? 0;
       if (
+        (node.deviceMetrics?.channelUtilization === undefined &&
+          !shallowEqualArray(
+            filterState.channelUtilization,
+            defaultFilterValues.channelUtilization,
+          )) ||
         channelUtilization < filterState.channelUtilization[0] ||
         channelUtilization > filterState.channelUtilization[1]
       ) {
@@ -146,6 +166,11 @@ export function useFilterNode() {
 
       const airUtilTx = node.deviceMetrics?.airUtilTx ?? 0;
       if (
+        (node.deviceMetrics?.airUtilTx === undefined &&
+          !shallowEqualArray(
+            filterState.airUtilTx,
+            defaultFilterValues.airUtilTx,
+          )) ||
         airUtilTx < filterState.airUtilTx[0] ||
         airUtilTx > filterState.airUtilTx[1]
       ) {
@@ -154,14 +179,24 @@ export function useFilterNode() {
 
       const batt = node.deviceMetrics?.batteryLevel ?? 101;
       if (
+        (node.deviceMetrics?.batteryLevel === undefined &&
+          !shallowEqualArray(
+            filterState.batteryLevel,
+            defaultFilterValues.batteryLevel,
+          )) ||
         batt < filterState.batteryLevel[0] ||
         batt > filterState.batteryLevel[1]
       ) {
         return false;
       }
 
-      const voltage = node.deviceMetrics?.voltage ?? 0;
+      const voltage = Math.abs(node.deviceMetrics?.voltage ?? 0);
       if (
+        (node.deviceMetrics?.voltage === undefined &&
+          !shallowEqualArray(
+            filterState.voltage,
+            defaultFilterValues.voltage,
+          )) ||
         voltage < filterState.voltage[0] ||
         (voltage > filterState.voltage[1] &&
           filterState.voltage[1] !== defaultFilterValues.voltage[1])
@@ -170,14 +205,25 @@ export function useFilterNode() {
       }
 
       const role: Protobuf.Config.Config_DeviceConfig_Role =
-        node.user.role ?? Protobuf.Config.Config_DeviceConfig_Role.CLIENT;
-      if (!filterState.role.includes(role)) {
+        node.user?.role ?? Protobuf.Config.Config_DeviceConfig_Role.CLIENT;
+      if (
+        (node.user?.role === undefined &&
+          !shallowEqualArray(filterState.role, defaultFilterValues.role)) ||
+        !filterState.role.includes(role)
+      ) {
         return false;
       }
 
       const hwModel: Protobuf.Mesh.HardwareModel =
-        node.user.hwModel ?? Protobuf.Mesh.HardwareModel.UNSET;
-      if (!filterState.hwModel.includes(hwModel)) {
+        node.user?.hwModel ?? Protobuf.Mesh.HardwareModel.UNSET;
+      if (
+        (node.user?.hwModel === undefined &&
+          !shallowEqualArray(
+            filterState.hwModel,
+            defaultFilterValues.hwModel,
+          )) ||
+        !filterState.hwModel.includes(hwModel)
+      ) {
         return false;
       }
 

--- a/packages/web/src/core/stores/index.ts
+++ b/packages/web/src/core/stores/index.ts
@@ -2,6 +2,7 @@ import { useDeviceContext } from "@core/hooks/useDeviceContext";
 import { type Device, useDeviceStore } from "@core/stores/deviceStore";
 import { type MessageStore, useMessageStore } from "@core/stores/messageStore";
 import { type NodeDB, useNodeDBStore } from "@core/stores/nodeDBStore";
+import { bindStoreToDevice } from "@core/stores/utils/bindStoreToDevice";
 
 export {
   CurrentDeviceContext,
@@ -30,13 +31,11 @@ export {
 } from "@core/stores/sidebarStore";
 
 // Define hooks to access the stores
-export const useNodeDB = (): NodeDB => {
-  const { deviceId } = useDeviceContext();
-  const nodeDB = useNodeDBStore(
-    (s) => s.getNodeDB(deviceId) ?? s.addNodeDB(deviceId),
-  );
-  return nodeDB;
-};
+export const useNodeDB = bindStoreToDevice(
+  useNodeDBStore,
+  (s, deviceId): NodeDB => s.getNodeDB(deviceId) ?? s.addNodeDB(deviceId),
+);
+
 export const useDevice = (): Device => {
   const { deviceId } = useDeviceContext();
 
@@ -45,6 +44,7 @@ export const useDevice = (): Device => {
   );
   return device;
 };
+
 export const useMessages = (): MessageStore => {
   const { deviceId } = useDeviceContext();
 

--- a/packages/web/src/core/stores/messageStore/index.ts
+++ b/packages/web/src/core/stores/messageStore/index.ts
@@ -393,7 +393,7 @@ const persistOptions: PersistOptions<
   PrivateMessageStoreState,
   MessageStorePersisted
 > = {
-  name: "meshtastic-MessageStore-store",
+  name: "meshtastic-message-store",
   storage: createStorage<MessageStorePersisted>(),
   version: CURRENT_STORE_VERSION,
   partialize: (s): MessageStorePersisted => ({

--- a/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.tsx
+++ b/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.tsx
@@ -105,7 +105,7 @@ describe("NodeDB store", () => {
     expect(db.getNode(50)?.snr).toBe(9);
 
     db.processPacket({ from: 50, time: 0, snr: 9 } as any);
-    expect(db.getNode(50)?.lastHeard).toBeCloseTo(Date.now() / 1000, 2); // within 10ms, note lastHeard is in seconds
+    expect(db.getNode(50)?.lastHeard).toBeCloseTo(Date.now() / 1000, -1); // within 1s, note lastHeard is in seconds
     expect(db.getNode(50)?.snr).toBe(9);
   });
 

--- a/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.tsx
+++ b/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.tsx
@@ -1,7 +1,6 @@
-/** biome-ignore-all lint/suspicious/noExplicitAny: <tests> */
-/** biome-ignore-all lint/style/noNonNullAssertion: <tests> */
 import { create } from "@bufbuild/protobuf";
 import { Protobuf } from "@meshtastic/core";
+import { act, render, screen } from "@testing-library/react";
 import { toByteArray } from "base64-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -16,6 +15,14 @@ vi.mock("idb-keyval", () => ({
     idbMem.delete(k);
     return Promise.resolve();
   }),
+}));
+
+let deviceIdForTests = 1;
+vi.mock("@core/hooks/useDeviceContext", () => ({
+  useDeviceContext: () => ({ deviceId: deviceIdForTests }),
+  __setDeviceId: (id: number) => {
+    deviceIdForTests = id;
+  },
 }));
 
 // import a fresh copy of the store module (because the store is created at import time)
@@ -33,8 +40,9 @@ async function freshStore(persist = false) {
     },
   }));
 
-  const mod = await import("./index.ts");
-  return mod;
+  const storeMod = await import("./index.ts");
+  const { useNodeDB } = await import("../index.ts");
+  return { ...storeMod, useNodeDB };
 }
 
 function makeNode(num: number, extras: Record<string, any> = {}) {
@@ -97,7 +105,7 @@ describe("NodeDB store", () => {
     expect(db.getNode(50)?.snr).toBe(9);
 
     db.processPacket({ from: 50, time: 0, snr: 9 } as any);
-    expect(db.getNode(50)?.lastHeard).toBeCloseTo(Date.now(), -1); // within 10ms
+    expect(db.getNode(50)?.lastHeard).toBeCloseTo(Date.now() / 1000, -1); // within 10ms, note lastHeard is in seconds
     expect(db.getNode(50)?.snr).toBe(9);
   });
 
@@ -336,9 +344,9 @@ describe("NodeDB – merge semantics, PKI checks & extras", () => {
     expect(n5.user?.publicKey).toEqual(keyOld); // keep old PK
     expect(n5.user?.longName).toBe("old-5");
 
-    // error flagged
+    // error not flagged; dropped silently
     const err = newDB!.getNodeError(5);
-    expect(String(err!.error)).toMatch(/MISMATCH|PK/i);
+    expect(err).toBeUndefined();
   });
 
   it("old key empty, new key present, store new node", async () => {
@@ -449,5 +457,120 @@ describe("NodeDB – merge semantics, PKI checks & extras", () => {
     newDB.setNodeNum(4242);
 
     expect(newDB.getMyNode().num).toBe(4242);
+  });
+});
+
+describe("NodeDB deviceContext & debounce", () => {
+  beforeEach(() => {
+    idbMem.clear();
+    vi.clearAllMocks();
+  });
+
+  it("useNodeDB resolves per-device DB and switches with deviceId", async () => {
+    const { useNodeDBStore, useNodeDB } = await freshStore();
+
+    // device 1
+    deviceIdForTests = 1;
+    const st = useNodeDBStore.getState();
+    const db1 = st.addNodeDB(1);
+    db1.addNode({ num: 10 } as any);
+
+    function Comp() {
+      const len = useNodeDB((db) => db.getNodesLength(), {
+        debounce: 0,
+        equality: (a, b) => a === b,
+      });
+      return <div data-testid="len">{len}</div>;
+    }
+
+    const { rerender } = render(<Comp />);
+    expect(screen.getByTestId("len").textContent).toBe("1");
+
+    // switch to device 2 and add nodes
+    deviceIdForTests = 2;
+    const db2 = st.addNodeDB(2);
+    db2.addNode({ num: 20 } as any);
+    db2.addNode({ num: 21 } as any);
+    db2.addNode({ num: 22 } as any);
+
+    // re-render so the hook re-subscribes with the new deviceId
+    await act(async () => {
+      rerender(<Comp />);
+    });
+
+    expect(screen.getByTestId("len").textContent).toBe("3");
+  });
+
+  it("useNodeDB selector re-renders only when the selected slice changes", async () => {
+    const { useNodeDBStore, useNodeDB } = await freshStore();
+    deviceIdForTests = 1;
+
+    const st = useNodeDBStore.getState();
+    const db = st.addNodeDB(1);
+
+    let renders = 0;
+    function Comp() {
+      const len = useNodeDB((d) => d.getNodesLength(), {
+        debounce: 0,
+        equality: (a, b) => a === b,
+      });
+      renders++;
+      return <div data-testid="len">{len}</div>;
+    }
+
+    render(<Comp />);
+    expect(screen.getByTestId("len").textContent).toBe("0");
+    expect(renders).toBe(1);
+
+    // mutate something unrelated to length
+    db.setNodeError(999, "X" as any);
+    await act(() => Promise.resolve());
+    expect(screen.getByTestId("len").textContent).toBe("0");
+    expect(renders).toBe(1); // no re-render
+
+    // now actually change the slice
+    db.addNode({ num: 1 } as any);
+    await act(() => Promise.resolve());
+    expect(screen.getByTestId("len").textContent).toBe("1");
+    expect(renders).toBe(2);
+  });
+
+  it("useNodeDB debounce coalesces rapid updates", async () => {
+    vi.useFakeTimers();
+    const { useNodeDBStore, useNodeDB } = await freshStore();
+    deviceIdForTests = 1;
+
+    const st = useNodeDBStore.getState();
+    const db = st.addNodeDB(1);
+
+    let renders = 0;
+    function Comp() {
+      const len = useNodeDB((d) => d.getNodesLength(), {
+        debounce: 50,
+        equality: (a, b) => a === b,
+      });
+      renders++;
+      return <div data-testid="len">{len}</div>;
+    }
+
+    render(<Comp />);
+
+    // burst of updates within the debounce window
+    db.addNode({ num: 1 } as any);
+    db.addNode({ num: 2 } as any);
+    db.addNode({ num: 3 } as any);
+
+    await act(() => {
+      vi.advanceTimersByTime(49);
+    });
+    expect(renders).toBe(1); // not yet
+
+    await act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(screen.getByTestId("len").textContent).toBe("3");
+    expect(renders).toBe(2); // single coalesced re-render
+
+    vi.useRealTimers();
   });
 });

--- a/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.tsx
+++ b/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.tsx
@@ -105,7 +105,7 @@ describe("NodeDB store", () => {
     expect(db.getNode(50)?.snr).toBe(9);
 
     db.processPacket({ from: 50, time: 0, snr: 9 } as any);
-    expect(db.getNode(50)?.lastHeard).toBeCloseTo(Date.now() / 1000, -1); // within 10ms, note lastHeard is in seconds
+    expect(db.getNode(50)?.lastHeard).toBeCloseTo(Date.now() / 1000, 2); // within 10ms, note lastHeard is in seconds
     expect(db.getNode(50)?.snr).toBe(9);
   });
 

--- a/packages/web/src/core/stores/nodeDBStore/nodeValidation.ts
+++ b/packages/web/src/core/stores/nodeDBStore/nodeValidation.ts
@@ -1,5 +1,28 @@
 import type { NodeErrorType } from "@core/stores";
 import type { Protobuf } from "@meshtastic/core";
+import { fromByteArray } from "base64-js";
+
+export function equalKey(
+  a?: Uint8Array | null,
+  b?: Uint8Array | null,
+): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  if (a === b) {
+    return true;
+  }
+  const len = a.byteLength;
+  if (len !== b.byteLength) {
+    return false;
+  }
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
 
 // Validates a new incoming node against existing nodes.
 // If valid, returns a node to store, else returns undefined.
@@ -26,6 +49,12 @@ export function validateIncomingNode(
       );
       if (nodesWithSameKey.length > 0) {
         // This is a potential impersonation attempt.
+
+        console.warn(
+          `Node ${num} rejected: Public key already claimed by another node. Key:`,
+          fromByteArray(newNode.user?.publicKey ?? new Uint8Array()),
+        );
+
         setNodeError(num, "DUPLICATE_PKI");
         return undefined; // drop newNode entirely
       }
@@ -41,7 +70,7 @@ export function validateIncomingNode(
     // A public key is considered matching if the incoming key equals
     // the existing key, OR if the existing key is empty.
     const isKeyMatchingOrExistingEmpty =
-      oldNode.user?.publicKey === newNode.user?.publicKey ||
+      equalKey(oldNode.user?.publicKey, newNode.user?.publicKey) ||
       oldNode.user?.publicKey === undefined ||
       oldNode.user?.publicKey.length === 0;
 
@@ -49,14 +78,33 @@ export function validateIncomingNode(
       // Keys match or existing key was empty: trust the incoming node data completely.
       // This allows for legitimate updates to user info and other fields.
       return newNode;
-    } else {
+    } else if (
+      newNode.user?.publicKey !== undefined &&
+      newNode.user?.publicKey.length > 0
+    ) {
+      console.warn(
+        `Node ${num} rejected: existing key does not match incoming key. Old key:`,
+        fromByteArray(oldNode.user?.publicKey ?? new Uint8Array()),
+        "New key:",
+        fromByteArray(newNode.user?.publicKey ?? new Uint8Array()),
+      );
+
       // Keys do not match and existing key was not empty: potential impersonation attempt.
       setNodeError(num, "MISMATCH_PKI");
       return oldNode; // drop newNode fields and return old
+    } else {
+      // Incoming node has no public key: ignore the new node entirely.
+      console.warn(
+        `Node ${num} rejected: incoming node has no public key, but existing does.`,
+      );
     }
   } else {
     // Multiple existing nodes with the same node number
     // This should never happen, but if it does, we drop the new node entirely.
+    console.warn(
+      `Node ${num} rejected: Multiple existing nodes with this node number.`,
+    );
+
     setNodeError(num, "DUPLICATE_PKI");
     return undefined; // drop newNode entirely
   }

--- a/packages/web/src/core/stores/nodeDBStore/nodeValidation.ts
+++ b/packages/web/src/core/stores/nodeDBStore/nodeValidation.ts
@@ -97,6 +97,7 @@ export function validateIncomingNode(
       console.warn(
         `Node ${num} rejected: incoming node has no public key, but existing does.`,
       );
+      return oldNode; // drop newNode fields and return old
     }
   } else {
     // Multiple existing nodes with the same node number

--- a/packages/web/src/core/stores/utils/bindStoreToDevice.ts
+++ b/packages/web/src/core/stores/utils/bindStoreToDevice.ts
@@ -1,0 +1,99 @@
+import { useDeviceContext } from "@core/hooks/useDeviceContext";
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import type { StoreApi, UseBoundStore } from "zustand";
+import { shallow } from "zustand/shallow";
+
+type GenericEqualityFn<T> = (a: T, b: T) => boolean;
+
+type DebounceOpts<T> = {
+  debounce?: number; // 0/undefined = no debounce
+  equality?: GenericEqualityFn<T>; // default: shallow
+  fireImmediately?: boolean; // default: true
+};
+
+type StoreWithSelector<S> = UseBoundStore<StoreApi<S>> & {
+  getState(): S;
+  subscribe: <U>(
+    selector: (state: S) => U,
+    listener: (next: U, prev: U) => void,
+    options?: { equalityFn?: GenericEqualityFn<U>; fireImmediately?: boolean },
+  ) => () => void;
+};
+
+export function bindStoreToDevice<S, DB>(
+  store: StoreWithSelector<S>,
+  resolveDB: (state: S, deviceId: number) => DB,
+) {
+  // Overloads:
+  function useBound(): DB;
+  function useBound<T>(selector: (db: DB) => T, opts?: DebounceOpts<T>): T;
+
+  // Implementation:
+  function useBound<T>(
+    selector?: (db: DB) => T,
+    opts?: DebounceOpts<T>,
+  ): DB | T {
+    const { deviceId } = useDeviceContext();
+
+    // Build the store-level selector
+    const storeSelector = useCallback(
+      (state: S) => {
+        const db = resolveDB(state, deviceId);
+        return selector ? selector(db) : db;
+      },
+      [deviceId, resolveDB, selector],
+    );
+
+    type Selected = ReturnType<typeof storeSelector>;
+
+    const wait = opts?.debounce ?? 0;
+    const fireImmediately = opts?.fireImmediately ?? true;
+    const equality: GenericEqualityFn<Selected> =
+      (opts?.equality as GenericEqualityFn<Selected>) ??
+      (shallow as unknown as GenericEqualityFn<Selected>);
+
+    const snapRef = useRef<Selected>(storeSelector(store.getState()));
+    snapRef.current = storeSelector(store.getState()); // this ensures rerenders with a new selector (new deviceId) see the right initial value
+
+    const subscribe = useMemo(() => {
+      return (onChange: () => void) => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+
+        const unsubscribe = store.subscribe(
+          storeSelector,
+          (next: Selected, prev: Selected) => {
+            if (equality(next, prev)) {
+              return;
+            }
+
+            if (wait > 0) {
+              if (timer) {
+                clearTimeout(timer);
+              }
+              timer = setTimeout(() => {
+                snapRef.current = next;
+                onChange();
+              }, wait);
+            } else {
+              snapRef.current = next;
+              onChange();
+            }
+          },
+          { equalityFn: equality, fireImmediately },
+        );
+
+        return () => {
+          if (timer) {
+            clearTimeout(timer);
+          }
+          unsubscribe();
+        };
+      };
+    }, [store, storeSelector, equality, wait, fireImmediately]);
+
+    const getSnapshot = () => snapRef.current;
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  }
+
+  return useBound;
+}

--- a/packages/web/src/pages/Nodes/index.tsx
+++ b/packages/web/src/pages/Nodes/index.tsx
@@ -184,7 +184,7 @@ const NodesPage = (): JSX.Element => {
                         ? t("unit.hop.plural")
                         : t("unit.hops_one")
                     } ${t("nodesTable.connectionStatus.away")}`
-                : t("nodesTable.connectionStatus.unknown")}
+                : t("unknown.longName")}
               {node?.viaMqtt === true
                 ? t("nodesTable.connectionStatus.viaMqtt")
                 : ""}
@@ -196,7 +196,7 @@ const NodesPage = (): JSX.Element => {
           content: (
             <Mono>
               {node.lastHeard === 0 ? (
-                t("nodesTable.lastHeardStatus.unknown")
+                t("unknown.longName")
               ) : (
                 <TimeAgo
                   timestamp={node.lastHeard * 1000}


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
This PR is a mixed bag of changes. One thing led to the other...

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Related Issues
Fixes #72 (!)
Fixes #668

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made
- Updated i18n labels, replacing "Never" with "Unknown" for last heard status and updating label for "Never Heard".
- `NodeDetailsDialog.tsx` and `Sidebar.tsx`: Modified the voltage value to always display the absolute value. 
- `Slider.tsx`: Adds unique IDs to slider thumbs to address warnings about duplicate keys.
- `useFilterNode.ts`: Implements more robust filtering logic for nodes, handling cases where node properties are undefined.  It also ensures that nodes with unknown values (e.g., hopsAway, lastHeard, snr, channelUtilization, airUtilTx, batteryLevel, voltage, role, hwModel) are only filtered out if the filter state is not at its default value.

**Stores:** 
- Implements a `bindStoreToDevice` helper function and uses it to bind the useNodeDB hook to the current device context. This ensures that each device has its own NodeDB instance, while also allowing use of Zustand's `subscribeWithSelector` for reactive re-renders on updates.
- `messageStore`: Changes the store name from "meshtastic-MessageStore-store" to "meshtastic-message-store".
- `nodeDBStore`: Changes nodeDBStore to use _new_ Maps for nodeMap and nodeErrors so that React triggers re-renders on change when using `subscribeWithSelector` middleware.
- `nodeDBStore.test.tsx`: Add new tests for nodeDBStore.
- `nodeValidation.ts`: Adds helper function equalKey for Uint8Array comparison
- `bindStoreToDevice.ts`: Adds a new helper function bindStoreToDevice to assist in binding stores to specific devices.
- Map and Nodes pages: Debounces useNodeDB hook and uses useCallback for the nodeFilter predicate in the Nodes page, ensuring re-render is triggered on db changes, while debouncing re-render for rapid changes.

## Testing Done
Tested locally, updated tests
<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
