### PR TITLE
Command Menu improvements

### DIFF
--- a/packages/web/public/i18n/locales/en/commandPalette.json
+++ b/packages/web/public/i18n/locales/en/commandPalette.json
@@ -45,7 +45,8 @@
     "label": "Debug",
     "command": {
       "reconfigure": "Reconfigure",
-      "clearAllStoredMessages": "Clear All Stored Message"
+      "clearAllStoredMessages": "Clear All Stored Messages",
+      "clearAllStores": "Clear All Local Storage"
     }
   }
 }

--- a/packages/web/public/i18n/locales/en/commandPalette.json
+++ b/packages/web/public/i18n/locales/en/commandPalette.json
@@ -15,7 +15,6 @@
       "messages": "Messages",
       "map": "Map",
       "config": "Config",
-      "channels": "Channels",
       "nodes": "Nodes"
     }
   },

--- a/packages/web/public/i18n/locales/en/dialog.json
+++ b/packages/web/public/i18n/locales/en/dialog.json
@@ -194,5 +194,25 @@
     "title": "Client Notification",
     "TraceRoute can only be sent once every 30 seconds": "TraceRoute can only be sent once every 30 seconds",
     "Compromised keys were detected and regenerated.": "Compromised keys were detected and regenerated."
+  },
+  "resetNodeDb": {
+    "title": "Reset Node Database",
+    "description": "This will clear all nodes from the connected device's node database and clear all message history in the client. This cannot be undone. Are you sure you want to continue?",
+    "confirm": "Reset Node Database"
+  },
+  "clearAllStores": {
+    "title": "Clear All Local Storage",
+    "description": "This will clear all locally stored data, including message history and node databases for all previously connected devices. This will require you to reconnect to your node once complete and cannot be undone. Are you sure you want to continue?",
+    "confirm": "Clear all local storage"
+  },
+  "factoryResetDevice": {
+    "title": "Factory Reset Device",
+    "description": "This will factory reset the connected device, erasing all configurations and data on the device as well as all nodes and messages saved in the client. This cannot be undone. Are you sure you want to continue?",
+    "confirm": "Factory Reset Device"
+  },
+  "factoryResetConfig": {
+    "title": "Factory Reset Config",
+    "description": "This will factory reset the configuration on the connected device, erasing all configurations on the device. This cannot be undone. Are you sure you want to continue?",
+    "confirm": "Factory Reset Config"
   }
 }

--- a/packages/web/public/i18n/locales/en/dialog.json
+++ b/packages/web/public/i18n/locales/en/dialog.json
@@ -198,21 +198,25 @@
   "resetNodeDb": {
     "title": "Reset Node Database",
     "description": "This will clear all nodes from the connected device's node database and clear all message history in the client. This cannot be undone. Are you sure you want to continue?",
-    "confirm": "Reset Node Database"
+    "confirm": "Reset Node Database",
+    "failedTitle": "There was an error resetting the Node DB. Please try again."
   },
   "clearAllStores": {
     "title": "Clear All Local Storage",
     "description": "This will clear all locally stored data, including message history and node databases for all previously connected devices. This will require you to reconnect to your node once complete and cannot be undone. Are you sure you want to continue?",
-    "confirm": "Clear all local storage"
+    "confirm": "Clear all local storage",
+    "failedTitle": "There was an error clearing local storage. Please try again."
   },
   "factoryResetDevice": {
     "title": "Factory Reset Device",
     "description": "This will factory reset the connected device, erasing all configurations and data on the device as well as all nodes and messages saved in the client. This cannot be undone. Are you sure you want to continue?",
-    "confirm": "Factory Reset Device"
+    "confirm": "Factory Reset Device",
+    "failedTitle": "There was an error performing the factory reset. Please try again."
   },
   "factoryResetConfig": {
     "title": "Factory Reset Config",
     "description": "This will factory reset the configuration on the connected device, erasing all configurations on the device. This cannot be undone. Are you sure you want to continue?",
-    "confirm": "Factory Reset Config"
+    "confirm": "Factory Reset Config",
+    "failedTitle": "There was an error performing the factory reset. Please try again."
   }
 }

--- a/packages/web/src/components/CommandPalette/index.tsx
+++ b/packages/web/src/components/CommandPalette/index.tsx
@@ -25,7 +25,6 @@ import {
   EraserIcon,
   FactoryIcon,
   HardDriveUpload,
-  LayersIcon,
   LinkIcon,
   type LucideIcon,
   MapIcon,
@@ -105,13 +104,6 @@ export const CommandPalette = () => {
             navigate({ to: "/config" });
           },
           tags: ["settings"],
-        },
-        {
-          label: t("goto.command.channels"),
-          icon: LayersIcon,
-          action() {
-            navigate({ to: "/channels" });
-          },
         },
         {
           label: t("goto.command.nodes"),

--- a/packages/web/src/components/CommandPalette/index.tsx
+++ b/packages/web/src/components/CommandPalette/index.tsx
@@ -71,7 +71,7 @@ export const CommandPalette = () => {
   } = useAppStore();
   const { getDevices } = useDeviceStore();
   const { setDialogOpen, connection } = useDevice();
-  const { getNode, removeAllNodeErrors, removeAllNodes } = useNodeDB();
+  const { getNode } = useNodeDB();
   const { pinnedItems, togglePinnedItem } = usePinnedItems({
     storageName: "pinnedCommandMenuGroups",
   });
@@ -206,9 +206,7 @@ export const CommandPalette = () => {
           label: t("contextual.command.resetNodeDb"),
           icon: TrashIcon,
           action() {
-            connection?.resetNodes();
-            removeAllNodeErrors();
-            removeAllNodes(true);
+            setDialogOpen("resetNodeDb", true);
           },
         },
         {
@@ -224,16 +222,14 @@ export const CommandPalette = () => {
           label: t("contextual.command.factoryResetDevice"),
           icon: FactoryIcon,
           action() {
-            connection?.factoryResetDevice();
-            removeAllNodeErrors();
-            removeAllNodes();
+            setDialogOpen("factoryResetDevice", true);
           },
         },
         {
           label: t("contextual.command.factoryResetConfig"),
           icon: FactoryIcon,
           action() {
-            connection?.factoryResetConfig();
+            setDialogOpen("factoryResetConfig", true);
           },
         },
       ],
@@ -255,6 +251,13 @@ export const CommandPalette = () => {
           icon: EraserIcon,
           action() {
             setDialogOpen("deleteMessages", true);
+          },
+        },
+        {
+          label: t("debug.command.clearAllStores"),
+          icon: EraserIcon,
+          action() {
+            setDialogOpen("clearAllStores", true);
           },
         },
       ],

--- a/packages/web/src/components/Dialog/ClearAllStoresDialog/ClearAllStoresDialog.test.tsx
+++ b/packages/web/src/components/Dialog/ClearAllStoresDialog/ClearAllStoresDialog.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClearAllStoresDialog } from "./ClearAllStoresDialog.tsx";
+
+const mockClearAllStores = vi.fn();
+
+vi.mock("@core/stores", () => ({
+  CurrentDeviceContext: {
+    _currentValue: { deviceId: 1234 },
+  },
+  clearAllStores: () => mockClearAllStores(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      switch (key) {
+        case "clearAllStores.title":
+          return "Clear All Data";
+        case "clearAllStores.description":
+          return "This will erase all data.";
+        case "clearAllStores.confirm":
+          return "Clear Everything";
+        default:
+          return key;
+      }
+    },
+  }),
+}));
+
+describe("ClearAllStoresDialog", () => {
+  const mockOnOpenChange = vi.fn();
+
+  // Capture window.location.href assignment without triggering real navigation
+  const originalLocation = window.location;
+  let assignedHref: string | undefined;
+
+  beforeEach(() => {
+    mockOnOpenChange.mockClear();
+    mockClearAllStores.mockClear();
+    assignedHref = undefined;
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        get href() {
+          return originalLocation.href;
+        },
+        set href(val: string) {
+          assignedHref = val;
+        },
+      },
+    });
+  });
+
+  // restore the real location object after each test
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("calls clearAllStores and navigates to '/' when confirm is clicked", () => {
+    render(<ClearAllStoresDialog open onOpenChange={mockOnOpenChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "Clear Everything" }));
+
+    expect(mockClearAllStores).toHaveBeenCalledTimes(1);
+    expect(assignedHref).toBe("/"); // forced reload target
+    // We reload instead of toggling the dialog, so ensure we didn't call onOpenChange
+    expect(mockOnOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("calls onOpenChange with false when cancel is clicked", () => {
+    render(<ClearAllStoresDialog open onOpenChange={mockOnOpenChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "button.cancel" }));
+
+    expect(mockClearAllStores).not.toHaveBeenCalled();
+    expect(assignedHref).toBeUndefined(); // no navigation
+    expect(mockOnOpenChange).toHaveBeenCalledTimes(1);
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/web/src/components/Dialog/ClearAllStoresDialog/ClearAllStoresDialog.test.tsx
+++ b/packages/web/src/components/Dialog/ClearAllStoresDialog/ClearAllStoresDialog.test.tsx
@@ -11,23 +11,6 @@ vi.mock("@core/stores", () => ({
   clearAllStores: () => mockClearAllStores(),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      switch (key) {
-        case "clearAllStores.title":
-          return "Clear All Data";
-        case "clearAllStores.description":
-          return "This will erase all data.";
-        case "clearAllStores.confirm":
-          return "Clear Everything";
-        default:
-          return key;
-      }
-    },
-  }),
-}));
-
 describe("ClearAllStoresDialog", () => {
   const mockOnOpenChange = vi.fn();
 
@@ -64,7 +47,9 @@ describe("ClearAllStoresDialog", () => {
 
   it("calls clearAllStores and navigates to '/' when confirm is clicked", () => {
     render(<ClearAllStoresDialog open onOpenChange={mockOnOpenChange} />);
-    fireEvent.click(screen.getByRole("button", { name: "Clear Everything" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear all local storage" }),
+    );
 
     expect(mockClearAllStores).toHaveBeenCalledTimes(1);
     expect(assignedHref).toBe("/"); // forced reload target
@@ -74,7 +59,7 @@ describe("ClearAllStoresDialog", () => {
 
   it("calls onOpenChange with false when cancel is clicked", () => {
     render(<ClearAllStoresDialog open onOpenChange={mockOnOpenChange} />);
-    fireEvent.click(screen.getByRole("button", { name: "button.cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(mockClearAllStores).not.toHaveBeenCalled();
     expect(assignedHref).toBeUndefined(); // no navigation

--- a/packages/web/src/components/Dialog/ClearAllStoresDialog/ClearAllStoresDialog.tsx
+++ b/packages/web/src/components/Dialog/ClearAllStoresDialog/ClearAllStoresDialog.tsx
@@ -1,0 +1,35 @@
+import { clearAllStores } from "@core/stores";
+import { useTranslation } from "react-i18next";
+import { DialogWrapper } from "../DialogWrapper.tsx";
+
+export interface ClearAllStoresDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const ClearAllStoresDialog = ({
+  open,
+  onOpenChange,
+}: ClearAllStoresDialogProps) => {
+  const { t } = useTranslation("dialog");
+
+  const handleClearAllStores = () => {
+    clearAllStores();
+
+    // Reload the app to ensure all state is cleared
+    window.location.href = "/";
+  };
+
+  return (
+    <DialogWrapper
+      open={open}
+      onOpenChange={onOpenChange}
+      type="confirm"
+      variant="destructive"
+      title={t("clearAllStores.title")}
+      description={t("clearAllStores.description")}
+      confirmText={t("clearAllStores.confirm")}
+      onConfirm={handleClearAllStores}
+    />
+  );
+};

--- a/packages/web/src/components/Dialog/DialogManager.tsx
+++ b/packages/web/src/components/Dialog/DialogManager.tsx
@@ -1,3 +1,6 @@
+import { FactoryResetConfigDialog } from "@app/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog";
+import { FactoryResetDeviceDialog } from "@app/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog";
+import { ClearAllStoresDialog } from "@components/Dialog/ClearAllStoresDialog/ClearAllStoresDialog.tsx";
 import { ClientNotificationDialog } from "@components/Dialog/ClientNotificationDialog/ClientNotificationDialog.tsx";
 import { DeleteMessagesDialog } from "@components/Dialog/DeleteMessagesDialog/DeleteMessagesDialog.tsx";
 import { DeviceNameDialog } from "@components/Dialog/DeviceNameDialog.tsx";
@@ -8,6 +11,7 @@ import { QRDialog } from "@components/Dialog/QRDialog.tsx";
 import { RebootDialog } from "@components/Dialog/RebootDialog.tsx";
 import { RefreshKeysDialog } from "@components/Dialog/RefreshKeysDialog/RefreshKeysDialog.tsx";
 import { RemoveNodeDialog } from "@components/Dialog/RemoveNodeDialog.tsx";
+import { ResetNodeDbDialog } from "@components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.tsx";
 import { ShutdownDialog } from "@components/Dialog/ShutdownDialog.tsx";
 import { UnsafeRolesDialog } from "@components/Dialog/UnsafeRolesDialog/UnsafeRolesDialog.tsx";
 import { useDevice } from "@core/stores";
@@ -89,6 +93,30 @@ export const DialogManager = () => {
         open={dialog.clientNotification}
         onOpenChange={(open) => {
           setDialogOpen("clientNotification", open);
+        }}
+      />
+      <ResetNodeDbDialog
+        open={dialog.resetNodeDb}
+        onOpenChange={(open) => {
+          setDialogOpen("resetNodeDb", open);
+        }}
+      />
+      <ClearAllStoresDialog
+        open={dialog.clearAllStores}
+        onOpenChange={(open) => {
+          setDialogOpen("clearAllStores", open);
+        }}
+      />
+      <FactoryResetDeviceDialog
+        open={dialog.factoryResetDevice}
+        onOpenChange={(open) => {
+          setDialogOpen("factoryResetDevice", open);
+        }}
+      />
+      <FactoryResetConfigDialog
+        open={dialog.factoryResetConfig}
+        onOpenChange={(open) => {
+          setDialogOpen("factoryResetConfig", open);
         }}
       />
     </>

--- a/packages/web/src/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog.test.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FactoryResetConfigDialog } from "./FactoryResetConfigDialog.tsx";
+
+const mockFactoryReset = vi.fn();
+
+vi.mock("@core/stores", () => ({
+  CurrentDeviceContext: {
+    _currentValue: { deviceId: 1234 },
+  },
+  useDevice: () => ({
+    connection: {
+      factoryResetConfig: mockFactoryReset,
+    },
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      switch (key) {
+        case "factoryResetConfig.title":
+          return "Factory Reset Config";
+        case "factoryResetConfig.description":
+          return "This will reset device configuration to factory defaults.";
+        case "factoryResetConfig.confirm":
+          return "Factory Reset";
+        default:
+          return key;
+      }
+    },
+  }),
+}));
+
+describe("FactoryResetConfigDialog", () => {
+  const mockOnOpenChange = vi.fn();
+
+  beforeEach(() => {
+    mockOnOpenChange.mockClear();
+    mockFactoryReset.mockClear();
+  });
+
+  it("calls factoryResetConfig and onOpenChange(false) when confirm is clicked", async () => {
+    render(<FactoryResetConfigDialog open onOpenChange={mockOnOpenChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Factory Reset" }));
+
+    expect(mockFactoryReset).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(mockOnOpenChange).toHaveBeenCalledTimes(1);
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("calls onOpenChange(false) and does not call factoryResetConfig when cancel is clicked", () => {
+    render(<FactoryResetConfigDialog open onOpenChange={mockOnOpenChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "button.cancel" }));
+
+    expect(mockFactoryReset).not.toHaveBeenCalled();
+    expect(mockOnOpenChange).toHaveBeenCalledTimes(1);
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/web/src/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog.test.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog.test.tsx
@@ -20,25 +20,6 @@ vi.mock("@core/hooks/useToast.ts", () => ({
   toast: (...args: unknown[]) => mockToast(...args),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      switch (key) {
-        case "factoryResetConfig.title":
-          return "Factory Reset Config";
-        case "factoryResetConfig.description":
-          return "This will reset device configuration to factory defaults.";
-        case "factoryResetConfig.confirm":
-          return "Factory Reset";
-        case "factoryResetConfig.failedTitle":
-          return "Reset failed";
-        default:
-          return key; // e.g. "button.cancel"
-      }
-    },
-  }),
-}));
-
 describe("FactoryResetConfigDialog", () => {
   const mockOnOpenChange = vi.fn();
 
@@ -52,7 +33,9 @@ describe("FactoryResetConfigDialog", () => {
   it("calls factoryResetConfig and then closes the dialog on confirm", async () => {
     render(<FactoryResetConfigDialog open onOpenChange={mockOnOpenChange} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Factory Reset" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Factory Reset Config" }),
+    );
 
     expect(mockFactoryReset).toHaveBeenCalledTimes(1);
 
@@ -68,7 +51,7 @@ describe("FactoryResetConfigDialog", () => {
   it("calls onOpenChange(false) and does not call factoryResetConfig when cancel is clicked", async () => {
     render(<FactoryResetConfigDialog open onOpenChange={mockOnOpenChange} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "button.cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
     await waitFor(() => {
       expect(mockOnOpenChange).toHaveBeenCalledTimes(1);

--- a/packages/web/src/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog.tsx
@@ -1,0 +1,33 @@
+import { useDevice } from "@core/stores";
+import { useTranslation } from "react-i18next";
+import { DialogWrapper } from "../DialogWrapper.tsx";
+
+export interface FactoryResetConfigDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const FactoryResetConfigDialog = ({
+  open,
+  onOpenChange,
+}: FactoryResetConfigDialogProps) => {
+  const { t } = useTranslation("dialog");
+  const { connection } = useDevice();
+
+  const handleFactoryResetConfig = () => {
+    connection?.factoryResetConfig();
+  };
+
+  return (
+    <DialogWrapper
+      open={open}
+      onOpenChange={onOpenChange}
+      type="confirm"
+      variant="destructive"
+      title={t("factoryResetConfig.title")}
+      description={t("factoryResetConfig.description")}
+      confirmText={t("factoryResetConfig.confirm")}
+      onConfirm={handleFactoryResetConfig}
+    />
+  );
+};

--- a/packages/web/src/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetConfigDialog/FactoryResetConfigDialog.tsx
@@ -1,3 +1,4 @@
+import { toast } from "@core/hooks/useToast.ts";
 import { useDevice } from "@core/stores";
 import { useTranslation } from "react-i18next";
 import { DialogWrapper } from "../DialogWrapper.tsx";
@@ -15,7 +16,12 @@ export const FactoryResetConfigDialog = ({
   const { connection } = useDevice();
 
   const handleFactoryResetConfig = () => {
-    connection?.factoryResetConfig();
+    connection?.factoryResetConfig().catch((error) => {
+      toast({
+        title: t("factoryResetConfig.failedTitle"),
+      });
+      console.error("Failed to factory reset config:", error);
+    });
   };
 
   return (

--- a/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.test.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.test.tsx
@@ -1,0 +1,109 @@
+// FactoryResetDeviceDialog.test.tsx
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FactoryResetDeviceDialog } from "./FactoryResetDeviceDialog.tsx";
+
+const mockFactoryResetDevice = vi.fn();
+const mockDeleteAllMessages = vi.fn();
+const mockRemoveAllNodeErrors = vi.fn();
+const mockRemoveAllNodes = vi.fn();
+
+vi.mock("@core/stores", () => ({
+  CurrentDeviceContext: {
+    _currentValue: { deviceId: 1234 },
+  },
+  useDevice: () => ({
+    connection: {
+      factoryResetDevice: mockFactoryResetDevice,
+    },
+  }),
+  useMessages: () => ({
+    deleteAllMessages: mockDeleteAllMessages,
+  }),
+  useNodeDB: () => ({
+    removeAllNodeErrors: mockRemoveAllNodeErrors,
+    removeAllNodes: mockRemoveAllNodes,
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      switch (key) {
+        case "factoryResetDevice.title":
+          return "Factory Reset Device";
+        case "factoryResetDevice.description":
+          return "This will reset the device and clear local data.";
+        case "factoryResetDevice.confirm":
+          return "Reset Device";
+        default:
+          return key;
+      }
+    },
+  }),
+}));
+
+describe("FactoryResetDeviceDialog", () => {
+  const mockOnOpenChange = vi.fn();
+
+  beforeEach(() => {
+    mockOnOpenChange.mockClear();
+    mockFactoryResetDevice.mockClear();
+    mockDeleteAllMessages.mockClear();
+    mockRemoveAllNodeErrors.mockClear();
+    mockRemoveAllNodes.mockClear();
+  });
+
+  it("calls factoryResetDevice, closes dialog, and after reset resolves clears messages and node DB", async () => {
+    // Control the promise returned by factoryResetDevice
+    let resolveReset: (() => void) | undefined;
+    mockFactoryResetDevice.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReset = resolve;
+        }),
+    );
+
+    render(<FactoryResetDeviceDialog open onOpenChange={mockOnOpenChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "Reset Device" }));
+
+    // Called immediately
+    expect(mockFactoryResetDevice).toHaveBeenCalledTimes(1);
+
+    // DialogWrapper awaits onConfirm (which returns undefined), so close happens on next microtask
+    await waitFor(() => {
+      expect(mockOnOpenChange).toHaveBeenCalledTimes(1);
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    // Nothing else should have happened yet (the promise hasn't resolved)
+    expect(mockDeleteAllMessages).not.toHaveBeenCalled();
+    expect(mockRemoveAllNodeErrors).not.toHaveBeenCalled();
+    expect(mockRemoveAllNodes).not.toHaveBeenCalled();
+
+    // Resolve the reset
+    resolveReset?.();
+
+    // Now the .then() chain should fire
+    await waitFor(() => {
+      expect(mockDeleteAllMessages).toHaveBeenCalledTimes(1);
+      expect(mockRemoveAllNodeErrors).toHaveBeenCalledTimes(1);
+      expect(mockRemoveAllNodes).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("calls onOpenChange(false) and does not call factoryResetDevice when cancel is clicked", async () => {
+    render(<FactoryResetDeviceDialog open onOpenChange={mockOnOpenChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "button.cancel" }));
+
+    await waitFor(() => {
+      expect(mockOnOpenChange).toHaveBeenCalledTimes(1);
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    expect(mockFactoryResetDevice).not.toHaveBeenCalled();
+    expect(mockDeleteAllMessages).not.toHaveBeenCalled();
+    expect(mockRemoveAllNodeErrors).not.toHaveBeenCalled();
+    expect(mockRemoveAllNodes).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.test.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.test.tsx
@@ -26,23 +26,6 @@ vi.mock("@core/stores", () => ({
   }),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      switch (key) {
-        case "factoryResetDevice.title":
-          return "Factory Reset Device";
-        case "factoryResetDevice.description":
-          return "This will reset the device and clear local data.";
-        case "factoryResetDevice.confirm":
-          return "Reset Device";
-        default:
-          return key;
-      }
-    },
-  }),
-}));
-
 describe("FactoryResetDeviceDialog", () => {
   const mockOnOpenChange = vi.fn();
 
@@ -65,7 +48,9 @@ describe("FactoryResetDeviceDialog", () => {
     );
 
     render(<FactoryResetDeviceDialog open onOpenChange={mockOnOpenChange} />);
-    fireEvent.click(screen.getByRole("button", { name: "Reset Device" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Factory Reset Device" }),
+    );
 
     // Called immediately
     expect(mockFactoryResetDevice).toHaveBeenCalledTimes(1);
@@ -94,7 +79,7 @@ describe("FactoryResetDeviceDialog", () => {
 
   it("calls onOpenChange(false) and does not call factoryResetDevice when cancel is clicked", async () => {
     render(<FactoryResetDeviceDialog open onOpenChange={mockOnOpenChange} />);
-    fireEvent.click(screen.getByRole("button", { name: "button.cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
     await waitFor(() => {
       expect(mockOnOpenChange).toHaveBeenCalledTimes(1);

--- a/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.tsx
@@ -1,3 +1,4 @@
+import { toast } from "@core/hooks/useToast.ts";
 import { useDevice, useMessages, useNodeDB } from "@core/stores";
 import { useTranslation } from "react-i18next";
 import { DialogWrapper } from "../DialogWrapper.tsx";
@@ -17,11 +18,19 @@ export const FactoryResetDeviceDialog = ({
   const { deleteAllMessages } = useMessages();
 
   const handleFactoryResetDevice = () => {
-    connection?.factoryResetDevice().then(() => {
-      deleteAllMessages();
-      removeAllNodeErrors();
-      removeAllNodes();
-    });
+    connection
+      ?.factoryResetDevice()
+      .catch((error) => {
+        toast({
+          title: t("factoryResetDevice.failedTitle"),
+        });
+        console.error("Failed to factory reset device:", error);
+      })
+      .finally(() => {
+        deleteAllMessages();
+        removeAllNodeErrors();
+        removeAllNodes();
+      });
   };
 
   return (

--- a/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.tsx
@@ -1,0 +1,39 @@
+import { useDevice, useMessages, useNodeDB } from "@core/stores";
+import { useTranslation } from "react-i18next";
+import { DialogWrapper } from "../DialogWrapper.tsx";
+
+export interface FactoryResetDeviceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const FactoryResetDeviceDialog = ({
+  open,
+  onOpenChange,
+}: FactoryResetDeviceDialogProps) => {
+  const { t } = useTranslation("dialog");
+  const { connection } = useDevice();
+  const { removeAllNodeErrors, removeAllNodes } = useNodeDB();
+  const { deleteAllMessages } = useMessages();
+
+  const handleFactoryResetDevice = () => {
+    connection?.factoryResetDevice().then(() => {
+      deleteAllMessages();
+      removeAllNodeErrors();
+      removeAllNodes();
+    });
+  };
+
+  return (
+    <DialogWrapper
+      open={open}
+      onOpenChange={onOpenChange}
+      type="confirm"
+      variant="destructive"
+      title={t("factoryResetDevice.title")}
+      description={t("factoryResetDevice.description")}
+      confirmText={t("factoryResetDevice.confirm")}
+      onConfirm={handleFactoryResetDevice}
+    />
+  );
+};

--- a/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.tsx
+++ b/packages/web/src/components/Dialog/FactoryResetDeviceDialog/FactoryResetDeviceDialog.tsx
@@ -20,16 +20,16 @@ export const FactoryResetDeviceDialog = ({
   const handleFactoryResetDevice = () => {
     connection
       ?.factoryResetDevice()
+      .then(() => {
+        deleteAllMessages();
+        removeAllNodeErrors();
+        removeAllNodes();
+      })
       .catch((error) => {
         toast({
           title: t("factoryResetDevice.failedTitle"),
         });
         console.error("Failed to factory reset device:", error);
-      })
-      .finally(() => {
-        deleteAllMessages();
-        removeAllNodeErrors();
-        removeAllNodes();
       });
   };
 

--- a/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.test.tsx
+++ b/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.test.tsx
@@ -1,0 +1,110 @@
+// ResetNodeDbDialog.test.tsx
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ResetNodeDbDialog } from "./ResetNodeDbDialog.tsx";
+
+const mockResetNodes = vi.fn();
+const mockDeleteAllMessages = vi.fn();
+const mockRemoveAllNodeErrors = vi.fn();
+const mockRemoveAllNodes = vi.fn();
+
+vi.mock("@core/stores", () => ({
+  CurrentDeviceContext: {
+    _currentValue: { deviceId: 1234 },
+  },
+  useDevice: () => ({
+    connection: {
+      resetNodes: mockResetNodes,
+    },
+  }),
+  useMessages: () => ({
+    deleteAllMessages: mockDeleteAllMessages,
+  }),
+  useNodeDB: () => ({
+    removeAllNodeErrors: mockRemoveAllNodeErrors,
+    removeAllNodes: mockRemoveAllNodes,
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      switch (key) {
+        case "resetNodeDb.title":
+          return "Reset Node DB";
+        case "resetNodeDb.description":
+          return "This will reset the device NodeDB and clear local data.";
+        case "resetNodeDb.confirm":
+          return "Reset NodeDB";
+        default:
+          return key;
+      }
+    },
+  }),
+}));
+
+describe("ResetNodeDbDialog", () => {
+  const mockOnOpenChange = vi.fn();
+
+  beforeEach(() => {
+    mockOnOpenChange.mockClear();
+    mockResetNodes.mockClear();
+    mockDeleteAllMessages.mockClear();
+    mockRemoveAllNodeErrors.mockClear();
+    mockRemoveAllNodes.mockClear();
+  });
+
+  it("calls resetNodes, closes dialog, and after resolve clears messages and node DB (with true flag)", async () => {
+    // Control the promise returned by resetNodes
+    let resolveReset: (() => void) | undefined;
+    mockResetNodes.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReset = resolve;
+        }),
+    );
+
+    render(<ResetNodeDbDialog open onOpenChange={mockOnOpenChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "Reset NodeDB" }));
+
+    // Called immediately
+    expect(mockResetNodes).toHaveBeenCalledTimes(1);
+
+    // DialogWrapper awaits onConfirm (which returns undefined), so close happens on next microtask
+    await waitFor(() => {
+      expect(mockOnOpenChange).toHaveBeenCalledTimes(1);
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    // Nothing else should have happened yet (the promise hasn't resolved)
+    expect(mockDeleteAllMessages).not.toHaveBeenCalled();
+    expect(mockRemoveAllNodeErrors).not.toHaveBeenCalled();
+    expect(mockRemoveAllNodes).not.toHaveBeenCalled();
+
+    // Resolve the reset
+    resolveReset?.();
+
+    // Now the .then() chain should fire
+    await waitFor(() => {
+      expect(mockDeleteAllMessages).toHaveBeenCalledTimes(1);
+      expect(mockRemoveAllNodeErrors).toHaveBeenCalledTimes(1);
+      expect(mockRemoveAllNodes).toHaveBeenCalledTimes(1);
+      expect(mockRemoveAllNodes).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it("calls onOpenChange(false) and does not call resetNodes when cancel is clicked", async () => {
+    render(<ResetNodeDbDialog open onOpenChange={mockOnOpenChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "button.cancel" }));
+
+    await waitFor(() => {
+      expect(mockOnOpenChange).toHaveBeenCalledTimes(1);
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    expect(mockResetNodes).not.toHaveBeenCalled();
+    expect(mockDeleteAllMessages).not.toHaveBeenCalled();
+    expect(mockRemoveAllNodeErrors).not.toHaveBeenCalled();
+    expect(mockRemoveAllNodes).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.test.tsx
+++ b/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.test.tsx
@@ -26,23 +26,6 @@ vi.mock("@core/stores", () => ({
   }),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      switch (key) {
-        case "resetNodeDb.title":
-          return "Reset Node DB";
-        case "resetNodeDb.description":
-          return "This will reset the device NodeDB and clear local data.";
-        case "resetNodeDb.confirm":
-          return "Reset NodeDB";
-        default:
-          return key;
-      }
-    },
-  }),
-}));
-
 describe("ResetNodeDbDialog", () => {
   const mockOnOpenChange = vi.fn();
 
@@ -65,7 +48,9 @@ describe("ResetNodeDbDialog", () => {
     );
 
     render(<ResetNodeDbDialog open onOpenChange={mockOnOpenChange} />);
-    fireEvent.click(screen.getByRole("button", { name: "Reset NodeDB" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reset Node Database" }),
+    );
 
     // Called immediately
     expect(mockResetNodes).toHaveBeenCalledTimes(1);
@@ -95,7 +80,7 @@ describe("ResetNodeDbDialog", () => {
 
   it("calls onOpenChange(false) and does not call resetNodes when cancel is clicked", async () => {
     render(<ResetNodeDbDialog open onOpenChange={mockOnOpenChange} />);
-    fireEvent.click(screen.getByRole("button", { name: "button.cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
     await waitFor(() => {
       expect(mockOnOpenChange).toHaveBeenCalledTimes(1);

--- a/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.tsx
+++ b/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.tsx
@@ -20,16 +20,16 @@ export const ResetNodeDbDialog = ({
   const handleResetNodeDb = () => {
     connection
       ?.resetNodes()
+      .then(() => {
+        deleteAllMessages();
+        removeAllNodeErrors();
+        removeAllNodes(true);
+      })
       .catch((error) => {
         toast({
           title: t("resetNodeDb.failedTitle"),
         });
         console.error("Failed to reset Node DB:", error);
-      })
-      .finally(() => {
-        deleteAllMessages();
-        removeAllNodeErrors();
-        removeAllNodes(true);
       });
   };
 

--- a/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.tsx
+++ b/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.tsx
@@ -1,0 +1,39 @@
+import { useDevice, useMessages, useNodeDB } from "@core/stores";
+import { useTranslation } from "react-i18next";
+import { DialogWrapper } from "../DialogWrapper.tsx";
+
+export interface ResetNodeDbDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const ResetNodeDbDialog = ({
+  open,
+  onOpenChange,
+}: ResetNodeDbDialogProps) => {
+  const { t } = useTranslation("dialog");
+  const { connection } = useDevice();
+  const { removeAllNodeErrors, removeAllNodes } = useNodeDB();
+  const { deleteAllMessages } = useMessages();
+
+  const handleResetNodeDb = () => {
+    connection?.resetNodes().then(() => {
+      deleteAllMessages();
+      removeAllNodeErrors();
+      removeAllNodes(true);
+    });
+  };
+
+  return (
+    <DialogWrapper
+      open={open}
+      onOpenChange={onOpenChange}
+      type="confirm"
+      variant="destructive"
+      title={t("resetNodeDb.title")}
+      description={t("resetNodeDb.description")}
+      confirmText={t("resetNodeDb.confirm")}
+      onConfirm={handleResetNodeDb}
+    />
+  );
+};

--- a/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.tsx
+++ b/packages/web/src/components/Dialog/ResetNodeDbDialog/ResetNodeDbDialog.tsx
@@ -1,3 +1,4 @@
+import { toast } from "@core/hooks/useToast.ts";
 import { useDevice, useMessages, useNodeDB } from "@core/stores";
 import { useTranslation } from "react-i18next";
 import { DialogWrapper } from "../DialogWrapper.tsx";
@@ -17,11 +18,19 @@ export const ResetNodeDbDialog = ({
   const { deleteAllMessages } = useMessages();
 
   const handleResetNodeDb = () => {
-    connection?.resetNodes().then(() => {
-      deleteAllMessages();
-      removeAllNodeErrors();
-      removeAllNodes(true);
-    });
+    connection
+      ?.resetNodes()
+      .catch((error) => {
+        toast({
+          title: t("resetNodeDb.failedTitle"),
+        });
+        console.error("Failed to reset Node DB:", error);
+      })
+      .finally(() => {
+        deleteAllMessages();
+        removeAllNodeErrors();
+        removeAllNodes(true);
+      });
   };
 
   return (

--- a/packages/web/src/core/stores/deviceStore/index.ts
+++ b/packages/web/src/core/stores/deviceStore/index.ts
@@ -57,6 +57,10 @@ export interface Device {
     deleteMessages: boolean;
     managedMode: boolean;
     clientNotification: boolean;
+    resetNodeDb: boolean;
+    clearAllStores: boolean;
+    factoryResetDevice: boolean;
+    factoryResetConfig: boolean;
   };
   clientNotifications: Protobuf.Mesh.ClientNotification[];
 
@@ -166,6 +170,10 @@ export const useDeviceStore = createStore<PrivateDeviceState>((set, get) => ({
             deleteMessages: false,
             managedMode: false,
             clientNotification: false,
+            resetNodeDb: false,
+            clearAllStores: false,
+            factoryResetDevice: false,
+            factoryResetConfig: false,
           },
           pendingSettingsChanges: false,
           messageDraft: "",

--- a/packages/web/src/core/stores/index.ts
+++ b/packages/web/src/core/stores/index.ts
@@ -30,6 +30,9 @@ export {
   useSidebar, // TODO: Bring hook into this file
 } from "@core/stores/sidebarStore";
 
+// Re-export idb-keyval functions for clearing all stores, expand this if we add more local storage types
+export { clear as clearAllStores } from "idb-keyval";
+
 // Define hooks to access the stores
 export const useNodeDB = bindStoreToDevice(
   useNodeDBStore,


### PR DESCRIPTION
## Description
This PR adds dialogs for actions that trigger resets or clearing of data. Also implements a "Clear All Local Storage" feature and ensures relevant actions also clear message store.

## Related Issues

## Changes Made
- Introduces new dialog components: `ResetNodeDbDialog`, `ClearAllStoresDialog`, `FactoryResetDeviceDialog`, and `FactoryResetConfigDialog` using the new `DialogWrapper`.
- Adds a "Clear All Local Storage" option to the command palette.
- Updates the device store to include boolean flags for the new dialogs.
- Updates i18n files with new dialog titles and descriptions.
- Moves the `resetNodes`, `factoryResetDevice`, and `factoryResetConfig` actions from the command palette into confirmation dialogs, preventing unintentional actions.
- The `clearAllStores` action clears all stores and reloads the app.

## Testing Done
New unit tests were added for `ClearAllStoresDialog`, `FactoryResetConfigDialog`, `FactoryResetDeviceDialog`, and `ResetNodeDbDialog` to verify destructive functionality.

## Screenshots (if applicable)
<img width="553" height="266" alt="Screenshot From 2025-09-15 23-10-12" src="https://github.com/user-attachments/assets/42b611c3-632e-4bec-a11a-92f810b5f749" />



## Checklist



- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [x] Tests have been added or updated
- [x] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)