### PR TITLE
fix: Added all_tags=nightly to Update nightly.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,6 +79,7 @@ jobs:
           # Outputs
           echo "moving_tag=nightly"            >> "$GITHUB_OUTPUT"
           echo "immutable_tag=${IMMUTABLE}"    >> "$GITHUB_OUTPUT"
+          echo "all_tags=nightly ${IMMUTABLE}" >> "$GITHUB_OUTPUT"
           echo "created=${ISO_CREATED}"            >> "$GITHUB_OUTPUT"
           echo "Resolved tags: nightly and ${IMMUTABLE}"
 


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
-->
-Issue: nightly-build-and-push
❌ All tags were not found in either Podman image storage, or Docker image storage. Tag "ghcr.io/meshtastic/web:" not found in Podman image storage, and tag "ghcr.io/meshtastic/web:" not found in Docker image storage.


## Related Issues

<!--
-->


## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

-Included  echo "all_tags=nightly ${IMMUTABLE}" >> "$GITHUB_OUTPUT"


## Testing Done

<!--
No testing was done. 
-->

## Screenshots (if applicable)

<!--
N/A
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [x] Code follows project style guidelines
- [x] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
