### PR TITLE
Restored user's node to ui (messages/node list)

### DIFF
--- a/packages/web/src/core/stores/nodeDBStore/index.ts
+++ b/packages/web/src/core/stores/nodeDBStore/index.ts
@@ -41,7 +41,7 @@ export interface NodeDB {
     filter?: (node: Protobuf.Mesh.NodeInfo) => boolean,
     includeSelf?: boolean,
   ) => Protobuf.Mesh.NodeInfo[];
-  getMyNode: () => Protobuf.Mesh.NodeInfo;
+  getMyNode: () => Protobuf.Mesh.NodeInfo | undefined;
 
   getNodeError: (nodeNum: number) => NodeError | undefined;
   hasNodeError: (nodeNum: number) => boolean;

--- a/packages/web/src/core/stores/nodeDBStore/index.ts
+++ b/packages/web/src/core/stores/nodeDBStore/index.ts
@@ -41,7 +41,7 @@ export interface NodeDB {
     filter?: (node: Protobuf.Mesh.NodeInfo) => boolean,
     includeSelf?: boolean,
   ) => Protobuf.Mesh.NodeInfo[];
-  getMyNode: () => Protobuf.Mesh.NodeInfo | undefined;
+  getMyNode: () => Protobuf.Mesh.NodeInfo;
 
   getNodeError: (nodeNum: number) => NodeError | undefined;
   hasNodeError: (nodeNum: number) => boolean;

--- a/packages/web/src/pages/Messages.tsx
+++ b/packages/web/src/pages/Messages.tsx
@@ -130,7 +130,7 @@ export const MessagesPage = () => {
           true,
           channelValue,
         );
-        if (messageId !== undefined && getMyNode() !== undefined) {
+        if (messageId !== undefined) {
           if (chatType === MessageType.Broadcast) {
             setMessageState({
               type: MessageType.Broadcast,

--- a/packages/web/src/pages/Messages.tsx
+++ b/packages/web/src/pages/Messages.tsx
@@ -100,7 +100,7 @@ export const MessagesPage = () => {
         longName.includes(lowerCaseSearchTerm) ||
         shortName.includes(lowerCaseSearchTerm)
       );
-    })
+    }, true)
       .map((node: Protobuf.Mesh.NodeInfo) => ({
         ...node,
         unreadCount: getUnreadCount(node.num) ?? 0,
@@ -130,7 +130,7 @@ export const MessagesPage = () => {
           true,
           channelValue,
         );
-        if (messageId !== undefined) {
+        if (messageId !== undefined && getMyNode() !== undefined) {
           if (chatType === MessageType.Broadcast) {
             setMessageState({
               type: MessageType.Broadcast,

--- a/packages/web/src/pages/Nodes/index.tsx
+++ b/packages/web/src/pages/Nodes/index.tsx
@@ -67,7 +67,7 @@ const NodesPage = (): JSX.Element => {
   // subscribe to actual data (nodes array) and to nodeErrors ref for badge updates
   const { nodes: filteredNodes, hasNodeError } = useNodeDB(
     (db) => ({
-      nodes: db.getNodes(predicate, false),
+      nodes: db.getNodes(predicate, true),
       hasNodeError: db.hasNodeError,
       _errorsRef: db.nodeErrors, // include the Map ref so UI also re-renders on error changes
     }),


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

This PR restore the users own node to both the messages screen and the node list. There has been debate if it should be listed and this PR has determined going forwards all nodes including the node you are connected to will be visible in the UI. 

## Related Issues
Fixes #870 

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

- Flipped boolean in Node store to include "self" which is the node you are currently connected to. 
- Added undefined check in Messages to resolve some TypeScript errors.

## Testing Done
Opened the webUI and determined the node you are connected to is favouriated and and at the top of the list. 

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
