### PR TITLE
Refactor CI workflow to remove Deno and add exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,25 +28,12 @@ jobs:
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
 
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Cache Deno dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/deno
-          key: ${{ runner.os }}-deno-${{ hashFiles('**/deno.lock', '**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-deno-
-
       - name: Cache pnpm dependencies
         uses: actions/cache@v4
         with:
           path: |
             ~/.pnpm-store
-            packages/web/node_modules
+            packages/*/node_modules
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
@@ -55,14 +42,25 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Add package folders you want to exclude here (space-separated)
+          EXCLUDED_DIRS=("packages/protobufs")
+
           for pkg_dir in packages/*/; do
             pkg_dir=${pkg_dir%/}  # Remove trailing slash
             echo "🔍 Inspecting $pkg_dir..."
 
-            if [[ -f "$pkg_dir/package.json" ]] && [[ "$pkg_dir" != "packages/web" ]]; then
+            # Check if directory is excluded
+            if [[ " ${EXCLUDED_DIRS[*]} " == *" $pkg_dir "* ]]; then
+              echo "🚫 Skipping $pkg_dir (excluded)"
+              continue
+            fi
+
+            # Build only if it has a package.json
+            if [[ -f "$pkg_dir/package.json" ]]; then
               echo "🔧 Building with pnpm: $pkg_dir"
               (cd "$pkg_dir" && pnpm install --frozen-lockfile && pnpm run build:npm)
             else
-              echo "⚠️ Skipping $pkg_dir (web package or no package.json)"
+              echo "⚠️ Skipping $pkg_dir (no package.json)"
             fi
           done
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           set -euo pipefail
 
           # Add package folders you want to exclude here (space-separated)
-          EXCLUDED_DIRS=("packages/protobufs")
+          EXCLUDED_DIRS=("packages/protobufs" "packages/transport-deno")
 
           for pkg_dir in packages/*/; do
             pkg_dir=${pkg_dir%/}  # Remove trailing slash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -28,39 +28,52 @@ jobs:
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
 
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.pnpm-store
-            packages/*/node_modules
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+      - name: Prewarm & Install (workspace)
+        run: |
+          set -euo pipefail
+          pnpm fetch
+          pnpm install --frozen-lockfile --offline
 
-      - name: Build All Packages
+      - name: Build All Packages (with exclusions)
+        shell: bash
         run: |
           set -euo pipefail
 
-          # Add package folders you want to exclude here (space-separated)
+          # List packages to exclude (full paths under repo root)
           EXCLUDED_DIRS=("packages/protobufs" "packages/transport-deno")
 
-          for pkg_dir in packages/*/; do
-            pkg_dir=${pkg_dir%/}  # Remove trailing slash
-            echo "🔍 Inspecting $pkg_dir..."
+          is_excluded() {
+            local dir="$1"
+            for ex in "${EXCLUDED_DIRS[@]}"; do
+              if [[ "$dir" == "$ex" ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
 
-            # Check if directory is excluded
-            if [[ " ${EXCLUDED_DIRS[*]} " == *" $pkg_dir "* ]]; then
+          for pkg_dir in packages/*/; do
+            pkg_dir="${pkg_dir%/}"  # trim trailing slash
+
+            # Must be a directory with a package.json
+            if [[ ! -f "$pkg_dir/package.json" ]]; then
+              echo "⚠️  Skipping $pkg_dir (no package.json)"
+              continue
+            fi
+
+            # Allow for exclusions
+            if is_excluded "$pkg_dir"; then
               echo "🚫 Skipping $pkg_dir (excluded)"
               continue
             fi
 
-            # Build only if it has a package.json
-            if [[ -f "$pkg_dir/package.json" ]]; then
-              echo "🔧 Building with pnpm: $pkg_dir"
-              (cd "$pkg_dir" && pnpm install --frozen-lockfile && pnpm run build:npm)
-            else
-              echo "⚠️ Skipping $pkg_dir (no package.json)"
+            # Optionally skip Deno-first packages automatically
+            if [[ -f "$pkg_dir/deno.json" || -f "$pkg_dir/deno.jsonc" ]]; then
+              echo "🦕 Skipping $pkg_dir (deno project)"
+              continue
             fi
-          done
 
+            echo "🔧 Building: $pkg_dir"
+            # No per-package install needed; workspace install already done
+            pnpm -C "$pkg_dir" run build:npm
+          done


### PR DESCRIPTION
Removed Deno setup and caching from CI workflow. Added exclusion logic for specific package directories during the build process.

<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This PR cleans up the CI workflow a bit, removing deno specific references as no packages require the deno runtime.

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
