### PR TITLE
feat(ci): add CI workflow to automatically close issue after 60 days

### DIFF
--- a/.github/workflows/inactive-issue.yml
+++ b/.github/workflows/inactive-issue.yml
@@ -1,7 +1,7 @@
 name: Close inactive issues
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "0 6 * * *"
 
 jobs:
   close-issues:

--- a/.github/workflows/inactive-issue.yml
+++ b/.github/workflows/inactive-issue.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request introduces a new GitHub Actions workflow to automatically manage inactive issues in the repository. The workflow uses the `actions/stale` action to mark issues as stale after a period of inactivity and close them if there is no further activity.

Automated issue management:

* Added `.github/workflows/inactive-issue.yml` to schedule a job that marks issues as stale after 60 days of inactivity and closes them 14 days later if still inactive, using `actions/stale@v10`.
* Configured the workflow to run daily at 1:30 AM UTC and to only affect issues, not pull requests.
* Customized the labels and messages for stale and closed issues to provide clear communication to contributors.

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
