### PR TITLE
Update inactive issue workflow schedule and settings

### DIFF
--- a/.github/workflows/inactive-issue.yml
+++ b/.github/workflows/inactive-issue.yml
@@ -1,8 +1,8 @@
 name: Close inactive issues
 on:
   schedule:
-    - cron: "0 6 * * *"
-
+    - cron: "0 */4 * * *" # every 4 hours
+  workflow_dispatch: #allow manual runs
 jobs:
   close-issues:
     runs-on: ubuntu-latest
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 60
           days-before-issue-close: 14
           stale-issue-label: "stale"
@@ -19,4 +20,5 @@ jobs:
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-issue-labels: "Bug"
+          remove-stale-when-updated: true

--- a/.github/workflows/inactive-issue.yml
+++ b/.github/workflows/inactive-issue.yml
@@ -2,7 +2,7 @@ name: Close inactive issues
 on:
   schedule:
     - cron: "0 */4 * * *" # every 4 hours
-  workflow_dispatch: #allow manual runs
+  workflow_dispatch: # allow manual runs
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request updates the `.github/workflows/inactive-issue.yml` workflow to improve how inactive issues are managed. The main changes include increasing the frequency of the workflow, allowing manual runs, and refining how issues are marked and closed.

**Workflow configuration improvements:**

* Increased the workflow schedule to run every 4 hours instead of once daily, ensuring inactive issues are processed more frequently.
* Added `workflow_dispatch` to allow manual triggering of the workflow.

**Issue management enhancements:**

* Restricted stale issue processing to issues labeled "Bug" only, making the workflow more targeted.
* Enabled automatic removal of the "stale" label when an issue is updated, preventing premature closure of active discussions.

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [ ] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
