### PR TITLE
Fix description for historyReturnWindow

### DIFF
--- a/packages/web/public/i18n/locales/be-BY/moduleConfig.json
+++ b/packages/web/public/i18n/locales/be-BY/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Return records from this time window (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/bg-BG/moduleConfig.json
+++ b/packages/web/public/i18n/locales/bg-BG/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Return records from this time window (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/cs-CZ/moduleConfig.json
+++ b/packages/web/public/i18n/locales/cs-CZ/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Return records from this time window (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/de-DE/moduleConfig.json
+++ b/packages/web/public/i18n/locales/de-DE/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "Zeitraum Rückgabewert",
-			"description": "Maximale Anzahl an zurückzugebenden Datensätzen"
+			"description": "Datensätze aus diesem Zeitfenster zurückgeben (Minuten)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/en/moduleConfig.json
+++ b/packages/web/public/i18n/locales/en/moduleConfig.json
@@ -398,7 +398,7 @@
     },
     "historyReturnWindow": {
       "label": "History return window",
-      "description": "Max number of records to return"
+      "description": "Return records from this time window (minutes)"
     }
   },
   "telemetry": {

--- a/packages/web/public/i18n/locales/es-ES/moduleConfig.json
+++ b/packages/web/public/i18n/locales/es-ES/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Devolver registros de esta ventana de tiempo (minutos)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/fi-FI/moduleConfig.json
+++ b/packages/web/public/i18n/locales/fi-FI/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "Historian aikamäärä",
-			"description": "Enimmäismäärä tietueita palautettaviksi"
+			"description": "Palauta tietueet tästä aikaikkunasta (minuutit)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/fr-FR/moduleConfig.json
+++ b/packages/web/public/i18n/locales/fr-FR/moduleConfig.json
@@ -397,8 +397,8 @@
 			"description": "Nombre maximum d'enregistrements à retourner"
 		},
 		"historyReturnWindow": {
-			"label": "Fenêtre de retour d’historique",
-			"description": "Nombre maximum d'enregistrements à retourner"
+			"label": "Fenêtre de retour d'historique",
+			"description": "Retourner les enregistrements de cette fenêtre de temps (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/hu-HU/moduleConfig.json
+++ b/packages/web/public/i18n/locales/hu-HU/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "Előzmény-visszaadás időablak",
-			"description": "Max number of records to return"
+			"description": "Return records from this time window (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/it-IT/moduleConfig.json
+++ b/packages/web/public/i18n/locales/it-IT/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "Finestra di ritorno cronologia",
-			"description": "Numero massimo di record da restituire"
+			"description": "Restituisce i record da questa finestra temporale (minuti)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/ja-JP/moduleConfig.json
+++ b/packages/web/public/i18n/locales/ja-JP/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "リクエスト可能な履歴の期間  (分)",
-			"description": "Max number of records to return"
+			"description": "この時間枠内の記録を返す（分）"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/ko-KR/moduleConfig.json
+++ b/packages/web/public/i18n/locales/ko-KR/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Return records from this time window (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/nl-NL/moduleConfig.json
+++ b/packages/web/public/i18n/locales/nl-NL/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Retourneer records uit dit tijdvenster (minuten)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/pl-PL/moduleConfig.json
+++ b/packages/web/public/i18n/locales/pl-PL/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Return records from this time window (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/pt-BR/moduleConfig.json
+++ b/packages/web/public/i18n/locales/pt-BR/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "Janela de retorno do histórico",
-			"description": "Max number of records to return"
+			"description": "Retornar registros desta janela de tempo (minutos)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/pt-PT/moduleConfig.json
+++ b/packages/web/public/i18n/locales/pt-PT/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Return records from this time window (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/sv-SE/moduleConfig.json
+++ b/packages/web/public/i18n/locales/sv-SE/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "Returfönstrets storlek för historik",
-			"description": "Maximalt antal poster att returnera"
+			"description": "Returnera poster från detta tidsfönster (minuter)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/tr-TR/moduleConfig.json
+++ b/packages/web/public/i18n/locales/tr-TR/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "Geçmiş geri dönüş penceresi",
-			"description": "Max number of records to return"
+			"description": "Bu zaman penceresinden kayıtları döndür (dakika)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/uk-UA/moduleConfig.json
+++ b/packages/web/public/i18n/locales/uk-UA/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "History return window",
-			"description": "Max number of records to return"
+			"description": "Return records from this time window (minutes)"
 		}
 	},
 	"telemetry": {

--- a/packages/web/public/i18n/locales/zh-CN/moduleConfig.json
+++ b/packages/web/public/i18n/locales/zh-CN/moduleConfig.json
@@ -398,7 +398,7 @@
 		},
 		"historyReturnWindow": {
 			"label": "历史记录返回窗口",
-			"description": "Max number of records to return"
+			"description": "返回此时间窗口内的记录（分钟）"
 		}
 	},
 	"telemetry": {


### PR DESCRIPTION
## Description
Description for this setting was wrong. It's not number of records but the time window to return from.

## Changes Made

Fixed the description

## Testing Done

Didn't test it!

- [x] Code follows project style guidelines
- [x] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
