### PR TITLE
fix: implement device connection redirect to home

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -9,8 +9,9 @@ import Footer from "@components/UI/Footer.tsx";
 import { useTheme } from "@core/hooks/useTheme.ts";
 import { SidebarProvider, useAppStore, useDeviceStore } from "@core/stores";
 import { Dashboard } from "@pages/Dashboard/index.tsx";
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useNavigate } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { useEffect, useRef } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { MapProvider } from "react-map-gl/maplibre";
 
@@ -18,11 +19,27 @@ export function App() {
   const { getDevice } = useDeviceStore();
   const { selectedDeviceId, setConnectDialogOpen, connectDialogOpen } =
     useAppStore();
+  const navigate = useNavigate();
+  const previousDeviceRef = useRef(getDevice(selectedDeviceId));
 
   const device = getDevice(selectedDeviceId);
 
   // Sets up light/dark mode based on user preferences or system settings
   useTheme();
+
+  // Redirect to home when a device connects
+  useEffect(() => {
+    const previousDevice = previousDeviceRef.current;
+
+    // Check if device just became available (went from undefined to defined)
+    if (!previousDevice && device) {
+      console.log("Device connected, redirecting to home");
+      navigate({ to: "/", replace: true });
+    }
+
+    // Update the ref for next comparison
+    previousDeviceRef.current = device;
+  }, [device, navigate]);
 
   return (
     <ErrorBoundary FallbackComponent={ErrorPage}>


### PR DESCRIPTION
## Description

This fixes possible invalid paths when the user refreshes the page and connects to a device. For example, `/messages/direct/1793492304` may not be available on the connected device, thus causing the app to crash with an error screen.

## Changes Made

Fixed to redirect to `/` upon successful connection to device.

## Testing Done

1. Connect to a device
2. Navigate to a specific node's messages
3. Refresh the browser
4. Connect to a device again

Without this fix, there will be an error. With this fix, it will redirect to `/`


## Checklist

- [x ] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
