### PR TITLE
fix: add @serialport/bindings-cpp to onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,15 @@
     "tslog": "^4.9.3"
   },
   "devDependencies": {
-    "@types/node": "^24.3.1",
     "@biomejs/biome": "2.2.4",
+    "@types/node": "^24.3.1",
     "tsdown": "^0.15.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@serialport/bindings-cpp",
       "@tailwindcss/oxide",
       "core-js",
       "esbuild",


### PR DESCRIPTION
I think this trusted dep was missing. When I ran `pnpm i` it complained.