### PR TITLE
fix: redirect to `/` on disconnect

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,8 +11,10 @@ import { SidebarProvider, useAppStore, useDeviceStore } from "@core/stores";
 import { Dashboard } from "@pages/Dashboard/index.tsx";
 import { Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { MapProvider } from "react-map-gl/maplibre";
+import { Types } from "@meshtastic/core";
 
 export function App() {
   const { getDevice } = useDeviceStore();
@@ -23,6 +25,24 @@ export function App() {
 
   // Sets up light/dark mode based on user preferences or system settings
   useTheme();
+
+  // Redirect to home when device disconnects
+  useEffect(() => {
+    if (!device?.connection) return;
+
+    const handleDisconnect = (status: Types.DeviceStatusEnum) => {
+      if (status === Types.DeviceStatusEnum.DeviceDisconnected) {
+        console.log("Device disconnected, redirecting to home");
+        window.location.href = "/";
+      }
+    };
+
+    device.connection.events.onDeviceStatus.subscribe(handleDisconnect);
+
+    return () => {
+      device.connection?.events.onDeviceStatus.unsubscribe(handleDisconnect);
+    };
+  }, [device]);
 
   return (
     <ErrorBoundary FallbackComponent={ErrorPage}>


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

This fix monitors for device disconnects and redirects back to `/` on disconnect. This seems reasonable since there is nothing to do but refresh the page anyway. Reconnections aren't possible.

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

- monitor for device disconnect and adjust `window.location`


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [x] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
