### PR TITLE
fix: use correct deprecated GPS coordinate format enum

### DIFF
--- a/packages/web/src/components/PageComponents/Settings/Display.tsx
+++ b/packages/web/src/components/PageComponents/Settings/Display.tsx
@@ -50,6 +50,10 @@ export const Display = ({ onFormInit }: DisplayConfigProps) => {
                 suffix: t("unit.second.plural"),
               },
             },
+            // TODO: This field is deprecated since protobufs 2.7.4 and only has UNUSED=0 value.
+            // GPS format has been moved to DeviceUIConfig.gps_format with proper enum values (DEC, DMS, UTM, MGRS, OLC, OSGR, MLS).
+            // This should be removed once DeviceUI settings are implemented.
+            // See: packages/protobufs/meshtastic/device_ui.proto
             {
               type: "select",
               name: "gpsFormat",
@@ -57,7 +61,7 @@ export const Display = ({ onFormInit }: DisplayConfigProps) => {
               description: t("display.gpsDisplayUnits.description"),
               properties: {
                 enumValue:
-                  Protobuf.Config.Config_DisplayConfig_GpsCoordinateFormat,
+                  Protobuf.Config.Config_DisplayConfig_DeprecatedGpsCoordinateFormat,
               },
             },
             {


### PR DESCRIPTION
## Description

Fixes a build error where `Config_DisplayConfig_GpsCoordinateFormat` was being imported but doesn't exist in the @meshtastic/protobufs package. The correct export is `Config_DisplayConfig_DeprecatedGpsCoordinateFormat`, which matches what's already used in the validation schema.

Additionally, added documentation explaining that this field is deprecated since protobufs 2.7.4 and should be migrated to `DeviceUIConfig.gps_format` when DeviceUI settings are implemented.

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made

- Fixed import error by using `Config_DisplayConfig_DeprecatedGpsCoordinateFormat` instead of the non-existent `Config_DisplayConfig_GpsCoordinateFormat`
- Added TODO comment documenting the deprecation and migration path to DeviceUIConfig
- Comment includes reference to the proto file and lists the new enum values (DEC, DMS, UTM, MGRS, OLC, OSGR, MLS)

## Testing Done

- Build error is resolved
- The field continues to work with the deprecated enum until DeviceUI migration is complete
- Verified the validation schema already uses the same deprecated enum

## Screenshots (if applicable)

N/A - This is a build fix with no UI changes

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
