### PR TITLE
fix(connection): support port on HTTP connection

### DIFF
--- a/packages/web/src/components/Dialog/AddConnectionDialog/validation.ts
+++ b/packages/web/src/components/Dialog/AddConnectionDialog/validation.ts
@@ -4,24 +4,43 @@ export const urlOrIpv4Schema = z
   .string()
   .trim()
   .refine((val) => {
-    const input = val.replace(/^https?:\/\//i, ""); // remove protocol for validation
+    const input = val.replace(/^https?:\/\//i, "");
+
+    // Split input into host and port (port is optional)
+    const lastColonIndex = input.lastIndexOf(":");
+    let host = input;
+    let port = null;
+
+    if (lastColonIndex !== -1) {
+      const potentialPort = input.substring(lastColonIndex + 1);
+      if (/^\d+$/.test(potentialPort)) {
+        host = input.substring(0, lastColonIndex);
+        port = parseInt(potentialPort, 10);
+      }
+    }
+
+    // Validate port if present
+    if (port !== null) {
+      // Must be 2-5 digits and between 10-65535
+      if (port < 10 || port > 65535) {
+        return false;
+      }
+    }
 
     // IPv4 pattern
     const ipv4Regex =
       /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/;
-
     // Domain pattern (e.g. example.com, meshtastic.local)
     const domainRegex = /^(?!-)(?:[a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,}$/;
-
     // Local domain (e.g. meshtastic.local)
     const localDomainRegex = /^(?!-)[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*\.local$/;
 
     return (
-      ipv4Regex.test(input) ||
-      domainRegex.test(input) ||
-      localDomainRegex.test(input)
+      ipv4Regex.test(host) ||
+      domainRegex.test(host) ||
+      localDomainRegex.test(host)
     );
-  }, "Must be a valid IPv4 address or domain name")
+  }, "Must be a valid IPv4 address or domain name with optional port (10-65535)")
   .transform((val) => {
     return /^https?:\/\//i.test(val) ? val : `http://${val}`;
   });


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request improves the validation logic for user input in the `AddConnectionDialog` by allowing optional port numbers in IPv4 addresses and domain names, and by enforcing stricter port validation. The changes ensure that if a port is provided, it must be numeric and within the range 10–65535.

Validation improvements:

* Enhanced the `urlOrIpv4Schema` validation in `validation.ts` to support optional port numbers in the input; the port is now parsed and validated to ensure it is numeric and between 10 and 65535.
* Updated validation logic to check only the host portion (excluding the port) against IPv4 and domain name patterns, improving accuracy when ports are present.
* Improved the validation error message to clarify that an optional port (10–65535) is allowed.


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
