### PR TITLE
Fix(config) track config changes for position flags

### DIFF
--- a/packages/web/src/components/PageComponents/Settings/Position.tsx
+++ b/packages/web/src/components/PageComponents/Settings/Position.tsx
@@ -44,7 +44,7 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
     );
   };
 
-  const onPositonFlagChange = useCallback(
+  const onPositionFlagChange = useCallback(
     (name: string) => {
       const newFlagsValue = flagsValue ^ FLAGS_CONFIG[name as FlagName].value;
       toggleFlag(name as FlagName);

--- a/packages/web/src/components/PageComponents/Settings/Position.tsx
+++ b/packages/web/src/components/PageComponents/Settings/Position.tsx
@@ -8,6 +8,7 @@ import {
   type DynamicFormFormInit,
 } from "@components/Form/DynamicForm.tsx";
 import {
+  FLAGS_CONFIG,
   type FlagName,
   usePositionFlags,
 } from "@core/hooks/usePositionFlags.ts";
@@ -45,9 +46,25 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
 
   const onPositonFlagChange = useCallback(
     (name: string) => {
-      return toggleFlag(name as FlagName);
+      const newFlagsValue = flagsValue ^ FLAGS_CONFIG[name as FlagName].value;
+      toggleFlag(name as FlagName);
+
+      // Immediately register the change in the ChangeRegistry
+      const formData = getEffectiveConfig("position");
+      if (formData) {
+        const payload = { ...formData, positionFlags: newFlagsValue };
+        if (deepCompareConfig(config.position, payload, true)) {
+          removeChange({ type: "config", variant: "position" });
+        } else {
+          setChange(
+            { type: "config", variant: "position" },
+            payload,
+            config.position,
+          );
+        }
+      }
     },
-    [toggleFlag],
+    [toggleFlag, flagsValue, getEffectiveConfig, config.position, removeChange, setChange],
   );
 
   return (

--- a/packages/web/src/components/PageComponents/Settings/Position.tsx
+++ b/packages/web/src/components/PageComponents/Settings/Position.tsx
@@ -64,7 +64,14 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
         }
       }
     },
-    [toggleFlag, flagsValue, getEffectiveConfig, config.position, removeChange, setChange],
+    [
+      toggleFlag,
+      flagsValue,
+      getEffectiveConfig,
+      config.position,
+      removeChange,
+      setChange,
+    ],
   );
 
   return (

--- a/packages/web/src/core/stores/deviceStore/changeRegistry.ts
+++ b/packages/web/src/core/stores/deviceStore/changeRegistry.ts
@@ -151,6 +151,23 @@ export function getConfigChangeCount(registry: ChangeRegistry): number {
 }
 
 /**
+ * Get count of config changes for specific variants
+ */
+export function getConfigChangeCountForVariants(
+  registry: ChangeRegistry,
+  variants: ValidConfigType[],
+): number {
+  let count = 0;
+  for (const keyStr of registry.changes.keys()) {
+    const key = deserializeKey(keyStr);
+    if (key.type === "config" && variants.includes(key.variant)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
  * Get count of module config changes
  */
 export function getModuleConfigChangeCount(registry: ChangeRegistry): number {

--- a/packages/web/src/core/stores/deviceStore/index.ts
+++ b/packages/web/src/core/stores/deviceStore/index.ts
@@ -18,6 +18,7 @@ import {
   getAllModuleConfigChanges,
   getChannelChangeCount,
   getConfigChangeCount,
+  getConfigChangeCountForVariants,
   getModuleConfigChangeCount,
   hasChannelChange,
   hasConfigChange,
@@ -130,6 +131,7 @@ export interface Device extends DeviceData {
   hasChannelChange: (index: Types.ChannelNumber) => boolean;
   hasUserChange: () => boolean;
   getConfigChangeCount: () => number;
+  getConfigChangeCountForVariants: (variants: ValidConfigType[]) => number;
   getModuleConfigChangeCount: () => number;
   getChannelChangeCount: () => number;
   getAllConfigChanges: () => Protobuf.Config.Config[];
@@ -805,6 +807,15 @@ function deviceFactory(
       }
 
       return getConfigChangeCount(device.changeRegistry);
+    },
+
+    getConfigChangeCountForVariants: (variants: ValidConfigType[]) => {
+      const device = get().devices.get(id);
+      if (!device) {
+        return 0;
+      }
+
+      return getConfigChangeCountForVariants(device.changeRegistry, variants);
     },
 
     getModuleConfigChangeCount: () => {

--- a/packages/web/src/pages/Settings/index.tsx
+++ b/packages/web/src/pages/Settings/index.tsx
@@ -304,8 +304,8 @@ const ConfigPage = () => {
         disabled: saveDisabled,
         iconClasses:
           !rhfState.isValid && hasPending
-            ? "cursor-pointer"
-            : "text-red-400 cursor-not-allowed",
+            ? "text-red-400 cursor-not-allowed"
+            : "cursor-pointer",
         className: cn([
           "transition-opacity hover:bg-slate-200 disabled:hover:bg-white",
           "hover:dark:bg-slate-300 hover:dark:text-black",


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description
This pull request introduces improvements to how configuration changes are tracked and displayed in the settings pages. The main focus is on providing more granular counts for different types of configuration changes (radio, device, module, channel, and user), updating the UI to reflect these counts accurately, and ensuring immediate registration of position flag changes. These changes enhance the accuracy and clarity of change tracking, especially when saving or reviewing pending changes.

**Change Tracking Enhancements:**

* Added a new function `getConfigChangeCountForVariants` to count config changes for specific variants, and integrated it into the `deviceStore` and `useDevice` hooks for more granular tracking. [[1]](diffhunk://#diff-2978b38cf0b1b96c3c96954c4b68a20514f5136ce2569973dcc49eefc20b4355R153-R169) [[2]](diffhunk://#diff-c672505bd999d1da060b93539798f9b13207091a63232b4d0cc29af62ffeb033R21) [[3]](diffhunk://#diff-c672505bd999d1da060b93539798f9b13207091a63232b4d0cc29af62ffeb033R134) [[4]](diffhunk://#diff-c672505bd999d1da060b93539798f9b13207091a63232b4d0cc29af62ffeb033R812-R820) [[5]](diffhunk://#diff-92e603ea769f279c954b3687c288716fccfe3b2e9df63d3cafa6903bb27b7652R36-R39)
* Updated the settings page logic to separately count radio config, device config (including user changes), module config, and channel changes, and to display these counts in the navigation sidebar for each section. [[1]](diffhunk://#diff-92e603ea769f279c954b3687c288716fccfe3b2e9df63d3cafa6903bb27b7652L49-R66) [[2]](diffhunk://#diff-92e603ea769f279c954b3687c288716fccfe3b2e9df63d3cafa6903bb27b7652L60-R103)

**UI and UX Improvements:**

* Changed the logic for enabling/disabling the save button: it now only disables when saving or there are no pending changes, regardless of form validity.
* Fixed the save button's appearance logic to correctly reflect the pending state and form validity.

**Immediate Change Registration:**

* Modified the `onPositonFlagChange` callback in `Position.tsx` to immediately register position flag changes in the change registry, improving responsiveness and accuracy of change tracking. [[1]](diffhunk://#diff-15d9afa80bd1fddc9a3e816889ecf48b09866528bcc079b274735001c5491794L48-R74) [[2]](diffhunk://#diff-15d9afa80bd1fddc9a3e816889ecf48b09866528bcc079b274735001c5491794R11)



## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
