### PR TITLE
issue724: add connection name to doc title

### DIFF
--- a/packages/web/src/components/PageComponents/Map/Markers/NodeMarker.tsx
+++ b/packages/web/src/components/PageComponents/Map/Markers/NodeMarker.tsx
@@ -16,7 +16,6 @@ export const NodeMarker = memo(function NodeMarker({
   id,
   lng,
   lat,
-  label,
   longLabel,
   tooltipLabel,
   hasError,
@@ -29,7 +28,6 @@ export const NodeMarker = memo(function NodeMarker({
   id: number;
   lng: number;
   lat: number;
-  label: string;
   longLabel?: string;
   tooltipLabel?: string;
   hasError?: boolean;

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { SidebarButton } from "@components/UI/Sidebar/SidebarButton.tsx";
 import { SidebarSection } from "@components/UI/Sidebar/SidebarSection.tsx";
 import { Spinner } from "@components/UI/Spinner.tsx";
 import { Subtle } from "@components/UI/Typography/Subtle.tsx";
+import { useDocumentTitle } from "@core/hooks/useDocumentTitle.ts";
 import {
   type Page,
   useAppStore,
@@ -83,6 +84,8 @@ export const Sidebar = ({ children }: SidebarProps) => {
     savedConnections.find((c) => c.isDefault) ||
     savedConnections[0];
 
+  useDocumentTitle(activeConnection?.name ?? "");
+
   const pathname = useLocation({
     select: (location) => location.pathname.replace(/^\//, ""),
   });
@@ -116,14 +119,14 @@ export const Sidebar = ({ children }: SidebarProps) => {
     },
     { name: t("navigation.map"), icon: MapIcon, page: "map" },
     {
-      name: t("navigation.settings"),
-      icon: SettingsIcon,
-      page: "settings",
-    },
-    {
       name: `${t("navigation.nodes")} (${displayedNodeCount})`,
       icon: UsersIcon,
       page: "nodes",
+    },
+    {
+      name: t("navigation.settings"),
+      icon: SettingsIcon,
+      page: "settings",
     },
   ];
 

--- a/packages/web/src/core/hooks/useDocumentTitle.test.ts
+++ b/packages/web/src/core/hooks/useDocumentTitle.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useDocumentTitle } from "./useDocumentTitle.ts";
+
+describe("useDocumentTitle", () => {
+  const originalTitle = "Meshtastic";
+
+  beforeEach(() => {
+    document.title = originalTitle;
+  });
+
+  afterEach(() => {
+    document.title = originalTitle;
+  });
+
+  it("should stash the original document title on mount", () => {
+    renderHook(() => useDocumentTitle("Test"));
+    expect(document.title).toBe("Test - Meshtastic");
+  });
+
+  it("should prepend prefix to original title", () => {
+    renderHook(() => useDocumentTitle("My Connection"));
+    expect(document.title).toBe("My Connection - Meshtastic");
+  });
+
+  it("should restore original title when prefix is empty", () => {
+    renderHook(() => useDocumentTitle(""));
+    expect(document.title).toBe(originalTitle);
+  });
+
+  it("should restore original title on unmount", () => {
+    const { unmount } = renderHook(() => useDocumentTitle("Test"));
+    expect(document.title).toBe("Test - Meshtastic");
+
+    unmount();
+    expect(document.title).toBe(originalTitle);
+  });
+
+  it("should update document title when prefix changes", () => {
+    const { rerender } = renderHook(
+      ({ prefix }) => useDocumentTitle(prefix),
+      {
+        initialProps: { prefix: "Connection 1" },
+      },
+    );
+
+    expect(document.title).toBe("Connection 1 - Meshtastic");
+
+    rerender({ prefix: "Connection 2" });
+    expect(document.title).toBe("Connection 2 - Meshtastic");
+  });
+
+  it("should not update document title if computed title hasn't changed", () => {
+    const { rerender } = renderHook(
+      ({ prefix }) => useDocumentTitle(prefix),
+      {
+        initialProps: { prefix: "Test" },
+      },
+    );
+
+    const titleBefore = document.title;
+    rerender({ prefix: "Test" });
+    expect(document.title).toBe(titleBefore);
+  });
+
+  it("should always use the original stashed title from initial mount", () => {
+    document.title = "Meshtastic";
+
+    const { unmount: unmount1 } = renderHook(() =>
+      useDocumentTitle("First"),
+    );
+    expect(document.title).toBe("First - Meshtastic");
+
+    unmount1();
+    expect(document.title).toBe("Meshtastic");
+
+    // Second mount should use the restored original title
+    const { unmount: unmount2 } = renderHook(() =>
+      useDocumentTitle("Second"),
+    );
+    expect(document.title).toBe("Second - Meshtastic");
+
+    unmount2();
+    expect(document.title).toBe("Meshtastic");
+  });
+
+  it("should handle switching from non-empty to empty prefix", () => {
+    const { rerender } = renderHook(
+      ({ prefix }) => useDocumentTitle(prefix),
+      {
+        initialProps: { prefix: "Connection" },
+      },
+    );
+
+    expect(document.title).toBe("Connection - Meshtastic");
+
+    rerender({ prefix: "" });
+    expect(document.title).toBe(originalTitle);
+  });
+
+  it("should handle switching from empty to non-empty prefix", () => {
+    const { rerender } = renderHook(
+      ({ prefix }) => useDocumentTitle(prefix),
+      {
+        initialProps: { prefix: "" },
+      },
+    );
+
+    expect(document.title).toBe(originalTitle);
+
+    rerender({ prefix: "Connection" });
+    expect(document.title).toBe("Connection - Meshtastic");
+  });
+});

--- a/packages/web/src/core/hooks/useDocumentTitle.ts
+++ b/packages/web/src/core/hooks/useDocumentTitle.ts
@@ -1,8 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useLayoutEffect } from "react";
 
 export function useDocumentTitle(prefix: string) {
-  const originalTitleRef = useRef<string>(document.title);
+  const originalTitleRef = useRef<string>("");
 
+  useLayoutEffect(() => {
+    originalTitleRef.current = document.title;
+  }, [prefix]);
   useEffect(() => {
     const newTitle = prefix
       ? `${prefix} - ${originalTitleRef.current}`

--- a/packages/web/src/core/hooks/useDocumentTitle.ts
+++ b/packages/web/src/core/hooks/useDocumentTitle.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from "react";
+
+export function useDocumentTitle(prefix: string) {
+  const originalTitleRef = useRef<string>(document.title);
+
+  useEffect(() => {
+    const newTitle = prefix
+      ? `${prefix} - ${originalTitleRef.current}`
+      : originalTitleRef.current;
+
+    // Skip if the computed title hasn't changed
+    if (document.title === newTitle) {
+      return;
+    }
+
+    document.title = newTitle;
+
+    return () => {
+      document.title = originalTitleRef.current;
+    };
+  }, [prefix]);
+}


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->
This pull request introduces a new hook to manage the document title dynamically based on the active connection and makes minor adjustments to the sidebar navigation and map marker components. The most notable change is the addition of the `useDocumentTitle` hook, which updates the browser tab title to reflect the current connection, improving user context. Additionally, the sidebar navigation order is tweaked, and an unused prop is removed from the map marker component.

**Document Title Management:**
- Added a new `useDocumentTitle` hook in `useDocumentTitle.ts` that updates the browser tab title based on a given prefix and restores the original title on cleanup.
- Integrated `useDocumentTitle` into the `Sidebar` component to set the document title to the active connection's name. [[1]](diffhunk://#diff-9f7203cea7dfe05bb4739f18e3e464760a91e8ecb417de4eb78642190d3ed212R5) [[2]](diffhunk://#diff-9f7203cea7dfe05bb4739f18e3e464760a91e8ecb417de4eb78642190d3ed212R87-R88)

**Sidebar Navigation Updates:**
- Adjusted the order of navigation items in the sidebar so that "Nodes" appears before "Settings."

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->
Fixes #724 

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

<img width="236" height="83" alt="image" src="https://github.com/user-attachments/assets/d17625b8-ec8a-40b3-bad6-19d56e96c73e" />

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [X] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
