### PR TITLE
Fix error handling by removing port.close()

### DIFF
--- a/packages/transport-node-serial/src/transport.ts
+++ b/packages/transport-node-serial/src/transport.ts
@@ -38,7 +38,6 @@ export class TransportNodeSerial implements Types.Transport {
       });
 
       const onError = (err: Error) => {
-        port.close();
         reject(err);
       };
 


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

<!--
Provide a clear and concise description of what this PR does. Explain the problem it solves or the feature it adds.
-->

At this stage of initialization, the port will never be open. When it opens, this error trigger is cancelled.

Trying to close the port will generate an exception.

If the user has an invalid or unreachable serial port , this exception will crash the script.

## Related Issues



<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

Just deleted the command.

## Testing Done

<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [ x] Code follows project style guidelines
- [ x] Documentation has been updated or added
- [ x] Tests have been added or updated
- [ x] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
