### PR TITLE
fix: interpolate longName and shortName in PKI backup download

### DIFF
--- a/packages/web/src/components/Dialog/PKIBackupDialog.tsx
+++ b/packages/web/src/components/Dialog/PKIBackupDialog.tsx
@@ -94,7 +94,11 @@ export const PkiBackupDialog = ({
     const decodedPublicKey = decodeKeyData(publicKey);
 
     const formattedContent = [
-      `${t("pkiBackup.header")}\n\n`,
+      `${t("pkiBackup.header", {
+        interpolation: { escapeValue: false },
+        shortName: getMyNode()?.user?.shortName ?? t("unknown.shortName"),
+        longName: getMyNode()?.user?.longName ?? t("unknown.longName"),
+      })}\n\n`,
       `${t("pkiBackup.privateKey")}\n`,
       decodedPrivateKey,
       `\n\n${t("pkiBackup.publicKey")}\n`,


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

When exporting the key backup file, the `{{longName}}` and `{{shortName}}` format strings appear in it literally, like this:

```
=== MESHTASTIC KEYS FOR {{longName}} ({{shortName}}) ===

Private Key:
<censored>

Public Key:
<censored>

=== END OF KEYS ===
```

## Changes Made

The fix simply replicates the behavior used elsewhere in PKIBackupDialog.

## Testing Done

Verified the format strings did not appear literally in the exported file.

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [x] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
