### PR TITLE
fix(ui): add "never" i18n string, fix "Favorite" tooltip

### DIFF
--- a/packages/web/public/i18n/locales/en/nodes.json
+++ b/packages/web/public/i18n/locales/en/nodes.json
@@ -47,6 +47,9 @@
       "direct": "Direct",
       "away": "away",
       "viaMqtt": ", via MQTT"
+    },
+    "lastHeardStatus": {
+      "never": "Never"
     }
   },
 

--- a/packages/web/src/components/UI/Avatar.tsx
+++ b/packages/web/src/components/UI/Avatar.tsx
@@ -4,6 +4,7 @@ import {
   Tooltip,
   TooltipArrow,
   TooltipContent,
+  TooltipPortal,
   TooltipProvider,
   TooltipTrigger,
 } from "@components/UI/Tooltip.tsx";
@@ -78,10 +79,12 @@ export const Avatar = ({
                 }}
               />
             </TooltipTrigger>
-            <TooltipContent className="bg-slate-800 dark:bg-slate-600 text-white px-4 py-1 rounded text-xs">
-              {t("nodeDetail.favorite.label", { ns: "nodes" })}
-              <TooltipArrow className="fill-slate-800 dark:fill-slate-600" />
-            </TooltipContent>
+            <TooltipPortal>
+                <TooltipContent className="bg-slate-800 dark:bg-slate-600 text-white px-4 py-1 rounded text-xs">
+                  {t("nodeDetail.favorite.label", { ns: "nodes" })}
+                  <TooltipArrow className="fill-slate-800 dark:fill-slate-600" />
+                </TooltipContent>
+            </TooltipPortal>
           </Tooltip>
         </TooltipProvider>
       ) : null}
@@ -94,10 +97,12 @@ export const Avatar = ({
                 aria-hidden="true"
               />
             </TooltipTrigger>
+            <TooltipPortal>
             <TooltipContent className="bg-slate-800 dark:bg-slate-600 text-white px-4 py-1 rounded text-xs">
               {t("nodeDetail.error.label", { ns: "nodes" })}
               <TooltipArrow className="fill-slate-800 dark:fill-slate-600" />
             </TooltipContent>
+              </TooltipPortal>
           </Tooltip>
         </TooltipProvider>
       ) : null}

--- a/packages/web/src/components/UI/Avatar.tsx
+++ b/packages/web/src/components/UI/Avatar.tsx
@@ -98,11 +98,11 @@ export const Avatar = ({
               />
             </TooltipTrigger>
             <TooltipPortal>
-            <TooltipContent className="bg-slate-800 dark:bg-slate-600 text-white px-4 py-1 rounded text-xs">
-              {t("nodeDetail.error.label", { ns: "nodes" })}
-              <TooltipArrow className="fill-slate-800 dark:fill-slate-600" />
-            </TooltipContent>
-              </TooltipPortal>
+              <TooltipContent className="bg-slate-800 dark:bg-slate-600 text-white px-4 py-1 rounded text-xs">
+                {t("nodeDetail.error.label", {ns: "nodes"})}
+                <TooltipArrow className="fill-slate-800 dark:fill-slate-600"/>
+              </TooltipContent>
+            </TooltipPortal>
           </Tooltip>
         </TooltipProvider>
       ) : null}

--- a/packages/web/src/components/UI/Avatar.tsx
+++ b/packages/web/src/components/UI/Avatar.tsx
@@ -80,10 +80,10 @@ export const Avatar = ({
               />
             </TooltipTrigger>
             <TooltipPortal>
-                <TooltipContent className="bg-slate-800 dark:bg-slate-600 text-white px-4 py-1 rounded text-xs">
-                  {t("nodeDetail.favorite.label", { ns: "nodes" })}
-                  <TooltipArrow className="fill-slate-800 dark:fill-slate-600" />
-                </TooltipContent>
+              <TooltipContent className="bg-slate-800 dark:bg-slate-600 text-white px-4 py-1 rounded text-xs">
+                {t("nodeDetail.favorite.label", { ns: "nodes" })}
+                <TooltipArrow className="fill-slate-800 dark:fill-slate-600" />
+              </TooltipContent>
             </TooltipPortal>
           </Tooltip>
         </TooltipProvider>
@@ -99,8 +99,8 @@ export const Avatar = ({
             </TooltipTrigger>
             <TooltipPortal>
               <TooltipContent className="bg-slate-800 dark:bg-slate-600 text-white px-4 py-1 rounded text-xs">
-                {t("nodeDetail.error.label", {ns: "nodes"})}
-                <TooltipArrow className="fill-slate-800 dark:fill-slate-600"/>
+                {t("nodeDetail.error.label", { ns: "nodes" })}
+                <TooltipArrow className="fill-slate-800 dark:fill-slate-600" />
               </TooltipContent>
             </TooltipPortal>
           </Tooltip>


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

In this PR 2 small issues are fixed:

1. In the node details window, if "Last Heard" is 0, the i18n key is displayed instead of the "Never" label.
2. In the nodes list, the "Favorite" tooltip appears too far away from the star icon when you hover over it.

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

- added i18n key
- added TooltipPortal around TooltipContent
-

## Testing Done

manual

## Screenshots (if applicable)

Before:
<img width=400 alt="изображение" src="https://github.com/user-attachments/assets/aef64348-e738-4282-9686-5ef46a83a7fb" /> <img  width=400 alt="изображение" src="https://github.com/user-attachments/assets/3a139408-4cdd-4826-9c9c-51f0bdf09a80" />
<hr>
After:

<img width=400 alt="изображение" src="https://github.com/user-attachments/assets/c64c59ca-7bbf-4e8d-9b3b-22c6db4d3274" /> <img width=400 alt="изображение" src="https://github.com/user-attachments/assets/bea4e2c9-34b2-4640-88d5-fbdda93507aa" />


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
