### PR TITLE
feat: received packets payload logging

### DIFF
--- a/packages/core/src/utils/transform/decodePacket.ts
+++ b/packages/core/src/utils/transform/decodePacket.ts
@@ -206,9 +206,11 @@ export const decodePacket = (device: MeshDevice) =>
             }
 
             case "queueStatus": {
+              // @ts-expect-error
+              delete decodedMessage.payloadVariant.value.$typeName;
               device.log.trace(
                 Types.Emitter[Types.Emitter.HandleFromRadio],
-                `🚧 Received Queue Status: ${decodedMessage.payloadVariant.value}`,
+                `🚧 Received Queue Status: ${JSON.stringify(decodedMessage.payloadVariant.value)}`,
               );
 
               device.events.onQueueStatus.dispatch(
@@ -266,6 +268,16 @@ export const decodePacket = (device: MeshDevice) =>
 
               device.events.onClientNotificationPacket.dispatch(
                 decodedMessage.payloadVariant.value,
+              );
+              break;
+            }
+
+            case "deviceuiConfig": {
+              // @ts-expect-error
+              delete decodedMessage.payloadVariant.value.$typeName;
+              device.log.trace(
+                Types.Emitter[Types.Emitter.HandleFromRadio],
+                `🔧 Received deviceuiConfig: ${JSON.stringify(decodedMessage.payloadVariant.value)}`,
               );
               break;
             }

--- a/packages/core/src/utils/transform/fromDevice.ts
+++ b/packages/core/src/utils/transform/fromDevice.ts
@@ -41,9 +41,8 @@ export const fromDeviceStream: () => TransformStream<Uint8Array, DeviceOutput> =
                 packet[malformedDetectorIndex + 1] === 0xc3
               ) {
                 console.warn(
-                  `⚠️ Malformed packet found, discarding: ${byteBuffer
-                    .subarray(0, malformedDetectorIndex - 1)
-                    .toString()}`,
+                  `⚠️ Malformed packet found, discarding:`,
+                  toHexString(byteBuffer, malformedDetectorIndex),
                 );
 
                 byteBuffer = byteBuffer.subarray(malformedDetectorIndex);
@@ -67,3 +66,13 @@ export const fromDeviceStream: () => TransformStream<Uint8Array, DeviceOutput> =
       },
     });
   };
+
+function toHexString(byteBuffer: Uint8Array<ArrayBuffer>, index: number) {
+  try {
+    return Array.from(byteBuffer.subarray(0, index - 1))
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+  } catch (_e) {
+    return byteBuffer.subarray(0, index - 1).toString();
+  }
+}

--- a/packages/web/src/components/PageComponents/Messages/MessageItem.tsx
+++ b/packages/web/src/components/PageComponents/Messages/MessageItem.tsx
@@ -269,7 +269,8 @@ export const MessageItem = ({ message }: MessageItemProps) => {
               <div className="text-xs text-slate-500 dark:text-slate-200 whitespace-pre-wrap break-words">
                 SNR: {message.rxSnr}, RSSI: {message.rxRssi}
               </div>
-            ))}
+            )) ||
+            ""}
         </div>
       </div>
       {/* Actions Menu Placeholder */}


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

Improved logging of received packets. It helps to understand what happens with device and useful for development.

## Related Issues

<!--
Link any related issues here using the GitHub syntax: "Fixes #123" or "Relates to #456".
If there are no related issues, you can remove this section.
-->

## Changes Made

<!--
List the key changes you've made. Focus on the most important aspects that reviewers should understand.
-->

- queueStatus packet is logged in JSON format instead of "[object Object]"
- Added deviceuiConfig packet logging (in JSON format as well)
- Malformed packet is logged in hex format instead of comma-separated decimal numbers. This way it's very easy to view it via protobuf viewer (protoscope for example)
- In dev mode: log received packets payload. If protobuf schema is known - then it's logged in JSON format. Else, in hex format

## Testing Done

<!--
Describe how you tested these changes (added new tests, etc).
-->

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [X] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
