### PR TITLE
Update README with Buf CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Follow the installation instructions on their home page.
    ```
    This command installs all necessary dependencies for all packages within the
    monorepo.
+3. **Install the Buf CLI**
+    Required for building `packages/protobufs`
+    https://buf.build/docs/cli/installation/
 
 ### Running Projects
 


### PR DESCRIPTION
Added instructions for installing the Buf CLI.

<!--
Thank you for your contribution to our project!
-->

## Description

When attempting to run `pnpm build:all` a cryptic error was given.
Turns out I needed the `buf` cli installed globally.

## Changes Made

Updated the README.md with a link to the Buf CLI install page

## Checklist

- [x] Documentation has been updated or added
