### PR TITLE
Channel bandwidth is kHz, not MHz

### DIFF
--- a/packages/web/public/i18n/locales/be-BY/common.json
+++ b/packages/web/public/i18n/locales/be-BY/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/be-BY/config.json
+++ b/packages/web/public/i18n/locales/be-BY/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Bandwidth"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/be-BY/deviceConfig.json
+++ b/packages/web/public/i18n/locales/be-BY/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Bandwidth"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/bg-BG/common.json
+++ b/packages/web/public/i18n/locales/bg-BG/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Метър",

--- a/packages/web/public/i18n/locales/bg-BG/config.json
+++ b/packages/web/public/i18n/locales/bg-BG/config.json
@@ -124,7 +124,7 @@
     "title": "Настройки на Mesh",
     "description": "Настройки за LoRa mesh",
     "bandwidth": {
-      "description": "Широчина на канала в MHz",
+      "description": "Широчина на канала в kHz",
       "label": "Широчина на честотната лента"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/bg-BG/deviceConfig.json
+++ b/packages/web/public/i18n/locales/bg-BG/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Настройки на Mesh",
 		"description": "Настройки за LoRa mesh",
 		"bandwidth": {
-			"description": "Широчина на канала в MHz",
+			"description": "Широчина на канала в kHz",
 			"label": "Широчина на честотната лента"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/cs-CZ/common.json
+++ b/packages/web/public/i18n/locales/cs-CZ/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/cs-CZ/config.json
+++ b/packages/web/public/i18n/locales/cs-CZ/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Šířka pásma"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/cs-CZ/deviceConfig.json
+++ b/packages/web/public/i18n/locales/cs-CZ/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Šířka pásma"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/de-DE/common.json
+++ b/packages/web/public/i18n/locales/de-DE/common.json
@@ -52,6 +52,7 @@
       "unknown": "Sprungweite unbekannt"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "Einheitslos",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/de-DE/config.json
+++ b/packages/web/public/i18n/locales/de-DE/config.json
@@ -124,7 +124,7 @@
     "title": "Netzeinstellungen",
     "description": "Einstellungen für das LoRa Netz",
     "bandwidth": {
-      "description": "Kanalbandbreite in MHz",
+      "description": "Kanalbandbreite in kHz",
       "label": "Bandbreite"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/de-DE/deviceConfig.json
+++ b/packages/web/public/i18n/locales/de-DE/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Netzeinstellungen",
 		"description": "Einstellungen für das LoRa Netz",
 		"bandwidth": {
-			"description": "Kanalbandbreite in MHz",
+			"description": "Kanalbandbreite in kHz",
 			"label": "Bandbreite"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/en/common.json
+++ b/packages/web/public/i18n/locales/en/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": { "one": "Meter", "plural": "Meters", "suffix": "m" },
     "kilometer": { "one": "Kilometer", "plural": "Kilometers", "suffix": "km" },

--- a/packages/web/public/i18n/locales/en/config.json
+++ b/packages/web/public/i18n/locales/en/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Bandwidth"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/es-ES/common.json
+++ b/packages/web/public/i18n/locales/es-ES/common.json
@@ -52,6 +52,7 @@
       "unknown": "Saltos desconocidos"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "bruto",
     "meter": {
       "one": "Metro",

--- a/packages/web/public/i18n/locales/es-ES/config.json
+++ b/packages/web/public/i18n/locales/es-ES/config.json
@@ -124,7 +124,7 @@
     "title": "Ajustes de la Red",
     "description": "Opciones de la malla LoRa",
     "bandwidth": {
-      "description": "Ancho de banda de canal en MHz",
+      "description": "Ancho de banda de canal en kHz",
       "label": "Ancho de Banda"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/es-ES/deviceConfig.json
+++ b/packages/web/public/i18n/locales/es-ES/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Ajustes de la Red",
 		"description": "Opciones de la malla LoRa",
 		"bandwidth": {
-			"description": "Ancho de banda de canal en MHz",
+			"description": "Ancho de banda de canal en kHz",
 			"label": "Ancho de Banda"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/fi-FI/common.json
+++ b/packages/web/public/i18n/locales/fi-FI/common.json
@@ -52,6 +52,7 @@
       "unknown": "Hyppyjen määrä tuntematon"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raakatieto",
     "meter": {
       "one": "Metri",

--- a/packages/web/public/i18n/locales/fi-FI/config.json
+++ b/packages/web/public/i18n/locales/fi-FI/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh-verkon asetukset",
     "description": "LoRa-verkon asetukset",
     "bandwidth": {
-      "description": "Kanavan kaistanleveys MHz",
+      "description": "Kanavan kaistanleveys kHz",
       "label": "Kaistanleveys"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/fi-FI/deviceConfig.json
+++ b/packages/web/public/i18n/locales/fi-FI/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh-verkon asetukset",
 		"description": "LoRa-verkon asetukset",
 		"bandwidth": {
-			"description": "Kanavan kaistanleveys MHz",
+			"description": "Kanavan kaistanleveys kHz",
 			"label": "Kaistanleveys"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/fr-FR/common.json
+++ b/packages/web/public/i18n/locales/fr-FR/common.json
@@ -52,6 +52,7 @@
       "unknown": "Nombre de sauts inconnu"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "brute",
     "meter": {
       "one": "Mètre",

--- a/packages/web/public/i18n/locales/fr-FR/config.json
+++ b/packages/web/public/i18n/locales/fr-FR/config.json
@@ -124,7 +124,7 @@
     "title": "Paramètres maillage",
     "description": "Paramètres du réseau maillé LoRa",
     "bandwidth": {
-      "description": "Largeur de bande du canal en MHz",
+      "description": "Largeur de bande du canal en kHz",
       "label": "Bande Passante"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/fr-FR/deviceConfig.json
+++ b/packages/web/public/i18n/locales/fr-FR/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Paramètres maillage",
 		"description": "Paramètres du réseau maillé LoRa",
 		"bandwidth": {
-			"description": "Largeur de bande du canal en MHz",
+			"description": "Largeur de bande du canal en kHz",
 			"label": "Bande Passante"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/hu-HU/common.json
+++ b/packages/web/public/i18n/locales/hu-HU/common.json
@@ -52,6 +52,7 @@
       "unknown": "Ismeretlen ugrásszám távolság"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "nyers",
     "meter": {
       "one": "Méter",

--- a/packages/web/public/i18n/locales/hu-HU/config.json
+++ b/packages/web/public/i18n/locales/hu-HU/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Sávszélesség"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/hu-HU/deviceConfig.json
+++ b/packages/web/public/i18n/locales/hu-HU/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Sávszélesség"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/it-IT/common.json
+++ b/packages/web/public/i18n/locales/it-IT/common.json
@@ -52,6 +52,7 @@
       "unknown": "Hop sconosciuti"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "grezzo",
     "meter": {
       "one": "Metro",

--- a/packages/web/public/i18n/locales/it-IT/config.json
+++ b/packages/web/public/i18n/locales/it-IT/config.json
@@ -124,7 +124,7 @@
     "title": "Impostazioni Mesh",
     "description": "Impostazioni per la mesh LoRa",
     "bandwidth": {
-      "description": "Larghezza di banda del canale in MHz",
+      "description": "Larghezza di banda del canale in kHz",
       "label": "Larghezza di banda"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/it-IT/deviceConfig.json
+++ b/packages/web/public/i18n/locales/it-IT/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Impostazioni Mesh",
 		"description": "Impostazioni per la mesh LoRa",
 		"bandwidth": {
-			"description": "Larghezza di banda del canale in MHz",
+			"description": "Larghezza di banda del canale in kHz",
 			"label": "Larghezza di banda"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/ja-JP/common.json
+++ b/packages/web/public/i18n/locales/ja-JP/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/ja-JP/config.json
+++ b/packages/web/public/i18n/locales/ja-JP/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "帯域"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/ja-JP/deviceConfig.json
+++ b/packages/web/public/i18n/locales/ja-JP/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "帯域"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/ko-KR/common.json
+++ b/packages/web/public/i18n/locales/ko-KR/common.json
@@ -52,6 +52,7 @@
       "unknown": "알 수 없는 hops 떨어짐"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "미터",

--- a/packages/web/public/i18n/locales/ko-KR/config.json
+++ b/packages/web/public/i18n/locales/ko-KR/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh 설정",
     "description": "LoRa mesh 설정",
     "bandwidth": {
-      "description": "채널 대역폭 MHz",
+      "description": "채널 대역폭 kHz",
       "label": "대역폭"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/ko-KR/deviceConfig.json
+++ b/packages/web/public/i18n/locales/ko-KR/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh 설정",
 		"description": "LoRa mesh 설정",
 		"bandwidth": {
-			"description": "채널 대역폭 MHz",
+			"description": "채널 대역폭 kHz",
 			"label": "대역폭"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/nl-NL/common.json
+++ b/packages/web/public/i18n/locales/nl-NL/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/nl-NL/config.json
+++ b/packages/web/public/i18n/locales/nl-NL/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Bandbreedte"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/nl-NL/deviceConfig.json
+++ b/packages/web/public/i18n/locales/nl-NL/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Bandbreedte"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/pl-PL/common.json
+++ b/packages/web/public/i18n/locales/pl-PL/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/pl-PL/config.json
+++ b/packages/web/public/i18n/locales/pl-PL/config.json
@@ -124,7 +124,7 @@
     "title": "Ustawienia sieci",
     "description": "Ustawienia sieci LoRa",
     "bandwidth": {
-      "description": "Szerokość kanału w MHz",
+      "description": "Szerokość kanału w kHz",
       "label": "Pasmo"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/pl-PL/deviceConfig.json
+++ b/packages/web/public/i18n/locales/pl-PL/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Bandwidth"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/pt-BR/common.json
+++ b/packages/web/public/i18n/locales/pt-BR/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/pt-BR/config.json
+++ b/packages/web/public/i18n/locales/pt-BR/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Largura da banda"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/pt-BR/deviceConfig.json
+++ b/packages/web/public/i18n/locales/pt-BR/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Largura da banda"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/pt-PT/common.json
+++ b/packages/web/public/i18n/locales/pt-PT/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/pt-PT/config.json
+++ b/packages/web/public/i18n/locales/pt-PT/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Largura de banda"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/pt-PT/deviceConfig.json
+++ b/packages/web/public/i18n/locales/pt-PT/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Largura de banda"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/ru-RU/common.json
+++ b/packages/web/public/i18n/locales/ru-RU/common.json
@@ -52,6 +52,7 @@
       "unknown": "? прыжков"
     },
     "megahertz": "МГц",
+    "kilohertz": "кГц",
     "raw": "raw",
     "meter": {
       "one": "Метр",

--- a/packages/web/public/i18n/locales/ru-RU/config.json
+++ b/packages/web/public/i18n/locales/ru-RU/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Ширина канала"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/sv-SE/common.json
+++ b/packages/web/public/i18n/locales/sv-SE/common.json
@@ -52,6 +52,7 @@
       "unknown": "Okänt antal hopp bort"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/sv-SE/config.json
+++ b/packages/web/public/i18n/locales/sv-SE/config.json
@@ -124,7 +124,7 @@
     "title": "Inställningar för nät",
     "description": "Inställningar för LoRa-nätet",
     "bandwidth": {
-      "description": "Kanalens bandbredd i MHz",
+      "description": "Kanalens bandbredd i kHz",
       "label": "Bandbredd"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/sv-SE/deviceConfig.json
+++ b/packages/web/public/i18n/locales/sv-SE/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Inställningar för nät",
 		"description": "Inställningar för LoRa-nätet",
 		"bandwidth": {
-			"description": "Kanalens bandbredd i MHz",
+			"description": "Kanalens bandbredd i kHz",
 			"label": "Bandbredd"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/tr-TR/common.json
+++ b/packages/web/public/i18n/locales/tr-TR/common.json
@@ -52,6 +52,7 @@
       "unknown": "Hop uzaklığı bilinmiyor"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "ham",
     "meter": {
       "one": "Metre",

--- a/packages/web/public/i18n/locales/tr-TR/config.json
+++ b/packages/web/public/i18n/locales/tr-TR/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Ayarları",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Bant genişliği"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/tr-TR/deviceConfig.json
+++ b/packages/web/public/i18n/locales/tr-TR/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Bant genişliği"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/uk-UA/common.json
+++ b/packages/web/public/i18n/locales/uk-UA/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "МГц",
+    "kilohertz": "кГц",
     "raw": "raw",
     "meter": {
       "one": "Метр",

--- a/packages/web/public/i18n/locales/uk-UA/config.json
+++ b/packages/web/public/i18n/locales/uk-UA/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "Bandwidth"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/uk-UA/deviceConfig.json
+++ b/packages/web/public/i18n/locales/uk-UA/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "Bandwidth"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/zh-CN/common.json
+++ b/packages/web/public/i18n/locales/zh-CN/common.json
@@ -52,6 +52,7 @@
       "unknown": "Unknown hops away"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "Meter",

--- a/packages/web/public/i18n/locales/zh-CN/config.json
+++ b/packages/web/public/i18n/locales/zh-CN/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "带宽"
     },
     "boostedRxGain": {

--- a/packages/web/public/i18n/locales/zh-CN/deviceConfig.json
+++ b/packages/web/public/i18n/locales/zh-CN/deviceConfig.json
@@ -122,7 +122,7 @@
 		"title": "Mesh Settings",
 		"description": "Settings for the LoRa mesh",
 		"bandwidth": {
-			"description": "Channel bandwidth in MHz",
+			"description": "Channel bandwidth in kHz",
 			"label": "带宽"
 		},
 		"boostedRxGain": {

--- a/packages/web/public/i18n/locales/zh-TW/common.json
+++ b/packages/web/public/i18n/locales/zh-TW/common.json
@@ -52,6 +52,7 @@
       "unknown": "跳數未知"
     },
     "megahertz": "MHz",
+    "kilohertz": "kHz",
     "raw": "raw",
     "meter": {
       "one": "公尺",

--- a/packages/web/public/i18n/locales/zh-TW/config.json
+++ b/packages/web/public/i18n/locales/zh-TW/config.json
@@ -124,7 +124,7 @@
     "title": "Mesh Settings",
     "description": "Settings for the LoRa mesh",
     "bandwidth": {
-      "description": "Channel bandwidth in MHz",
+      "description": "Channel bandwidth in kHz",
       "label": "帶寬"
     },
     "boostedRxGain": {

--- a/packages/web/src/components/PageComponents/Settings/LoRa.tsx
+++ b/packages/web/src/components/PageComponents/Settings/LoRa.tsx
@@ -117,7 +117,7 @@ export const LoRa = ({ onFormInit }: LoRaConfigProps) => {
                 },
               ],
               properties: {
-                suffix: t("unit.megahertz"),
+                suffix: t("unit.kilohertz"),
               },
             },
             {


### PR DESCRIPTION
## Description

Channel bandwidth is not in the magnitude of MHz, but is kHz. Fix the UI to reflect this.

## Testing Done

Did not test.

## Screenshots (if applicable)

<img width="817" height="122" alt="image" src="https://github.com/user-attachments/assets/c33d1276-a56c-4076-a055-b568052ea45d" />


## Checklist



- [x] Code follows project style guidelines
- [x] Documentation has been updated or added
- [x] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
