### PR TITLE
#984 added missing units in config

### DIFF
--- a/packages/web/src/components/PageComponents/ModuleConfig/DetectionSensor.tsx
+++ b/packages/web/src/components/PageComponents/ModuleConfig/DetectionSensor.tsx
@@ -77,6 +77,9 @@ export const DetectionSensor = ({
               name: "stateBroadcastSecs",
               label: t("detectionSensor.stateBroadcastSecs.label"),
               description: t("detectionSensor.stateBroadcastSecs.description"),
+              properties: {
+                suffix: t("unit.second.plural"),
+              },
               disabledBy: [
                 {
                   fieldName: "enabled",

--- a/packages/web/src/components/PageComponents/ModuleConfig/ExternalNotification.tsx
+++ b/packages/web/src/components/PageComponents/ModuleConfig/ExternalNotification.tsx
@@ -202,6 +202,9 @@ export const ExternalNotification = ({
               name: "nagTimeout",
               label: t("externalNotification.nagTimeout.label"),
               description: t("externalNotification.nagTimeout.description"),
+              properties: {
+                suffix: t("unit.second.plural"),
+              },
               disabledBy: [
                 {
                   fieldName: "enabled",

--- a/packages/web/src/components/PageComponents/ModuleConfig/StoreForward.tsx
+++ b/packages/web/src/components/PageComponents/ModuleConfig/StoreForward.tsx
@@ -88,6 +88,9 @@ export const StoreForward = ({ onFormInit }: StoreForwardModuleConfigProps) => {
                   fieldName: "enabled",
                 },
               ],
+              properties: {
+                suffix: t("unit.record.plural"),
+              },
             },
             {
               type: "number",
@@ -99,6 +102,9 @@ export const StoreForward = ({ onFormInit }: StoreForwardModuleConfigProps) => {
                   fieldName: "enabled",
                 },
               ],
+              properties: {
+                suffix: t("unit.record.plural"),
+              },
             },
           ],
         },

--- a/packages/web/src/components/PageComponents/ModuleConfig/Telemetry.tsx
+++ b/packages/web/src/components/PageComponents/ModuleConfig/Telemetry.tsx
@@ -98,6 +98,9 @@ export const Telemetry = ({ onFormInit }: TelemetryModuleConfigProps) => {
               name: "airQualityInterval",
               label: t("telemetry.airQualityInterval.label"),
               description: t("telemetry.airQualityInterval.description"),
+              properties: {
+                suffix: t("unit.second.plural"),
+              },
             },
             {
               type: "toggle",
@@ -110,6 +113,9 @@ export const Telemetry = ({ onFormInit }: TelemetryModuleConfigProps) => {
               name: "powerUpdateInterval",
               label: t("telemetry.powerUpdateInterval.label"),
               description: t("telemetry.powerUpdateInterval.description"),
+              properties: {
+                suffix: t("unit.second.plural"),
+              },
             },
             {
               type: "toggle",

--- a/packages/web/src/components/PageComponents/Settings/Position.tsx
+++ b/packages/web/src/components/PageComponents/Settings/Position.tsx
@@ -278,6 +278,9 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
               name: "broadcastSmartMinimumDistance",
               label: t("position.smartPositionMinDistance.label"),
               description: t("position.smartPositionMinDistance.description"),
+              properties: {
+                suffix: t("unit.meter.plural"),
+              },
               disabledBy: [
                 {
                   fieldName: "positionBroadcastSmartEnabled",
@@ -289,6 +292,9 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
               name: "broadcastSmartMinimumIntervalSecs",
               label: t("position.smartPositionMinInterval.label"),
               description: t("position.smartPositionMinInterval.description"),
+              properties: {
+                suffix: t("unit.second.plural"),
+              },
               disabledBy: [
                 {
                   fieldName: "positionBroadcastSmartEnabled",


### PR DESCRIPTION
## Description
Just a small update, added missing units in five config screens.

## Related Issues
Relates to #984 

## Testing Done
Performed a quick manual testing on a self-hosted instance.


## Screenshots (if applicable)
<img width="1600" height="946" alt="image" src="https://github.com/user-attachments/assets/9ecf2ef0-1afb-46a5-b89e-87a6b4850ffb" />

