### PR TITLE
Update hopsAway when packets are received

### DIFF
--- a/packages/web/src/core/stores/nodeDBStore/index.ts
+++ b/packages/web/src/core/stores/nodeDBStore/index.ts
@@ -270,12 +270,18 @@ function nodeDBFactory(
           }
           const node = nodeDB.nodeMap.get(data.from);
           const nowSec = Math.floor(Date.now() / 1000); // lastHeard is in seconds(!)
+          const hopsAway =
+            data.hopLimit > data.hopStart ||
+            (data.hopStart === 0 && !data.hasBitfield)
+              ? undefined
+              : data.hopStart - data.hopLimit;
 
           if (node) {
             const updated = {
               ...node,
               lastHeard: data.time > 0 ? data.time : nowSec,
               snr: data.snr,
+              hopsAway,
             };
             nodeDB.nodeMap = new Map(nodeDB.nodeMap).set(data.from, updated);
           } else {
@@ -285,6 +291,7 @@ function nodeDBFactory(
                 num: data.from,
                 lastHeard: data.time > 0 ? data.time : nowSec, // fallback to now if time is 0 or negative,
                 snr: data.snr,
+                hopsAway,
               }),
             );
           }

--- a/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.tsx
+++ b/packages/web/src/core/stores/nodeDBStore/nodeDBStore.test.tsx
@@ -95,18 +95,43 @@ describe("NodeDB store", () => {
     const { useNodeDBStore } = await freshStore();
     const db = useNodeDBStore.getState().addNodeDB(1);
 
-    db.processPacket({ from: 50, time: 1111, snr: 7 } as any);
+    db.processPacket({
+      from: 50,
+      time: 1111,
+      snr: 7,
+      hopStart: 5,
+      hopLimit: 2,
+      hasBitfield: true,
+    } as any);
     expect(db.getNode(50)).toBeTruthy();
     expect(db.getNode(50)?.lastHeard).toBe(1111);
     expect(db.getNode(50)?.snr).toBe(7);
+    expect(db.getNode(50)?.hopsAway).toBe(3);
 
-    db.processPacket({ from: 50, time: 2222, snr: 9 } as any);
+    db.processPacket({
+      from: 50,
+      time: 2222,
+      snr: 9,
+      hopStart: 6,
+      hopLimit: 3,
+      hasBitfield: true,
+    } as any);
     expect(db.getNode(50)?.lastHeard).toBe(2222);
     expect(db.getNode(50)?.snr).toBe(9);
+    expect(db.getNode(50)?.hopsAway).toBe(3);
 
-    db.processPacket({ from: 50, time: 0, snr: 9 } as any);
+    // when hopStart===0 and hasBitfield is false, hopsAway should be undefined
+    db.processPacket({
+      from: 50,
+      time: 0,
+      snr: 9,
+      hopStart: 0,
+      hopLimit: 0,
+      hasBitfield: false,
+    } as any);
     expect(db.getNode(50)?.lastHeard).toBeCloseTo(Date.now() / 1000, -1); // within 1s, note lastHeard is in seconds
     expect(db.getNode(50)?.snr).toBe(9);
+    expect(db.getNode(50)?.hopsAway).toBeUndefined();
   });
 
   it("addUser and addPosition updates existing or creates new nodes", async () => {

--- a/packages/web/src/core/stores/nodeDBStore/types.ts
+++ b/packages/web/src/core/stores/nodeDBStore/types.ts
@@ -14,6 +14,9 @@ type ProcessPacketParams = {
   from: number;
   snr: number;
   time: number;
+  hopStart: number;
+  hopLimit: number;
+  hasBitfield: boolean;
 };
 
 export type { NodeError, ProcessPacketParams, NodeErrorType };

--- a/packages/web/src/core/subscriptions.ts
+++ b/packages/web/src/core/subscriptions.ts
@@ -116,6 +116,11 @@ export const subscribeAll = (
       from: meshPacket.from,
       snr: meshPacket.rxSnr,
       time: meshPacket.rxTime,
+      hopStart: meshPacket.hopStart,
+      hopLimit: meshPacket.hopLimit,
+      hasBitfield:
+        meshPacket.payloadVariant.case === "decoded" &&
+        meshPacket.payloadVariant.value.bitfield !== undefined,
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

Update the number of hops away for each node in the 'Connections' column of the node list table as new packets arrive.

## Related Issues

Follows the logic from the firmware project: https://github.com/meshtastic/firmware/pull/9120

## Changes Made

`hopsAway` for a node is calculated each time a new packet is received. It is set based on the difference between the hop_start & hop_limit in the MeshPacket.

Prior to firmware version v2.3.0 nodes did not provide a hop_start in packets. This meant that receiving a hop_start value of 0 could mean two different things; either the node was older and didn't supply a hop_start, or the transmitting node had LoRa number of hops set to 0. This PR uses the presence of the bitfield, added in v2.5.0, to distinguish between these two cases.

When hop_start=0 and the bitfield is present, we can trust that the transmitting node had LoRa number of hops set to 0.  Otherwise the value for hopsAway is undefined.

## Testing Done

Updated existing unit tests and verified the hops are calculated correctly by connecting to a bluetooth device.

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [x] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [x] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
