### PR TITLE
Guard against undefined values in the UI

### DIFF
--- a/packages/web/src/pages/Messages.tsx
+++ b/packages/web/src/pages/Messages.tsx
@@ -103,7 +103,7 @@ export const MessagesPage = () => {
     }, true)
       .map((node: Protobuf.Mesh.NodeInfo) => ({
         ...node,
-        unreadCount: getUnreadCount(node.num) ?? 0,
+        unreadCount: getUnreadCount(node?.num) ?? 0,
       }))
       .sort((a: NodeInfoWithUnread, b: NodeInfoWithUnread) => {
         const diff = b.unreadCount - a.unreadCount;
@@ -141,7 +141,7 @@ export const MessagesPage = () => {
           } else {
             setMessageState({
               type: MessageType.Direct,
-              nodeA: getMyNode().num,
+              nodeA: getMyNode()?.num,
               nodeB: numericChatId,
               messageId,
               newState: MessageState.Ack,
@@ -163,7 +163,7 @@ export const MessagesPage = () => {
         } else {
           setMessageState({
             type: MessageType.Direct,
-            nodeA: getMyNode().num,
+            nodeA: getMyNode()?.num,
             nodeB: numericChatId,
             messageId: failedId,
             newState: MessageState.Failed,
@@ -190,7 +190,7 @@ export const MessagesPage = () => {
           <ChannelChat
             messages={getMessages({
               type: MessageType.Direct,
-              nodeA: getMyNode().num,
+              nodeA: getMyNode()?.num,
               nodeB: numericChatId,
             }).reverse()}
           />
@@ -270,22 +270,22 @@ export const MessagesPage = () => {
       >
         {filteredNodes()?.map((node) => (
           <SidebarButton
-            key={node.num}
+            key={node?.num}
             preventCollapse
             label={node.user?.longName ?? t("unknown.shortName")}
             count={node.unreadCount > 0 ? node.unreadCount : undefined}
             active={
-              numericChatId === node.num && chatType === MessageType.Direct
+              numericChatId === node?.num && chatType === MessageType.Direct
             }
             onClick={() => {
-              navigateToChat(MessageType.Direct, node.num.toString());
-              resetUnread(node.num);
+              navigateToChat(MessageType.Direct, node?.num.toString());
+              resetUnread(node?.num);
             }}
           >
             <Avatar
-              nodeNum={node.num}
-              className={cn(hasNodeError(node.num) && "text-red-500")}
-              showError={hasNodeError(node.num)}
+              nodeNum={node?.num}
+              className={cn(hasNodeError(node?.num) && "text-red-500")}
+              showError={hasNodeError(node?.num)}
               showFavorite={node.isFavorite}
               size="sm"
             />


### PR DESCRIPTION
## Description

For some reason `getMyNode()` and/or `node` can be `undefined`, making the UI entirely unusable. Even after reconnecting to the node. Any other state is much more desirable than this.

## Related Issues

Fixes https://github.com/meshtastic/web/issues/982
Fixes https://github.com/meshtastic/web/issues/975
Fixes https://github.com/meshtastic/web/issues/960

## Changes Made

Basic guards against potentially `undefined` values.

## Testing Done

For testing I made these changes to the (obfuscated) release build on client.meshtastic.org, it made the WebUI usable again. Unfortunately the source maps weren't available (why?) so I couldn't deobfuscate the stacktraces other people have reported, so I'm only 95% sure I added handling for those as well. Can't know for sure.

## Checklist

- [X] Code follows project style guidelines
- [X] Documentation has been updated or added
- [X] Tests have been added or updated
- [X] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
