### PR TITLE
feat(i18n): add support for ja,sc, tc  languages

### DIFF
--- a/packages/web/src/i18n-config.ts
+++ b/packages/web/src/i18n-config.ts
@@ -18,6 +18,9 @@ export const supportedLanguages: Lang[] = [
   { code: "en", name: "English", flag: "🇺🇸" },
   { code: "fr", name: "Français", flag: "🇫🇷" },
   { code: "sv", name: "Svenska", flag: "🇸🇪" },
+  { code: "ja", name: "日本語", flag: "🇯🇵" },
+  { code: "sc", name: "简体中文", flag: "🇨🇳" },
+  { code: "tc", name: "繁體中文", flag: "🇹🇼" },
 ];
 
 export const FALLBACK_LANGUAGE_CODE: LangCode = "en";
@@ -45,6 +48,9 @@ i18next
       fr: ["fr-FR", FALLBACK_LANGUAGE_CODE],
       sv: ["sv-SE", FALLBACK_LANGUAGE_CODE],
       de: ["de-DE", FALLBACK_LANGUAGE_CODE],
+      ja: ["ja-JP", FALLBACK_LANGUAGE_CODE],
+      sc: ["zh-CN", FALLBACK_LANGUAGE_CODE],
+      tc: ["zh-TW", FALLBACK_LANGUAGE_CODE],
     },
     fallbackNS: ["common", "ui", "dialog"],
     debug: import.meta.env.MODE === "development",


### PR DESCRIPTION
feat(i18n): add Japanese (ja), Simplified Chinese (sc) and Traditional Chinese (tc)  to supportedLanguages

feat(i18n): register ja,sc, tc in supportedLanguages and fallbackLng

## Description

This PR adds support for three new languages in the Meshtastic WebUI:

- Japanese (`ja`)
- Simplified Chinese (`sc`)
- Traditional Chinese (`tc`)

## Changes Made

- Added `ja`, `sc`, and `tc` entries to `supportedLanguages` with appropriate names and flags.
- Updated `fallbackLng` configuration to include `ja-JP`, `zh-CN`, and `zh-TW` mappings.
- Verified that translation files in `/i18n/locales/` are correctly loaded.

## Testing Done

- Built the WebUI locally and confirmed that the language selector now shows Japanese, Simplified Chinese, and Traditional Chinese.
- Switched browser language settings to `ja-JP`, `zh-CN`, and `zh-TW` to verify automatic detection and fallback behavior.
- Manually selected each language in the UI to confirm translations load correctly.

## Checklist

- [x] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [x] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)
