### PR TITLE
fix(i18n): correct HTTPS typo

### DIFF
--- a/packages/web/public/i18n/locales/be-BY/dialog.json
+++ b/packages/web/public/i18n/locales/be-BY/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/cs-CZ/dialog.json
+++ b/packages/web/public/i18n/locales/cs-CZ/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/es-ES/dialog.json
+++ b/packages/web/public/i18n/locales/es-ES/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/fr-FR/dialog.json
+++ b/packages/web/public/i18n/locales/fr-FR/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/hu-HU/dialog.json
+++ b/packages/web/public/i18n/locales/hu-HU/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/it-IT/dialog.json
+++ b/packages/web/public/i18n/locales/it-IT/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/ja-JP/dialog.json
+++ b/packages/web/public/i18n/locales/ja-JP/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/ko-KR/dialog.json
+++ b/packages/web/public/i18n/locales/ko-KR/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/nl-NL/dialog.json
+++ b/packages/web/public/i18n/locales/nl-NL/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/pl-PL/dialog.json
+++ b/packages/web/public/i18n/locales/pl-PL/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/pt-BR/dialog.json
+++ b/packages/web/public/i18n/locales/pt-BR/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/pt-PT/dialog.json
+++ b/packages/web/public/i18n/locales/pt-PT/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/ru-RU/dialog.json
+++ b/packages/web/public/i18n/locales/ru-RU/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/tr-TR/dialog.json
+++ b/packages/web/public/i18n/locales/tr-TR/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/uk-UA/dialog.json
+++ b/packages/web/public/i18n/locales/uk-UA/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/zh-CN/dialog.json
+++ b/packages/web/public/i18n/locales/zh-CN/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."

--- a/packages/web/public/i18n/locales/zh-TW/dialog.json
+++ b/packages/web/public/i18n/locales/zh-TW/dialog.json
@@ -78,7 +78,7 @@
       "namePlaceholder": "My HTTP Node",
       "inputPlaceholder": "192.168.1.10 or meshtastic.local",
       "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "useHttps": "Use HTTPS",
       "invalidUrl": {
         "title": "Invalid URL",
         "description": "Please enter a valid HTTP or HTTPS URL."


### PR DESCRIPTION
## Description

Fixes a typo in the `useHttps` label across multiple locale files.

Several locales contained the incorrect string `"Use HTTTPS"` (extra `T`).  
This PR corrects it to `"Use HTTPS"` in all affected files.

## Related Issues

N/A

## Changes Made

- Replaced `"Use HTTTPS"` with `"Use HTTPS"` in affected `dialog.json` locale files
- Left already translated locale strings untouched

## Testing Done

- Verified no remaining occurrences of `"HTTTPS"` in the repository
- Confirmed only intended locale files were modified via `git diff`

## Screenshots

Not applicable (text-only change)

## Checklist

- [x] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [x] All i18n translation labels have been added