### PR TITLE
chore: remove protobufs git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packages/packages/protobufs"]
-	path = packages/packages/protobufs
-	url = https://github.com/meshtastic/protobufs


### PR DESCRIPTION
## Summary
- Removed the `packages/packages/protobufs` git submodule and cleaned up `.gitmodules`

## Test plan
- [ ] Verify build still works without the submodule
- [ ] Confirm no remaining references to the protobufs submodule