### PR TITLE
chore(i18n): improve Russian translation consistency

### DIFF
--- a/packages/web/public/i18n/locales/ru-RU/channels.json
+++ b/packages/web/public/i18n/locales/ru-RU/channels.json
@@ -3,69 +3,69 @@
     "sectionLabel": "Каналы",
     "channelName": "Канал: {{channelName}}",
     "broadcastLabel": "Первичный",
-    "channelIndex": "Кн {{index}}",
-    "import": "Импортировать",
+    "channelIndex": "Канал {{index}}",
+    "import": "Импорт",
     "export": "Экспорт"
   },
   "validation": {
-    "pskInvalid": "Введите правильный {{bits}} бит PSK."
+    "pskInvalid": "Введите корректный PSK длиной {{bits}} бит."
   },
   "settings": {
     "label": "Настройки канала",
-    "description": "Настройка шифрования, MQTT и пр"
+    "description": "Шифрование, MQTT и прочие настройки"
   },
   "role": {
     "label": "Роль",
-    "description": "Телеметрия устройства отправляется через ГЛАВНЫЙ. Только один ГЛАВНЫЙ разрешен",
+    "description": "Телеметрия устройства отправляется по ПЕРВИЧНОМУ каналу. Допускается только один ПЕРВИЧНЫЙ канал",
     "options": {
-      "primary": "ГЛАВНЫЙ",
-      "disabled": "ЗАПРЕЩЕННЫЙ",
+      "primary": "ПЕРВИЧНЫЙ",
+      "disabled": "ОТКЛЮЧЕН",
       "secondary": "ВТОРИЧНЫЙ"
     }
   },
   "psk": {
-    "label": "Pre-Shared Ключ",
-    "description": "Поддерживаемая длина PSK: 256-бит, 128-бит, 8-бит, Пустое (0-бит)",
+    "label": "Pre-Shared Key (PSK)",
+    "description": "Поддерживаемая длина PSK: 256 бит, 128 бит, 8 бит, пустой (0 бит)",
     "generate": "Сгенерировать"
   },
   "name": {
     "label": "Имя",
-    "description": "ЗАПРЕЩЕННЫЙ"
+    "description": "Уникальное имя канала (до 12 байт); оставьте пустым для значения по умолчанию"
   },
   "uplinkEnabled": {
-    "label": "Выгрузка Разрешена",
-    "description": "Отправлять сообщения из местного mesh в MQTT"
+    "label": "Аплинк включён",
+    "description": "Отправлять сообщения из локальной mesh-сети в MQTT"
   },
   "downlinkEnabled": {
-    "label": "Загрузка Разрешена",
-    "description": "Отправлять сообщения из MQTT в местный mesh"
+    "label": "Даунлинк включён",
+    "description": "Отправлять сообщения из MQTT в локальную mesh-сеть"
   },
   "positionPrecision": {
-    "label": "Позиция",
-    "description": "Точность позиции для отправки в канал. Можно запретить.",
+    "label": "Местоположение",
+    "description": "Точность местоположения для обмена в канале. Можно отключить.",
     "options": {
-      "none": "Не делиться позицией",
-      "precise": "Точная позиция",
-      "metric_km23": "Около 23 километров",
-      "metric_km12": "Около 12 километров",
-      "metric_km5_8": "Within 5.8 kilometers",
-      "metric_km2_9": "Within 2.9 kilometers",
-      "metric_km1_5": "Около 1,5 километров",
-      "metric_m700": "Около 700 метров",
-      "metric_m350": "Около 350 метров",
-      "metric_m200": "Около 200 метров",
-      "metric_m90": "Около 90 метров",
-      "metric_m50": "Около 50 метров",
-      "imperial_mi15": "Около 15 миль",
-      "imperial_mi7_3": "Within 7.3 miles",
-      "imperial_mi3_6": "Within 3.6 miles",
-      "imperial_mi1_8": "Within 1.8 miles",
-      "imperial_mi0_9": "Within 0.9 miles",
-      "imperial_mi0_5": "Within 0.5 miles",
-      "imperial_mi0_2": "Около 0,2 миль",
-      "imperial_ft600": "Около 600 футов",
-      "imperial_ft300": "Около 300 футов",
-      "imperial_ft150": "Около 150 футов"
+      "none": "Не делиться местоположением",
+      "precise": "Точное местоположение",
+      "metric_km23": "В пределах 23 километров",
+      "metric_km12": "В пределах 12 километров",
+      "metric_km5_8": "В пределах 5,8 километра",
+      "metric_km2_9": "В пределах 2,9 километра",
+      "metric_km1_5": "В пределах 1,5 километра",
+      "metric_m700": "В пределах 700 метров",
+      "metric_m350": "В пределах 350 метров",
+      "metric_m200": "В пределах 200 метров",
+      "metric_m90": "В пределах 90 метров",
+      "metric_m50": "В пределах 50 метров",
+      "imperial_mi15": "В пределах 15 миль",
+      "imperial_mi7_3": "В пределах 7,3 мили",
+      "imperial_mi3_6": "В пределах 3,6 мили",
+      "imperial_mi1_8": "В пределах 1,8 мили",
+      "imperial_mi0_9": "В пределах 0,9 мили",
+      "imperial_mi0_5": "В пределах 0,5 мили",
+      "imperial_mi0_2": "В пределах 0,2 мили",
+      "imperial_ft600": "В пределах 600 футов",
+      "imperial_ft300": "В пределах 300 футов",
+      "imperial_ft150": "В пределах 150 футов"
     }
   }
 }

--- a/packages/web/public/i18n/locales/ru-RU/commandPalette.json
+++ b/packages/web/public/i18n/locales/ru-RU/commandPalette.json
@@ -1,50 +1,50 @@
 {
-  "emptyState": "Результаты не найдены..",
+  "emptyState": "Результаты не найдены.",
   "page": {
-    "title": "Меню"
+    "title": "Командное меню"
   },
   "pinGroup": {
-    "label": "Закрепить меню"
+    "label": "Закрепить группу команд"
   },
   "unpinGroup": {
-    "label": "Открепить меню"
+    "label": "Открепить группу команд"
   },
   "goto": {
     "label": "Перейти",
     "command": {
       "messages": "Сообщения",
       "map": "Карта",
-      "config": "Настройка",
-      "nodes": "Узлы"
+      "config": "Настройки",
+      "nodes": "Ноды"
     }
   },
   "manage": {
     "label": "Управление",
     "command": {
-      "switchNode": "Выбрать узел",
-      "connectNewNode": "Подключить новый узел"
+      "switchNode": "Переключить ноду",
+      "connectNewNode": "Подключить новую ноду"
     }
   },
   "contextual": {
-    "label": "Контекст",
+    "label": "Контекстные",
     "command": {
-      "qrCode": "QR Код",
+      "qrCode": "QR-код",
       "qrGenerator": "Генератор",
-      "qrImport": "Импортировать",
-      "scheduleShutdown": "Расписание выключения",
+      "qrImport": "Импорт",
+      "scheduleShutdown": "Запланировать выключение",
       "scheduleReboot": "Перезагрузить устройство",
-      "resetNodeDb": "Стереть базу данных узлов",
+      "resetNodeDb": "Сбросить базу нод",
       "dfuMode": "Войти в режим DFU",
-      "factoryResetDevice": "Сброс устройства к заводским установкам",
-      "factoryResetConfig": "Factory Reset Config",
+      "factoryResetDevice": "Сброс устройства к заводским настройкам",
+      "factoryResetConfig": "Сброс настроек к заводским",
       "disconnect": "Отключиться"
     }
   },
   "debug": {
-    "label": "Debug",
+    "label": "Отладка",
     "command": {
       "reconfigure": "Перенастроить",
-      "clearAllStoredMessages": "Удалить все сохранённые сообщения",
+      "clearAllStoredMessages": "Очистить все сохранённые сообщения",
       "clearAllStores": "Очистить всё локальное хранилище"
     }
   }

--- a/packages/web/public/i18n/locales/ru-RU/common.json
+++ b/packages/web/public/i18n/locales/ru-RU/common.json
@@ -3,39 +3,39 @@
     "apply": "Применить",
     "addConnection": "Добавить подключение",
     "saveConnection": "Сохранить подключение",
-    "backupKey": "Бэкап ключа",
+    "backupKey": "Резервная копия ключа",
     "cancel": "Отмена",
     "connect": "Подключиться",
     "clearMessages": "Очистить сообщения",
     "close": "Закрыть",
     "confirm": "Подтвердить",
     "delete": "Удалить",
-    "dismiss": "Отменить",
+    "dismiss": "Скрыть",
     "download": "Скачать",
     "disconnect": "Отключиться",
     "export": "Экспорт",
-    "generate": "Создать",
-    "regenerate": "Создать снова",
-    "import": "Импортировать",
+    "generate": "Сгенерировать",
+    "regenerate": "Сгенерировать заново",
+    "import": "Импорт",
     "message": "Сообщение",
     "now": "Сейчас",
-    "ok": "Лады",
+    "ok": "ОК",
     "print": "Печать",
     "remove": "Удалить",
-    "requestNewKeys": "Запрос нового ключа",
-    "requestPosition": "Запрос позиции",
+    "requestNewKeys": "Запросить новые ключи",
+    "requestPosition": "Запросить позицию",
     "reset": "Сброс",
     "retry": "Повторить",
     "save": "Сохранить",
-    "setDefault": "Установить по умолчанию",
-    "unsetDefault": "Убрать умолчание",
-    "scanQr": "Сканировать QR код",
-    "traceRoute": "Отследить маршрут",
+    "setDefault": "Сделать по умолчанию",
+    "unsetDefault": "Снять по умолчанию",
+    "scanQr": "Сканировать QR-код",
+    "traceRoute": "Трассировка маршрута",
     "submit": "Отправить"
   },
   "app": {
     "title": "Meshtastic",
-    "fullTitle": "Веб клиент Meshtastic"
+    "fullTitle": "Веб-клиент Meshtastic"
   },
   "loading": "Загрузка...",
   "unit": {
@@ -43,123 +43,89 @@
     "dbm": "dBm",
     "hertz": "Гц",
     "hop": {
-      "one": "Прыжок",
-      "plural": "Прыжков"
+      "one": "прыжок",
+      "plural": "прыжков"
     },
     "hopsAway": {
-      "one": "{{count}} прыжок до",
-      "plural": "{{count}} прыжков",
-      "unknown": "? прыжков"
+      "one": "{{count}} прыжок от вас",
+      "plural": "{{count}} прыжков от вас",
+      "unknown": "Неизвестно, сколько прыжков"
     },
     "megahertz": "МГц",
     "kilohertz": "кГц",
-    "raw": "raw",
-    "meter": {
-      "one": "Метр",
-      "plural": "Метров",
-      "suffix": "м"
-    },
-    "kilometer": {
-      "one": "Километр",
-      "plural": "Километров",
-      "suffix": "км"
-    },
-    "minute": {
-      "one": "Минута",
-      "plural": "Минут"
-    },
-    "hour": {
-      "one": "Час",
-      "plural": "Часов"
-    },
+    "raw": "сырое",
+    "meter": { "one": "метр", "plural": "метров", "suffix": "м" },
+    "kilometer": { "one": "километр", "plural": "километров", "suffix": "км" },
+    "minute": { "one": "минута", "plural": "минут" },
+    "hour": { "one": "час", "plural": "часов" },
     "millisecond": {
-      "one": "Миллисекунда",
-      "plural": "Миллисекунд",
+      "one": "миллисекунда",
+      "plural": "миллисекунд",
       "suffix": "мс"
     },
-    "second": {
-      "one": "Секунда",
-      "plural": "Секунд"
-    },
+    "second": { "one": "секунда", "plural": "секунд" },
     "day": {
-      "one": "День",
-      "plural": "Дней",
+      "one": "день",
+      "plural": "дней",
       "today": "Сегодня",
       "yesterday": "Вчера"
     },
-    "month": {
-      "one": "Месяц",
-      "plural": "Месяцев"
-    },
-    "year": {
-      "one": "Year",
-      "plural": "Years"
-    },
-    "snr": "Сигнал/шум",
-    "volt": {
-      "one": "Volt",
-      "plural": "Volts",
-      "suffix": "V"
-    },
-    "record": {
-      "one": "Records",
-      "plural": "Records"
-    },
-    "degree": {
-      "one": "Degree",
-      "plural": "Degrees",
-      "suffix": "°"
-    }
+    "month": { "one": "месяц", "plural": "месяцев" },
+    "year": { "one": "год", "plural": "лет" },
+    "snr": "SNR",
+    "volt": { "one": "вольт", "plural": "вольт", "suffix": "В" },
+    "record": { "one": "запись", "plural": "записей" },
+    "degree": { "one": "градус", "plural": "градусов", "suffix": "°" }
   },
   "security": {
-    "0bit": "Empty",
-    "8bit": "8 bit",
-    "128bit": "128 bit",
-    "256bit": "256 bit"
+    "0bit": "Пусто",
+    "8bit": "8 бит",
+    "128bit": "128 бит",
+    "256bit": "256 бит"
   },
   "unknown": {
     "longName": "Неизвестно",
-    "shortName": "UNK",
-    "notAvailable": "N/A",
+    "shortName": "Н/Д",
+    "notAvailable": "Н/Д",
     "num": "??"
   },
   "nodeUnknownPrefix": "!",
-  "unset": "UNSET",
+  "unset": "НЕ ЗАДАНО",
   "fallbackName": "Meshtastic {{last4}}",
-  "node": "Node",
+  "node": "Нода",
   "formValidation": {
-    "unsavedChanges": "Unsaved changes",
+    "unsavedChanges": "Есть несохранённые изменения",
     "tooBig": {
-      "string": "Too long, expected less than or equal to {{maximum}} characters.",
-      "number": "Too big, expected a number smaller than or equal to {{maximum}}.",
-      "bytes": "Too big, expected less than or equal to {{params.maximum}} bytes."
+      "string": "Слишком длинно, ожидается не более {{maximum}} символов.",
+      "number": "Слишком большое значение, ожидается число не более {{maximum}}.",
+      "bytes": "Слишком большое значение, ожидается не более {{params.maximum}} байт."
     },
     "tooSmall": {
-      "string": "Too short, expected more than or equal to {{minimum}} characters.",
-      "number": "Too small, expected a number larger than or equal to {{minimum}}."
+      "string": "Слишком коротко, ожидается не менее {{minimum}} символов.",
+      "number": "Слишком маленькое значение, ожидается число не менее {{minimum}}."
     },
     "invalidFormat": {
-      "ipv4": "Invalid format, expected an IPv4 address.",
-      "key": "Invalid format, expected a Base64 encoded pre-shared key (PSK)."
+      "ipv4": "Неверный формат, ожидается IPv4-адрес.",
+      "key": "Неверный формат, ожидается Pre-Shared Key (PSK), закодированный в Base64."
     },
     "invalidType": {
-      "number": "Invalid type, expected a number."
+      "number": "Неверный тип, ожидается число."
     },
     "pskLength": {
-      "0bit": "Key is required to be empty.",
-      "8bit": "Key is required to be an 8 bit pre-shared key (PSK).",
-      "128bit": "Key is required to be a 128 bit pre-shared key (PSK).",
-      "256bit": "Key is required to be a 256 bit pre-shared key (PSK)."
+      "0bit": "Ключ должен быть пустым.",
+      "8bit": "Ключ должен быть Pre-Shared Key (PSK) длиной 8 бит.",
+      "128bit": "Ключ должен быть Pre-Shared Key (PSK) длиной 128 бит.",
+      "256bit": "Ключ должен быть Pre-Shared Key (PSK) длиной 256 бит."
     },
     "required": {
-      "generic": "This field is required.",
-      "managed": "At least one admin key is requred if the node is managed.",
-      "key": "Key is required."
+      "generic": "Это поле обязательно.",
+      "managed": "Для управляемой ноды требуется хотя бы один ключ администратора.",
+      "key": "Ключ обязателен."
     },
     "invalidOverrideFreq": {
-      "number": "Invalid format, expected a value in the range 410-930 MHz or 0 (use default)."
+      "number": "Неверный формат, ожидается значение в диапазоне 410–930 МГц или 0 (использовать по умолчанию)."
     }
   },
-  "yes": "Yes",
-  "no": "No"
+  "yes": "Да",
+  "no": "Нет"
 }

--- a/packages/web/public/i18n/locales/ru-RU/config.json
+++ b/packages/web/public/i18n/locales/ru-RU/config.json
@@ -5,454 +5,466 @@
     "tabChannels": "Каналы",
     "tabBluetooth": "Bluetooth",
     "tabDevice": "Устройство",
-    "tabDisplay": "Дисплей",
+    "tabDisplay": "Экран",
     "tabLora": "LoRa",
     "tabNetwork": "Сеть",
-    "tabPosition": "Местоположение",
+    "tabPosition": "Позиция",
     "tabPower": "Питание",
     "tabSecurity": "Безопасность"
   },
   "sidebar": {
-    "label": "Configuration"
+    "label": "Конфигурация"
   },
   "device": {
-    "title": "Device Settings",
-    "description": "Settings for the device",
+    "title": "Настройки устройства",
+    "description": "Настройки устройства",
     "buttonPin": {
-      "description": "Button pin override",
-      "label": "Button Pin"
+      "description": "Переопределение пина кнопки",
+      "label": "Пин кнопки"
     },
     "buzzerPin": {
-      "description": "Buzzer pin override",
-      "label": "Buzzer Pin"
+      "description": "Переопределение пина зуммера",
+      "label": "Пин зуммера"
     },
     "disableTripleClick": {
-      "description": "Disable triple click",
-      "label": "Disable Triple Click"
+      "description": "Отключить тройное нажатие",
+      "label": "Отключить тройное нажатие"
     },
     "doubleTapAsButtonPress": {
-      "description": "Treat double tap as button press",
-      "label": "Double Tap as Button Press"
+      "description": "Считать двойной тап нажатием кнопки",
+      "label": "Двойной тап как нажатие"
     },
     "ledHeartbeatDisabled": {
-      "description": "Disable default blinking LED",
-      "label": "LED Heartbeat Disabled"
+      "description": "Отключить стандартный мигающий LED",
+      "label": "Отключить индикатор"
     },
     "nodeInfoBroadcastInterval": {
-      "description": "How often to broadcast node info",
-      "label": "Интервал вещания передачи информации об узле"
+      "description": "Как часто рассылать информацию о ноде",
+      "label": "Интервал рассылки информации о ноде"
     },
     "posixTimezone": {
-      "description": "The POSIX timezone string for the device",
+      "description": "Строка POSIX часового пояса устройства",
       "label": "Часовой пояс POSIX"
     },
     "rebroadcastMode": {
-      "description": "How to handle rebroadcasting",
+      "description": "Как обрабатывать ретрансляцию",
       "label": "Режим ретрансляции"
     },
     "role": {
-      "description": "What role the device performs on the mesh",
+      "description": "Какую роль устройство выполняет в mesh-сети",
       "label": "Роль"
     }
   },
   "bluetooth": {
-    "title": "Bluetooth Settings",
-    "description": "Settings for the Bluetooth module",
-    "note": "Note: Some devices (ESP32) cannot use both Bluetooth and WiFi at the same time.",
+    "title": "Настройки Bluetooth",
+    "description": "Настройки модуля Bluetooth",
+    "note": "Примечание: некоторые устройства (ESP32) не могут использовать Bluetooth и WiFi одновременно.",
     "enabled": {
-      "description": "Enable or disable Bluetooth",
+      "description": "Включить или отключить Bluetooth",
       "label": "Включено"
     },
     "pairingMode": {
-      "description": "Pin selection behaviour.",
+      "description": "Поведение выбора PIN.",
       "label": "Режим сопряжения"
     },
     "pin": {
-      "description": "Pin to use when pairing",
-      "label": "Pin"
+      "description": "PIN для сопряжения",
+      "label": "PIN"
     }
   },
   "display": {
-    "description": "Settings for the device display",
-    "title": "Display Settings",
+    "description": "Настройки экрана устройства",
+    "title": "Настройки экрана",
     "headingBold": {
-      "description": "Bolden the heading text",
-      "label": "Выделять жирным заголовок"
+      "description": "Сделать заголовок жирным",
+      "label": "Жирный заголовок"
     },
     "carouselDelay": {
-      "description": "How fast to cycle through windows",
-      "label": "Carousel Delay"
+      "description": "Скорость переключения окон",
+      "label": "Задержка карусели"
     },
     "compassNorthTop": {
-      "description": "Fix north to the top of compass",
-      "label": "Compass North Top"
+      "description": "Зафиксировать север вверху компаса",
+      "label": "Север сверху"
     },
     "displayMode": {
-      "description": "Screen layout variant",
-      "label": "Display Mode"
+      "description": "Вариант компоновки экрана",
+      "label": "Режим отображения"
     },
     "displayUnits": {
-      "description": "Display metric or imperial units",
-      "label": "Display Units"
+      "description": "Показывать метрические или имперские единицы",
+      "label": "Единицы измерения"
     },
     "flipScreen": {
-      "description": "Flip display 180 degrees",
-      "label": "Flip Screen"
+      "description": "Повернуть экран на 180 градусов",
+      "label": "Повернуть экран"
     },
     "gpsDisplayUnits": {
-      "description": "Coordinate display format",
-      "label": "GPS Display Units"
+      "description": "Формат отображения координат",
+      "label": "Единицы GPS"
     },
     "oledType": {
-      "description": "Type of OLED screen attached to the device",
-      "label": "OLED Type"
+      "description": "Тип OLED-экрана, подключённого к устройству",
+      "label": "Тип OLED"
     },
     "screenTimeout": {
-      "description": "Turn off the display after this long",
-      "label": "Screen Timeout"
+      "description": "Выключать экран через это время",
+      "label": "Тайм-аут экрана"
     },
     "twelveHourClock": {
-      "description": "Use 12-hour clock format",
-      "label": "12-Hour Clock"
+      "description": "Использовать 12-часовой формат времени",
+      "label": "12-часовой формат"
     },
     "wakeOnTapOrMotion": {
-      "description": "Wake the device on tap or motion",
-      "label": "Wake on Tap or Motion"
+      "description": "Пробуждать устройство по касанию или движению",
+      "label": "Пробуждать по касанию или движению"
     }
   },
   "lora": {
-    "title": "Mesh Settings",
-    "description": "Settings for the LoRa mesh",
+    "title": "Настройки mesh-сети",
+    "description": "Настройки LoRa для mesh-сети",
     "bandwidth": {
-      "description": "Channel bandwidth in kHz",
-      "label": "Ширина канала"
+      "description": "Ширина канала в кГц",
+      "label": "Ширина полосы"
     },
     "boostedRxGain": {
-      "description": "Boosted RX gain",
-      "label": "Boosted RX Gain"
+      "description": "Усиленный RX Gain",
+      "label": "Усиленный RX Gain"
     },
     "codingRate": {
-      "description": "The denominator of the coding rate",
-      "label": "Частота кодирования"
+      "description": "Знаменатель скорости кодирования",
+      "label": "Скорость кодирования"
     },
     "frequencyOffset": {
-      "description": "Frequency offset to correct for crystal calibration errors",
-      "label": "Frequency Offset"
+      "description": "Смещение частоты для компенсации ошибок калибровки кварца",
+      "label": "Смещение частоты"
     },
     "frequencySlot": {
-      "description": "LoRa frequency channel number",
-      "label": "Частота слота"
+      "description": "Номер частотного канала LoRa",
+      "label": "Частотный слот"
     },
     "hopLimit": {
-      "description": "Maximum number of hops",
-      "label": "Hop Limit"
+      "description": "Максимальное число прыжков",
+      "label": "Лимит прыжков"
     },
     "ignoreMqtt": {
-      "description": "Don't forward MQTT messages over the mesh",
+      "description": "Не пересылать сообщения MQTT по mesh-сети",
       "label": "Игнорировать MQTT"
     },
     "modemPreset": {
-      "description": "Modem preset to use",
-      "label": "Режим работы модема"
+      "description": "Используемый пресет модема",
+      "label": "Пресет модема"
     },
     "okToMqtt": {
-      "description": "When set to true, this configuration indicates that the user approves the packet to be uploaded to MQTT. If set to false, remote nodes are requested not to forward packets to MQTT",
-      "label": "ОК в MQTT"
+      "description": "Если установлено значение true, эта конфигурация указывает, что пользователь разрешает выгрузку пакета в MQTT. Если установлено значение false, удалённым нодам предлагается не пересылать пакеты в MQTT",
+      "label": "Разрешено в MQTT"
     },
     "overrideDutyCycle": {
       "description": "Переопределить рабочий цикл",
       "label": "Переопределить рабочий цикл"
     },
     "overrideFrequency": {
-      "description": "Override frequency",
-      "label": "Override Frequency"
+      "description": "Переопределить частоту",
+      "label": "Переопределить частоту"
     },
     "region": {
-      "description": "Sets the region for your node",
-      "label": "Регион / Страна"
+      "description": "Задаёт регион для вашей ноды",
+      "label": "Регион"
     },
     "spreadingFactor": {
-      "description": "Indicates the number of chirps per symbol",
-      "label": "Spreading Factor"
+      "description": "Количество чирпов на символ",
+      "label": "Фактор расширения"
     },
     "transmitEnabled": {
-      "description": "Enable/Disable transmit (TX) from the LoRa radio",
+      "description": "Включить/выключить передачу (TX) для LoRa",
       "label": "Передача включена"
     },
     "transmitPower": {
-      "description": "Max transmit power",
-      "label": "Мощность передатчика"
+      "description": "Максимальная мощность передачи",
+      "label": "Мощность передачи"
     },
     "usePreset": {
-      "description": "Use one of the predefined modem presets",
-      "label": "Использовать шаблон"
+      "description": "Использовать один из предопределённых пресетов модема",
+      "label": "Использовать пресет"
     },
     "meshSettings": {
-      "description": "Settings for the LoRa mesh",
-      "label": "Mesh Settings"
+      "description": "Настройки LoRa для mesh-сети",
+      "label": "Настройки mesh-сети"
     },
     "waveformSettings": {
-      "description": "Settings for the LoRa waveform",
-      "label": "Waveform Settings"
+      "description": "Настройки формы сигнала LoRa",
+      "label": "Настройки формы сигнала"
     },
     "radioSettings": {
-      "label": "Radio Settings",
-      "description": "Settings for the LoRa radio"
+      "label": "Настройки радио",
+      "description": "Настройки LoRa-радиомодуля"
     }
   },
   "network": {
-    "title": "WiFi Config",
-    "description": "WiFi radio configuration",
-    "note": "Note: Some devices (ESP32) cannot use both Bluetooth and WiFi at the same time.",
+    "title": "Настройки WiFi",
+    "description": "Конфигурация WiFi-радио",
+    "note": "Примечание: некоторые устройства (ESP32) не могут использовать Bluetooth и WiFi одновременно.",
     "addressMode": {
-      "description": "Address assignment selection",
-      "label": "Address Mode"
+      "description": "Выбор способа назначения адреса",
+      "label": "Режим адресации"
     },
     "dns": {
-      "description": "DNS Server",
+      "description": "DNS-сервер",
       "label": "DNS"
     },
     "ethernetEnabled": {
-      "description": "Enable or disable the Ethernet port",
+      "description": "Включить или отключить Ethernet-порт",
       "label": "Включено"
     },
     "gateway": {
-      "description": "Default Gateway",
+      "description": "Шлюз по умолчанию",
       "label": "Шлюз"
     },
     "ip": {
-      "description": "IP Address",
-      "label": "IP-адрес"
+      "description": "IP-адрес",
+      "label": "IP"
     },
     "psk": {
-      "description": "Network password",
-      "label": "Пароль"
+      "description": "Пароль сети",
+      "label": "PSK"
     },
     "ssid": {
-      "description": "Network name",
-      "label": "Название сети"
+      "description": "Имя сети",
+      "label": "SSID"
     },
     "subnet": {
-      "description": "Subnet Mask",
+      "description": "Маска подсети",
       "label": "Подсеть"
     },
     "wifiEnabled": {
-      "description": "Enable or disable the WiFi radio",
+      "description": "Включить или отключить WiFi-радио",
       "label": "Включено"
     },
     "meshViaUdp": {
-      "label": "Mesh via UDP"
+      "label": "Mesh-сеть через UDP"
     },
     "ntpServer": {
-      "label": "NTP Server"
+      "label": "NTP-сервер"
     },
     "rsyslogServer": {
-      "label": "Rsyslog Server"
+      "label": "Rsyslog-сервер"
     },
     "ethernetConfigSettings": {
-      "description": "Ethernet port configuration",
-      "label": "Ethernet Config"
+      "description": "Конфигурация Ethernet-порта",
+      "label": "Настройки Ethernet"
     },
     "ipConfigSettings": {
-      "description": "IP configuration",
-      "label": "IP Config"
+      "description": "IP-конфигурация",
+      "label": "Настройки IP"
     },
     "ntpConfigSettings": {
-      "description": "NTP configuration",
-      "label": "NTP Config"
+      "description": "Конфигурация NTP",
+      "label": "Настройки NTP"
     },
     "rsyslogConfigSettings": {
-      "description": "Rsyslog configuration",
-      "label": "Rsyslog Config"
+      "description": "Конфигурация Rsyslog",
+      "label": "Настройки Rsyslog"
     },
     "udpConfigSettings": {
-      "description": "UDP over Mesh configuration",
-      "label": "UDP Config"
+      "description": "Конфигурация UDP поверх mesh-сети",
+      "label": "Настройки UDP"
     }
   },
   "position": {
-    "title": "Position Settings",
-    "description": "Settings for the position module",
+    "title": "Настройки позиции",
+    "description": "Настройки модуля позиционирования",
     "broadcastInterval": {
-      "description": "How often your position is sent out over the mesh",
-      "label": "Период трансляции"
+      "description": "Как часто ваша позиция отправляется по mesh-сети",
+      "label": "Интервал рассылки"
     },
     "enablePin": {
-      "description": "GPS module enable pin override",
-      "label": "Enable Pin"
+      "description": "Переопределение пина включения GPS-модуля",
+      "label": "Пин включения"
     },
     "fixedPosition": {
-      "description": "Don't report GPS position, but a manually-specified one",
-      "label": "Фиксированное положение"
+      "description": "Не передавать GPS-позицию, а использовать указанную вручную",
+      "label": "Фиксированная позиция",
+      "latitude": {
+        "label": "Широта",
+        "description": "Десятичные градусы между -90 и 90 (например, 37.7749)"
+      },
+      "longitude": {
+        "label": "Долгота",
+        "description": "Десятичные градусы между -180 и 180 (например, -122.4194)"
+      },
+      "altitude": {
+        "label": "Высота",
+        "description": "Необязательно — введите высоту в {{unit}} над уровнем моря (например, 100). Оставьте пустым, если неизвестно, или добавьте высоту для антенн/мачт."
+      }
     },
     "gpsMode": {
-      "description": "Configure whether device GPS is Enabled, Disabled, or Not Present",
-      "label": "GPS Mode"
+      "description": "Настройте, включён ли GPS устройства, выключен или отсутствует",
+      "label": "Режим GPS"
     },
     "gpsUpdateInterval": {
-      "description": "How often a GPS fix should be acquired",
-      "label": "GPS Update Interval"
+      "description": "Как часто следует получать GPS-фикс",
+      "label": "Интервал обновления GPS"
     },
     "positionFlags": {
-      "description": "Optional fields to include when assembling position messages. The more fields are selected, the larger the message will be leading to longer airtime usage and a higher risk of packet loss.",
+      "description": "Необязательные поля для включения в сообщения о позиции. Чем больше полей выбрано, тем больше будет сообщение, что приводит к увеличению времени в эфире и риску потери пакетов.",
       "label": "Флаги позиции"
     },
     "receivePin": {
-      "description": "GPS module RX pin override",
-      "label": "Receive Pin"
+      "description": "Переопределение RX-пина GPS-модуля",
+      "label": "Пин приёма"
     },
     "smartPositionEnabled": {
-      "description": "Only send position when there has been a meaningful change in location",
-      "label": "Enable Smart Position"
+      "description": "Отправлять позицию только при значимом изменении",
+      "label": "Включить умную позицию"
     },
     "smartPositionMinDistance": {
-      "description": "Minimum distance (in meters) that must be traveled before a position update is sent",
-      "label": "Smart Position Minimum Distance"
+      "description": "Минимальная дистанция (в метрах), которую нужно пройти перед отправкой обновления",
+      "label": "Мин. дистанция умной позиции"
     },
     "smartPositionMinInterval": {
-      "description": "Minimum interval (in seconds) that must pass before a position update is sent",
-      "label": "Smart Position Minimum Interval"
+      "description": "Минимальный интервал (в секундах), который должен пройти перед отправкой обновления",
+      "label": "Мин. интервал умной позиции"
     },
     "transmitPin": {
-      "description": "GPS module TX pin override",
-      "label": "Transmit Pin"
+      "description": "Переопределение TX-пина GPS-модуля",
+      "label": "Пин передачи"
     },
     "intervalsSettings": {
-      "description": "How often to send position updates",
-      "label": "Intervals"
+      "description": "Как часто отправлять обновления позиции",
+      "label": "Интервалы"
     },
     "flags": {
-      "placeholder": "Select position flags...",
+      "placeholder": "Выберите флаги позиции...",
       "altitude": "Высота",
-      "altitudeGeoidalSeparation": "Altitude Geoidal Separation",
-      "altitudeMsl": "Altitude is Mean Sea Level",
-      "dop": "Dilution of precision (DOP) PDOP used by default",
-      "hdopVdop": "If DOP is set, use HDOP / VDOP values instead of PDOP",
-      "numSatellites": "Number of satellites",
-      "sequenceNumber": "Sequence number",
-      "timestamp": "Отметка времени",
-      "unset": "Не установлена",
-      "vehicleHeading": "Vehicle heading",
-      "vehicleSpeed": "Vehicle speed"
+      "altitudeGeoidalSeparation": "Геоидальная разность высот",
+      "altitudeMsl": "Высота — средний уровень моря",
+      "dop": "Размытость точности (DOP), по умолчанию используется PDOP",
+      "hdopVdop": "Если DOP задан, использовать значения HDOP/VDOP вместо PDOP",
+      "numSatellites": "Количество спутников",
+      "sequenceNumber": "Порядковый номер",
+      "timestamp": "Временная метка",
+      "unset": "Не задано",
+      "vehicleHeading": "Курс",
+      "vehicleSpeed": "Скорость"
     }
   },
   "power": {
     "adcMultiplierOverride": {
-      "description": "Used for tweaking battery voltage reading",
-      "label": "ADC Multiplier Override ratio"
+      "description": "Используется для коррекции показаний напряжения батареи",
+      "label": "Переопределение коэффициента ADC"
     },
     "ina219Address": {
-      "description": "Address of the INA219 battery monitor",
-      "label": "INA219 Address"
+      "description": "Адрес монитора батареи INA219",
+      "label": "Адрес INA219"
     },
     "lightSleepDuration": {
-      "description": "How long the device will be in light sleep for",
-      "label": "Light Sleep Duration"
+      "description": "Сколько устройство будет в лёгком сне",
+      "label": "Длительность лёгкого сна"
     },
     "minimumWakeTime": {
-      "description": "Minimum amount of time the device will stay awake for after receiving a packet",
-      "label": "Minimum Wake Time"
+      "description": "Минимальное время бодрствования после получения пакета",
+      "label": "Минимальное время бодрствования"
     },
     "noConnectionBluetoothDisabled": {
-      "description": "If the device does not receive a Bluetooth connection, the BLE radio will be disabled after this long",
-      "label": "No Connection Bluetooth Disabled"
+      "description": "Если устройство не получает Bluetooth-подключение, BLE-радио будет отключено через это время",
+      "label": "Отключение Bluetooth при отсутствии подключения"
     },
     "powerSavingEnabled": {
-      "description": "Select if powered from a low-current source (i.e. solar), to minimize power consumption as much as possible.",
+      "description": "Выберите, если питание от источника с малым током (например, солнечного), чтобы максимально снизить потребление.",
       "label": "Включить режим энергосбережения"
     },
     "shutdownOnBatteryDelay": {
-      "description": "Automatically shutdown node after this long when on battery, 0 for indefinite",
-      "label": "Shutdown on battery delay"
+      "description": "Автоматически выключать ноду через это время при питании от батареи, 0 — без ограничения",
+      "label": "Задержка выключения от батареи"
     },
     "superDeepSleepDuration": {
-      "description": "How long the device will be in super deep sleep for",
-      "label": "Super Deep Sleep Duration"
+      "description": "Сколько устройство будет в сверхглубоком сне",
+      "label": "Длительность сверхглубокого сна"
     },
     "powerConfigSettings": {
-      "description": "Settings for the power module",
-      "label": "Настройка питания"
+      "description": "Настройки модуля питания",
+      "label": "Настройки питания"
     },
     "sleepSettings": {
-      "description": "Sleep settings for the power module",
-      "label": "Sleep Settings"
+      "description": "Настройки сна модуля питания",
+      "label": "Настройки сна"
     }
   },
   "security": {
-    "description": "Settings for the Security configuration",
-    "title": "Security Settings",
-    "button_backupKey": "Backup Key",
+    "description": "Параметры безопасности",
+    "title": "Настройки безопасности",
+    "button_backupKey": "Резервная копия ключа",
     "adminChannelEnabled": {
-      "description": "Allow incoming device control over the insecure legacy admin channel",
-      "label": "Allow Legacy Admin"
+      "description": "Разрешить входящее управление устройством через небезопасный устаревший админ-канал",
+      "label": "Разрешить устаревший админ"
     },
     "enableDebugLogApi": {
-      "description": "Output live debug logging over serial, view and export position-redacted device logs over Bluetooth",
-      "label": "Enable Debug Log API"
+      "description": "Выводить живой отладочный лог по COM-порту, просматривать и экспортировать логи устройства с удалением координат по Bluetooth",
+      "label": "Включить API отладочных логов"
     },
     "managed": {
-      "description": "If enabled, device configuration options are only able to be changed remotely by a Remote Admin node via admin messages. Do not enable this option unless at least one suitable Remote Admin node has been setup, and the public key is stored in one of the fields above.",
-      "label": "Managed"
+      "description": "Если включено, параметры устройства можно менять удалённо только через ноду Remote Admin с помощью админ-сообщений. Не включайте эту опцию, если не настроена хотя бы одна подходящая нода Remote Admin и её публичный ключ не сохранён в одном из полей выше.",
+      "label": "Управляемый режим"
     },
     "privateKey": {
-      "description": "Used to create a shared key with a remote device",
+      "description": "Используется для создания общего ключа с удалённым устройством",
       "label": "Приватный ключ"
     },
     "publicKey": {
-      "description": "Sent out to other nodes on the mesh to allow them to compute a shared secret key",
+      "description": "Отправляется другим нодам в mesh-сети, чтобы они могли вычислить общий секретный ключ",
       "label": "Публичный ключ"
     },
     "primaryAdminKey": {
-      "description": "The primary public key authorized to send admin messages to this node",
-      "label": "Primary Admin Key"
+      "description": "Первичный публичный ключ, которому разрешено отправлять админ-сообщения этой ноде",
+      "label": "Первичный админ-ключ"
     },
     "secondaryAdminKey": {
-      "description": "The secondary public key authorized to send admin messages to this node",
-      "label": "Secondary Admin Key"
+      "description": "Вторичный публичный ключ, которому разрешено отправлять админ-сообщения этой ноде",
+      "label": "Вторичный админ-ключ"
     },
     "serialOutputEnabled": {
-      "description": "Serial Console over the Stream API",
-      "label": "Serial Output Enabled"
+      "description": "Консоль COM-порта через Stream API",
+      "label": "Вывод через COM-порт включён"
     },
     "tertiaryAdminKey": {
-      "description": "The tertiary public key authorized to send admin messages to this node",
-      "label": "Tertiary Admin Key"
+      "description": "Третичный публичный ключ, которому разрешено отправлять админ-сообщения этой ноде",
+      "label": "Третичный админ-ключ"
     },
     "adminSettings": {
-      "description": "Settings for Admin",
-      "label": "Admin Settings"
+      "description": "Настройки администратора",
+      "label": "Настройки администратора"
     },
     "loggingSettings": {
-      "description": "Settings for Logging",
-      "label": "Logging Settings"
+      "description": "Настройки логирования",
+      "label": "Настройки логирования"
     }
   },
   "user": {
-    "title": "User Settings",
-    "description": "Configure your device name and identity settings",
+    "title": "Настройки пользователя",
+    "description": "Настройте имя устройства и параметры идентификации",
     "longName": {
       "label": "Полное имя",
-      "description": "Your full display name (1-40 characters)",
+      "description": "Ваше полное отображаемое имя (1–40 символов)",
       "validation": {
-        "min": "Long name must be at least 1 character",
-        "max": "Long name must be at most 40 characters"
+        "min": "Полное имя должно быть не короче 1 символа",
+        "max": "Полное имя должно быть не длиннее 40 символов"
       }
     },
     "shortName": {
       "label": "Короткое имя",
-      "description": "Your abbreviated name (2-4 characters)",
+      "description": "Сокращённое имя (2–4 символа)",
       "validation": {
-        "min": "Short name must be at least 2 characters",
-        "max": "Short name must be at most 4 characters"
+        "min": "Короткое имя должно быть не короче 2 символов",
+        "max": "Короткое имя должно быть не длиннее 4 символов"
       }
     },
     "isUnmessageable": {
-      "label": "Не отправляемо",
-      "description": "Used to identify unmonitored or infrastructure nodes so that messaging is not available to nodes that will never respond."
+      "label": "Недоступен для сообщений",
+      "description": "Используется для обозначения необслуживаемых или инфраструктурных нод, чтобы отключить обмен сообщениями для нод, которые никогда не отвечают."
     },
     "isLicensed": {
       "label": "Лицензированный радиолюбитель (HAM)",
-      "description": "Enable if you are a licensed amateur radio operator, enabling this option disables encryption and is not compatible with the default Meshtastic network."
+      "description": "Включите, если вы лицензированный радиолюбитель; это отключает шифрование и несовместимо с сетью Meshtastic по умолчанию."
     }
   }
 }

--- a/packages/web/public/i18n/locales/ru-RU/connections.json
+++ b/packages/web/public/i18n/locales/ru-RU/connections.json
@@ -1,34 +1,34 @@
 {
   "page": {
-    "title": "Connect to a Meshtastic device",
-    "description": "Add a device connection via HTTP, Bluetooth, or Serial. Your saved connections will be saved in your browser."
+    "title": "Подключение к устройству Meshtastic",
+    "description": "Добавьте подключение по HTTP, Bluetooth или COM-порту. Сохранённые подключения будут храниться в вашем браузере."
   },
   "connectionType_ble": "BLE",
   "connectionType_serial": "COM-порт",
   "connectionType_network": "Сеть",
-  "deleteConnection": "Delete connection",
-  "areYouSure": "This will remove {{name}}. You canot undo this action.",
-  "moreActions": "More actions",
+  "deleteConnection": "Удалить подключение",
+  "areYouSure": "Это удалит {{name}}. Это действие нельзя отменить.",
+  "moreActions": "Другие действия",
   "noConnections": {
-    "title": "No connections yet.",
-    "description": "Create your first connection. It will connect immediately and be saved for later."
+    "title": "Подключений пока нет.",
+    "description": "Создайте первое подключение. Оно подключится сразу и сохранится на будущее."
   },
-  "lastConnectedAt": "Last connected: {{date}}",
-  "neverConnected": "Never connected",
+  "lastConnectedAt": "Последнее подключение: {{date}}",
+  "neverConnected": "Никогда не подключалось",
   "toasts": {
     "connected": "Подключено",
-    "nowConnected": "{{name}} is now connected",
-    "nowDisconnected": "{{name}} are now disconnecte",
+    "nowConnected": "Подключено: {{name}}",
+    "nowDisconnected": "Отключено: {{name}}",
     "disconnected": "Отключено",
-    "failed": "Failed to connect",
-    "checkConnetion": "Check your device or settings and try again",
-    "defaultSet": "Default set",
-    "defaultConnection": "Default connection is now {{nameisconnected}}",
-    "deleted": "Deleted",
-    "deletedByName": "{{name}} was removed",
-    "pickConnectionAgain": "Could not connect. You may need to reselect the device/port.",
-    "added": "Connection added",
-    "savedByName": "{{name}} saved.",
-    "savedCantConnect": "The connection was saved but could not connect."
+    "failed": "Не удалось подключиться",
+    "checkConnection": "Проверьте устройство или настройки и попробуйте снова",
+    "defaultSet": "По умолчанию",
+    "defaultConnection": "Теперь подключение по умолчанию: {{nameisconnected}}",
+    "deleted": "Удалено",
+    "deletedByName": "Удалено: {{name}}",
+    "pickConnectionAgain": "Не удалось подключиться. Возможно, нужно заново выбрать устройство/порт.",
+    "added": "Подключение добавлено",
+    "savedByName": "{{name}} сохранено.",
+    "savedCantConnect": "Подключение сохранено, но подключиться не удалось."
   }
 }

--- a/packages/web/public/i18n/locales/ru-RU/dialog.json
+++ b/packages/web/public/i18n/locales/ru-RU/dialog.json
@@ -1,238 +1,238 @@
 {
   "deleteMessages": {
-    "description": "This action will clear all message history. This cannot be undone. Are you sure you want to continue?",
-    "title": "Clear All Messages"
+    "description": "Это действие очистит всю историю сообщений. Это нельзя отменить. Вы уверены, что хотите продолжить?",
+    "title": "Очистить все сообщения"
   },
   "import": {
-    "description": "Import a Channel Set from a Meshtastic URL. <br />Valid Meshtasic URLs start with \"<italic>https://meshtastic.org/e/...</italic>\"",
+    "description": "Импортируйте набор каналов по URL Meshtastic. <br />Корректные URL Meshtastic начинаются с \"<italic>https://meshtastic.org/e/...</italic>\"",
     "error": {
-      "invalidUrl": "Invalid Meshtastic URL"
+      "invalidUrl": "Некорректный URL Meshtastic"
     },
-    "channelPrefix": "Channel ",
-    "primary": "Primary ",
-    "doNotImport": "No not import",
+    "channelPrefix": "Канал ",
+    "primary": "Первичный ",
+    "doNotImport": "Не импортировать",
     "channelName": "Имя",
     "channelSlot": "Слот",
-    "channelSetUrl": "Channel Set/QR Code URL",
-    "useLoraConfig": "Import LoRa Config",
-    "presetDescription": "The current LoRa Config will be replaced.",
-    "title": "Import Channels"
+    "channelSetUrl": "URL набора каналов/QR-кода",
+    "useLoraConfig": "Импортировать конфигурацию LoRa",
+    "presetDescription": "Текущая конфигурация LoRa будет заменена.",
+    "title": "Импорт каналов"
   },
   "locationResponse": {
-    "title": "Location: {{identifier}}",
-    "altitude": "Altitude: ",
-    "coordinates": "Coordinates: ",
-    "noCoordinates": "No Coordinates"
+    "title": "Местоположение: {{identifier}}",
+    "altitude": "Высота: ",
+    "coordinates": "Координаты: ",
+    "noCoordinates": "Нет координат"
   },
   "pkiRegenerateDialog": {
-    "title": "Regenerate Pre-Shared Key?",
-    "description": "Are you sure you want to regenerate the pre-shared key?",
-    "regenerate": "Regenerate"
+    "title": "Сгенерировать Pre-Shared Key заново?",
+    "description": "Вы уверены, что хотите пересоздать Pre-Shared Key?",
+    "regenerate": "Сгенерировать заново"
   },
   "addConnection": {
-    "title": "Add connection",
-    "description": "Choose a connection type and fill in the details",
+    "title": "Добавить подключение",
+    "description": "Выберите тип подключения и заполните параметры",
     "validation": {
-      "requiresWebBluetooth": "This connection type requires <0>Web Bluetooth</0>. Please use a supported browser, like Chrome or Edge.",
-      "requiresWebSerial": "This connection type requires <0>Web Serial</0>. Please use a supported browser, like Chrome or Edge.",
-      "requiresSecureContext": "This application requires a <0>secure context</0>. Please connect using HTTPS or localhost.",
-      "additionallyRequiresSecureContext": "Additionally, it requires a <0>secure context</0>. Please connect using HTTPS or localhost."
+      "requiresWebBluetooth": "Для этого типа подключения требуется <0>Web Bluetooth</0>. Используйте поддерживаемый браузер, например Chrome или Edge.",
+      "requiresWebSerial": "Для этого типа подключения требуется <0>Web Serial</0>. Используйте поддерживаемый браузер, например Chrome или Edge.",
+      "requiresSecureContext": "Этому приложению требуется <0>безопасный контекст</0>. Подключайтесь через HTTPS или localhost.",
+      "additionallyRequiresSecureContext": "Кроме того, требуется <0>безопасный контекст</0>. Подключайтесь через HTTPS или localhost."
     },
     "bluetoothConnection": {
-      "namePlaceholder": "My Bluetooth Node",
+      "namePlaceholder": "Моя Bluetooth-нода",
       "supported": {
-        "title": "Web Bluetooth supported"
+        "title": "Web Bluetooth поддерживается"
       },
       "notSupported": {
-        "title": "Web Bluetooth not supported",
-        "description": "Your browser or device does not support Web Bluetooth"
+        "title": "Web Bluetooth не поддерживается",
+        "description": "Ваш браузер или устройство не поддерживает Web Bluetooth"
       },
       "short": "BT: {{deviceName}}",
-      "long": "Bluetooth Device",
+      "long": "Bluetooth-устройство",
       "device": "Устройство",
-      "selectDevice": "Select device",
-      "selected": "Bluetooth device selected",
-      "notSelected": "No device selected",
-      "helperText": "Uses the Meshtastic Bluetooth service for discovery."
+      "selectDevice": "Выберите устройство",
+      "selected": "Bluetooth-устройство выбрано",
+      "notSelected": "Устройство не выбрано",
+      "helperText": "Используется служба Meshtastic Bluetooth для обнаружения."
     },
     "serialConnection": {
-      "namePlaceholder": "My Serial Node",
-      "helperText": "Selecting a port grants permission so the app can open it to connect.",
+      "namePlaceholder": "Моя COM-нода",
+      "helperText": "Выбор порта даёт разрешение, чтобы приложение могло открыть его для подключения.",
       "supported": {
-        "title": "Web Serial supported"
+        "title": "Web Serial поддерживается"
       },
       "notSupported": {
-        "title": "Web Serial not supported",
-        "description": "Your browser or device does not support Web Serial"
+        "title": "Web Serial не поддерживается",
+        "description": "Ваш браузер или устройство не поддерживает Web Serial"
       },
       "portSelected": {
-        "title": "Serial port selected",
-        "description": "Port permissions granted."
+        "title": "Порт выбран",
+        "description": "Разрешения на порт предоставлены."
       },
-      "port": "Port",
-      "selectPort": "Select port",
+      "port": "Порт",
+      "selectPort": "Выберите порт",
       "deviceName": "USB {{vendorId}}:{{productId}}",
-      "notSelected": "No port selected"
+      "notSelected": "Порт не выбран"
     },
     "httpConnection": {
-      "namePlaceholder": "My HTTP Node",
-      "inputPlaceholder": "192.168.1.10 or meshtastic.local",
-      "heading": "URL or IP",
-      "useHttps": "Use HTTTPS",
+      "namePlaceholder": "Моя HTTP-нода",
+      "inputPlaceholder": "192.168.1.10 или meshtastic.local",
+      "heading": "URL или IP",
+      "useHttps": "Использовать HTTPS",
       "invalidUrl": {
-        "title": "Invalid URL",
-        "description": "Please enter a valid HTTP or HTTPS URL."
+        "title": "Неверный URL",
+        "description": "Введите корректный URL HTTP или HTTPS."
       },
       "connectionTest": {
-        "description": "Test the connetion before saving to verify the device is reachable.",
+        "description": "Проверьте подключение перед сохранением, чтобы убедиться, что устройство доступно.",
         "button": {
-          "loading": "Testing...",
-          "label": "Test connection"
+          "loading": "Проверка...",
+          "label": "Проверить подключение"
         },
-        "reachable": "Reachable",
-        "notReachable": "Not reachable",
+        "reachable": "Доступно",
+        "notReachable": "Недоступно",
         "success": {
-          "title": "Connection test successful",
-          "description": "The device appears to be reachable."
+          "title": "Проверка подключения успешна",
+          "description": "Устройство доступно."
         },
         "failure": {
-          "title": "Connection test failed",
-          "description": "Could not reach the device. Check the URL and try again."
+          "title": "Проверка подключения не удалась",
+          "description": "Не удалось связаться с устройством. Проверьте URL и попробуйте снова."
         }
       }
     }
   },
   "nodeDetails": {
     "message": "Сообщение",
-    "requestPosition": "Request Position",
-    "traceRoute": "Trace Route",
-    "airTxUtilization": "Air TX utilization",
-    "allRawMetrics": "All Raw Metrics:",
-    "batteryLevel": "Battery level",
-    "channelUtilization": "Channel utilization",
-    "details": "Details:",
-    "deviceMetrics": "Device Metrics:",
-    "hardware": "Hardware: ",
-    "lastHeard": "Last Heard: ",
-    "nodeHexPrefix": "Node Hex: ",
-    "nodeNumber": "Node Number: ",
-    "position": "Position:",
-    "role": "Role: ",
-    "uptime": "Uptime: ",
+    "requestPosition": "Запросить позицию",
+    "traceRoute": "Трассировка маршрута",
+    "airTxUtilization": "Загрузка TX в эфире",
+    "allRawMetrics": "Все сырые метрики:",
+    "batteryLevel": "Уровень батареи",
+    "channelUtilization": "Загрузка канала",
+    "details": "Детали:",
+    "deviceMetrics": "Метрики устройства:",
+    "hardware": "Оборудование: ",
+    "lastHeard": "Последний раз слышен: ",
+    "nodeHexPrefix": "HEX ноды: ",
+    "nodeNumber": "Номер ноды: ",
+    "position": "Позиция:",
+    "role": "Роль: ",
+    "uptime": "Время работы: ",
     "voltage": "Напряжение",
-    "title": "Node Details for {{identifier}}",
-    "ignoreNode": "Ignore node",
-    "removeNode": "Remove node",
-    "unignoreNode": "Unignore node",
-    "security": "Security:",
-    "publicKey": "Public Key: ",
-    "messageable": "Messageable: ",
-    "KeyManuallyVerifiedTrue": "Public Key has been manually verified",
-    "KeyManuallyVerifiedFalse": "Public Key is not manually verified"
+    "title": "Детали ноды {{identifier}}",
+    "ignoreNode": "Игнорировать ноду",
+    "removeNode": "Удалить ноду",
+    "unignoreNode": "Не игнорировать ноду",
+    "security": "Безопасность:",
+    "publicKey": "Публичный ключ: ",
+    "messageable": "Доступен для сообщений: ",
+    "KeyManuallyVerifiedTrue": "Публичный ключ вручную подтверждён",
+    "KeyManuallyVerifiedFalse": "Публичный ключ не подтверждён вручную"
   },
   "pkiBackup": {
-    "loseKeysWarning": "If you lose your keys, you will need to reset your device.",
-    "secureBackup": "Its important to backup your public and private keys and store your backup securely!",
-    "footer": "=== END OF KEYS ===",
-    "header": "=== MESHTASTIC KEYS FOR {{longName}} ({{shortName}}) ===",
-    "privateKey": "Private Key:",
-    "publicKey": "Public Key:",
+    "loseKeysWarning": "Если вы потеряете ключи, потребуется сбросить устройство.",
+    "secureBackup": "Важно сделать резервную копию публичного и приватного ключей и хранить её безопасно!",
+    "footer": "=== КОНЕЦ КЛЮЧЕЙ ===",
+    "header": "=== КЛЮЧИ MESHTASTIC ДЛЯ {{longName}} ({{shortName}}) ===",
+    "privateKey": "Приватный ключ:",
+    "publicKey": "Публичный ключ:",
     "fileName": "meshtastic_keys_{{longName}}_{{shortName}}.txt",
-    "title": "Backup Keys"
+    "title": "Резервное копирование ключей"
   },
   "pkiBackupReminder": {
-    "description": "We recommend backing up your key data regularly. Would you like to back up now?",
-    "title": "Backup Reminder",
-    "remindLaterPrefix": "Remind me in",
-    "remindNever": "Never remind me",
-    "backupNow": "Back up now"
+    "description": "Рекомендуем регулярно делать резервную копию ключевых данных. Хотите сделать копию сейчас?",
+    "title": "Напоминание о резервной копии",
+    "remindLaterPrefix": "Напомнить через",
+    "remindNever": "Никогда не напоминать",
+    "backupNow": "Сделать копию сейчас"
   },
   "pkiRegenerate": {
-    "description": "Are you sure you want to regenerate key pair?",
-    "title": "Regenerate Key Pair"
+    "description": "Вы уверены, что хотите пересоздать пару ключей?",
+    "title": "Пересоздать пару ключей"
   },
   "qr": {
-    "addChannels": "Add Channels",
-    "replaceChannels": "Replace Channels",
-    "description": "The current LoRa configuration will also be shared.",
-    "sharableUrl": "Sharable URL",
-    "title": "Generate QR Code"
+    "addChannels": "Добавить каналы",
+    "replaceChannels": "Заменить каналы",
+    "description": "Текущая конфигурация LoRa также будет передана.",
+    "sharableUrl": "Ссылка для обмена",
+    "title": "Сгенерировать QR-код"
   },
   "reboot": {
-    "title": "Reboot device",
-    "description": "Reboot now or schedule a reboot of the connected node. Optionally, you can choose to reboot into OTA (Over-the-Air) mode.",
-    "ota": "Reboot into OTA mode",
-    "enterDelay": "Enter delay",
-    "scheduled": "Reboot has been scheduled",
-    "schedule": "Schedule reboot",
-    "now": "Reboot now",
-    "cancel": "Cancel scheduled reboot"
+    "title": "Перезагрузка устройства",
+    "description": "Перезагрузить сейчас или запланировать перезагрузку подключённой ноды. При желании можно перезагрузить в режим OTA (Over-the-Air).",
+    "ota": "Перезагрузить в режим OTA",
+    "enterDelay": "Укажите задержку",
+    "scheduled": "Перезагрузка запланирована",
+    "schedule": "Запланировать перезагрузку",
+    "now": "Перезагрузить сейчас",
+    "cancel": "Отменить запланированную перезагрузку"
   },
   "refreshKeys": {
     "description": {
-      "acceptNewKeys": "This will remove the node from device and request new keys.",
-      "keyMismatchReasonSuffix": ". This is due to the remote node's current public key does not match the previously stored key for this node.",
-      "unableToSendDmPrefix": "Your node is unable to send a direct message to node: "
+      "acceptNewKeys": "Это удалит ноду с устройства и запросит новые ключи.",
+      "keyMismatchReasonSuffix": ". Это связано с тем, что текущий публичный ключ удалённой ноды не совпадает с ранее сохранённым ключом для этой ноды.",
+      "unableToSendDmPrefix": "Ваша нода не может отправить личное сообщение ноде: "
     },
-    "acceptNewKeys": "Accept New Keys",
-    "title": "Keys Mismatch - {{identifier}}"
+    "acceptNewKeys": "Принять новые ключи",
+    "title": "Несоответствие ключей — {{identifier}}"
   },
   "removeNode": {
-    "description": "Are you sure you want to remove this Node?",
-    "title": "Remove Node?"
+    "description": "Вы уверены, что хотите удалить эту ноду?",
+    "title": "Удалить ноду?"
   },
   "shutdown": {
-    "title": "Schedule Shutdown",
-    "description": "Turn off the connected node after x minutes."
+    "title": "Запланировать выключение",
+    "description": "Выключить подключённую ноду через X минут."
   },
   "traceRoute": {
-    "routeToDestination": "Route to destination:",
-    "routeBack": "Route back:"
+    "routeToDestination": "Маршрут к месту назначения:",
+    "routeBack": "Маршрут обратно:"
   },
   "tracerouteResponse": {
-    "title": "Traceroute: {{identifier}}"
+    "title": "Трассировка: {{identifier}}"
   },
   "unsafeRoles": {
-    "confirmUnderstanding": "Yes, I know what I'm doing",
-    "conjunction": " and the blog post about ",
-    "postamble": " and understand the implications of changing the role.",
-    "preamble": "I have read the ",
-    "choosingRightDeviceRole": "Choosing The Right Device Role",
-    "deviceRoleDocumentation": "Device Role Documentation",
+    "confirmUnderstanding": "Да, я понимаю, что делаю",
+    "conjunction": " и запись в блоге о ",
+    "postamble": " и понимаю последствия изменения роли.",
+    "preamble": "Я прочитал(а) ",
+    "choosingRightDeviceRole": "Как выбрать правильную роль устройства",
+    "deviceRoleDocumentation": "Документация по ролям устройств",
     "title": "Вы уверены?"
   },
   "managedMode": {
-    "confirmUnderstanding": "Yes, I know what I'm doing",
+    "confirmUnderstanding": "Да, я понимаю, что делаю",
     "title": "Вы уверены?",
-    "description": "Enabling Managed Mode blocks client applications (including the web client) from writing configurations to a radio. Once enabled, radio configurations can only be changed through Remote Admin messages. This setting is not required for remote node administration."
+    "description": "Включение управляемого режима блокирует клиентские приложения (включая веб-клиент) от записи конфигурации в радио. После включения конфигурации радиомодуля можно менять только через сообщения удалённого администратора. Эта настройка не требуется для удалённого администрирования нод."
   },
   "clientNotification": {
-    "title": "Уведомления клиента",
-    "TraceRoute can only be sent once every 30 seconds": "TraceRoute can only be sent once every 30 seconds",
-    "Compromised keys were detected and regenerated.": "Compromised keys were detected and regenerated."
+    "title": "Уведомление клиента",
+    "TraceRoute can only be sent once every 30 seconds": "Трассировку можно отправлять не чаще одного раза в 30 секунд",
+    "Compromised keys were detected and regenerated.": "Обнаружены скомпрометированные ключи и они были пересозданы."
   },
   "resetNodeDb": {
-    "title": "Reset Node Database",
-    "description": "This will clear all nodes from the connected device's node database and clear all message history in the client. This cannot be undone. Are you sure you want to continue?",
-    "confirm": "Reset Node Database",
-    "failedTitle": "There was an error resetting the Node DB. Please try again."
+    "title": "Сброс базы нод",
+    "description": "Это действие удалит все ноды из базы нод подключённого устройства и очистит всю историю сообщений в клиенте. Это нельзя отменить. Вы уверены, что хотите продолжить?",
+    "confirm": "Сбросить базу нод",
+    "failedTitle": "Произошла ошибка при сбросе базы нод. Повторите попытку."
   },
   "clearAllStores": {
-    "title": "Clear All Local Storage",
-    "description": "This will clear all locally stored data, including message history and node databases for all previously connected devices. This will require you to reconnect to your node once complete and cannot be undone. Are you sure you want to continue?",
-    "confirm": "Clear all local storage",
-    "failedTitle": "There was an error clearing local storage. Please try again."
+    "title": "Очистить всё локальное хранилище",
+    "description": "Это действие очистит все локально сохранённые данные, включая историю сообщений и базы нод для всех ранее подключённых устройств. После завершения потребуется заново подключиться к ноде. Это нельзя отменить. Вы уверены, что хотите продолжить?",
+    "confirm": "Очистить всё локальное хранилище",
+    "failedTitle": "Произошла ошибка при очистке локального хранилища. Повторите попытку."
   },
   "factoryResetDevice": {
-    "title": "Factory Reset Device",
-    "description": "This will factory reset the connected device, erasing all configurations and data on the device as well as all nodes and messages saved in the client. This cannot be undone. Are you sure you want to continue?",
-    "confirm": "Factory Reset Device",
-    "failedTitle": "There was an error performing the factory reset. Please try again."
+    "title": "Сброс устройства к заводским настройкам",
+    "description": "Это действие выполнит сброс подключённого устройства к заводским настройкам, удалив все конфигурации и данные на устройстве, а также все ноды и сообщения, сохранённые в клиенте. Это нельзя отменить. Вы уверены, что хотите продолжить?",
+    "confirm": "Сбросить устройство к заводским настройкам",
+    "failedTitle": "Произошла ошибка при выполнении сброса. Повторите попытку."
   },
   "factoryResetConfig": {
-    "title": "Factory Reset Config",
-    "description": "This will factory reset the configuration on the connected device, erasing all configurations on the device. This cannot be undone. Are you sure you want to continue?",
-    "confirm": "Factory Reset Config",
-    "failedTitle": "There was an error performing the factory reset. Please try again."
+    "title": "Сброс конфигурации к заводским настройкам",
+    "description": "Это действие выполнит сброс конфигурации на подключённом устройстве, удалив все конфигурации на устройстве. Это нельзя отменить. Вы уверены, что хотите продолжить?",
+    "confirm": "Сбросить конфигурацию к заводским настройкам",
+    "failedTitle": "Произошла ошибка при выполнении сброса. Повторите попытку."
   }
 }

--- a/packages/web/public/i18n/locales/ru-RU/map.json
+++ b/packages/web/public/i18n/locales/ru-RU/map.json
@@ -1,38 +1,40 @@
 {
   "maplibre": {
-    "GeolocateControl.FindMyLocation": "Find my location",
-    "NavigationControl.ZoomIn": "Zoom in",
-    "NavigationControl.ZoomOut": "Zoom out",
-    "CooperativeGesturesHandler.WindowsHelpText": "Use Ctrl + scroll to zoom the map",
-    "CooperativeGesturesHandler.MacHelpText": "Use ⌘ + scroll to zoom the map",
-    "CooperativeGesturesHandler.MobileHelpText": "Use two fingers to move the map"
+    "GeolocateControl.FindMyLocation": "Найти моё местоположение",
+    "NavigationControl.ZoomIn": "Увеличить",
+    "NavigationControl.ZoomOut": "Уменьшить",
+    "CooperativeGesturesHandler.WindowsHelpText": "Используйте Ctrl + прокрутку, чтобы приблизить карту",
+    "CooperativeGesturesHandler.MacHelpText": "Используйте ⌘ + прокрутку, чтобы приблизить карту",
+    "CooperativeGesturesHandler.MobileHelpText": "Используйте два пальца, чтобы перемещать карту"
   },
   "layerTool": {
-    "nodeMarkers": "Show nodes",
-    "directNeighbors": "Show direct connections",
-    "remoteNeighbors": "Show remote connections",
-    "positionPrecision": "Show position precision",
-    "traceroutes": "Show traceroutes",
-    "waypoints": "Show waypoints"
+    "nodeMarkers": "Показать ноды",
+    "directNeighbors": "Показать прямые соединения",
+    "remoteNeighbors": "Показать удалённые соединения",
+    "positionPrecision": "Показать точность позиции",
+    "traceroutes": "Показать трассировки",
+    "waypoints": "Показать путевые точки",
+    "heatmap": "Показать тепловую карту",
+    "density": "Плотность"
   },
   "mapMenu": {
-    "locateAria": "Locate my node",
-    "layersAria": "Change map style"
+    "locateAria": "Найти мою ноду",
+    "layersAria": "Изменить стиль карты"
   },
   "waypointDetail": {
     "edit": "Редактировать",
-    "description": "Description:",
-    "createdBy": "Edited by:",
-    "createdDate": "Created:",
-    "updated": "Updated:",
-    "expires": "Expires:",
-    "distance": "Distance:",
-    "bearing": "Absolute bearing:",
-    "lockedTo": "Locked by:",
-    "latitude": "Latitude:",
-    "longitude": "Longitude:"
+    "description": "Описание:",
+    "createdBy": "Кем изменено:",
+    "createdDate": "Создано:",
+    "updated": "Обновлено:",
+    "expires": "Истекает:",
+    "distance": "Расстояние:",
+    "bearing": "Абсолютный азимут:",
+    "lockedTo": "Закреплено за:",
+    "latitude": "Широта:",
+    "longitude": "Долгота:"
   },
   "myNode": {
-    "tooltip": "This device"
+    "tooltip": "Это устройство"
   }
 }

--- a/packages/web/public/i18n/locales/ru-RU/messages.json
+++ b/packages/web/public/i18n/locales/ru-RU/messages.json
@@ -1,39 +1,39 @@
 {
   "page": {
-    "title": "Messages: {{chatName}}",
-    "placeholder": "Enter Message"
+    "title": "Сообщения: {{chatName}}",
+    "placeholder": "Введите сообщение"
   },
   "emptyState": {
-    "title": "Select a Chat",
-    "text": "No messages yet."
+    "title": "Выберите чат",
+    "text": "Сообщений пока нет."
   },
   "selectChatPrompt": {
-    "text": "Select a channel or node to start messaging."
+    "text": "Выберите канал или ноду, чтобы начать переписку."
   },
   "sendMessage": {
-    "placeholder": "Enter your message here...",
+    "placeholder": "Введите сообщение...",
     "sendButton": "Отправить"
   },
   "actionsMenu": {
-    "addReactionLabel": "Add Reaction",
+    "addReactionLabel": "Добавить реакцию",
     "replyLabel": "Ответить"
   },
   "deliveryStatus": {
     "delivered": {
-      "label": "Message delivered",
-      "displayText": "Message delivered"
+      "label": "Сообщение доставлено",
+      "displayText": "Сообщение доставлено"
     },
     "failed": {
-      "label": "Message delivery failed",
-      "displayText": "Delivery failed"
+      "label": "Не удалось доставить сообщение",
+      "displayText": "Доставка не удалась"
     },
     "unknown": {
-      "label": "Message status unknown",
-      "displayText": "Unknown state"
+      "label": "Статус сообщения неизвестен",
+      "displayText": "Неизвестный статус"
     },
     "waiting": {
-      "label": "Sending message",
-      "displayText": "Waiting for delivery"
+      "label": "Отправка сообщения",
+      "displayText": "Ожидание доставки"
     }
   }
 }

--- a/packages/web/public/i18n/locales/ru-RU/moduleConfig.json
+++ b/packages/web/public/i18n/locales/ru-RU/moduleConfig.json
@@ -1,448 +1,448 @@
 {
   "page": {
-    "tabAmbientLighting": "Световое освещение",
-    "tabAudio": "Звук",
-    "tabCannedMessage": "Canned",
+    "tabAmbientLighting": "Подсветка",
+    "tabAudio": "Аудио",
+    "tabCannedMessage": "Шаблоны",
     "tabDetectionSensor": "Датчик обнаружения",
-    "tabExternalNotification": "Ext Notif",
+    "tabExternalNotification": "Внешн. уведомл.",
     "tabMqtt": "MQTT",
-    "tabNeighborInfo": "Информация об окружности",
-    "tabPaxcounter": "Счётчик прохожих",
-    "tabRangeTest": "Проверка дальности",
+    "tabNeighborInfo": "Инфо о соседях",
+    "tabPaxcounter": "Paxcounter",
+    "tabRangeTest": "Тест дальности",
     "tabSerial": "COM-порт",
     "tabStoreAndForward": "S&F",
     "tabTelemetry": "Телеметрия"
   },
   "ambientLighting": {
-    "title": "Ambient Lighting Settings",
-    "description": "Settings for the Ambient Lighting module",
+    "title": "Настройки подсветки",
+    "description": "Настройки модуля подсветки",
     "ledState": {
-      "label": "LED State",
-      "description": "Sets LED to on or off"
+      "label": "Состояние LED",
+      "description": "Включить или выключить LED"
     },
     "current": {
       "label": "Ток",
-      "description": "Sets the current for the LED output. Default is 10"
+      "description": "Устанавливает ток для LED-выхода. По умолчанию 10"
     },
     "red": {
       "label": "Красный",
-      "description": "Sets the red LED level. Values are 0-255"
+      "description": "Устанавливает яркость красного LED. Значения 0–255"
     },
     "green": {
-      "label": "Зеленый",
-      "description": "Sets the green LED level. Values are 0-255"
+      "label": "Зелёный",
+      "description": "Устанавливает яркость зелёного LED. Значения 0–255"
     },
     "blue": {
       "label": "Синий",
-      "description": "Sets the blue LED level. Values are 0-255"
+      "description": "Устанавливает яркость синего LED. Значения 0–255"
     }
   },
   "audio": {
-    "title": "Audio Settings",
-    "description": "Settings for the Audio module",
+    "title": "Настройки аудио",
+    "description": "Настройки аудио-модуля",
     "codec2Enabled": {
-      "label": "Codec 2 Enabled",
-      "description": "Enable Codec 2 audio encoding"
+      "label": "Codec 2 включён",
+      "description": "Включить аудиокодирование Codec 2"
     },
     "pttPin": {
-      "label": "PTT Pin",
-      "description": "GPIO pin to use for PTT"
+      "label": "Пин PTT",
+      "description": "GPIO-пин для PTT"
     },
     "bitrate": {
-      "label": "Bitrate",
-      "description": "Bitrate to use for audio encoding"
+      "label": "Битрейт",
+      "description": "Битрейт для аудиокодирования"
     },
     "i2sWs": {
       "label": "i2S WS",
-      "description": "GPIO pin to use for i2S WS"
+      "description": "GPIO-пин для i2S WS"
     },
     "i2sSd": {
       "label": "i2S SD",
-      "description": "GPIO pin to use for i2S SD"
+      "description": "GPIO-пин для i2S SD"
     },
     "i2sDin": {
       "label": "i2S DIN",
-      "description": "GPIO pin to use for i2S DIN"
+      "description": "GPIO-пин для i2S DIN"
     },
     "i2sSck": {
       "label": "i2S SCK",
-      "description": "GPIO pin to use for i2S SCK"
+      "description": "GPIO-пин для i2S SCK"
     }
   },
   "cannedMessage": {
-    "title": "Canned Message Settings",
-    "description": "Settings for the Canned Message module",
+    "title": "Настройки шаблонных сообщений",
+    "description": "Настройки модуля шаблонных сообщений",
     "moduleEnabled": {
-      "label": "Module Enabled",
-      "description": "Enable Canned Message"
+      "label": "Модуль включён",
+      "description": "Включить шаблонные сообщения"
     },
     "rotary1Enabled": {
-      "label": "Rotary Encoder #1 Enabled",
-      "description": "Enable the rotary encoder"
+      "label": "Энкодер #1 включён",
+      "description": "Включить энкодер"
     },
     "inputbrokerPinA": {
-      "label": "Encoder Pin A",
-      "description": "GPIO Pin Value (1-39) For encoder port A"
+      "label": "Пин энкодера A",
+      "description": "Значение GPIO (1–39) для порта A энкодера"
     },
     "inputbrokerPinB": {
-      "label": "Encoder Pin B",
-      "description": "GPIO Pin Value (1-39) For encoder port B"
+      "label": "Пин энкодера B",
+      "description": "Значение GPIO (1–39) для порта B энкодера"
     },
     "inputbrokerPinPress": {
-      "label": "Encoder Pin Press",
-      "description": "GPIO Pin Value (1-39) For encoder Press"
+      "label": "Пин нажатия энкодера",
+      "description": "Значение GPIO (1–39) для нажатия энкодера"
     },
     "inputbrokerEventCw": {
-      "label": "Clockwise event",
-      "description": "Select input event."
+      "label": "Событие по часовой",
+      "description": "Выберите событие ввода."
     },
     "inputbrokerEventCcw": {
-      "label": "Counter Clockwise event",
-      "description": "Select input event."
+      "label": "Событие против часовой",
+      "description": "Выберите событие ввода."
     },
     "inputbrokerEventPress": {
-      "label": "Press event",
-      "description": "Select input event"
+      "label": "Событие нажатия",
+      "description": "Выберите событие ввода"
     },
     "updown1Enabled": {
-      "label": "Up Down enabled",
-      "description": "Enable the up / down encoder"
+      "label": "Вверх/вниз включён",
+      "description": "Включить энкодер вверх/вниз"
     },
     "allowInputSource": {
-      "label": "Allow Input Source",
-      "description": "Select from: '_any', 'rotEnc1', 'upDownEnc1', 'cardkb'"
+      "label": "Разрешённый источник ввода",
+      "description": "Выберите из: '_any', 'rotEnc1', 'upDownEnc1', 'cardkb'"
     },
     "sendBell": {
-      "label": "Send Bell",
-      "description": "Sends a bell character with each message"
+      "label": "Отправлять звонок",
+      "description": "Отправляет символ звонка с каждым сообщением"
     }
   },
   "detectionSensor": {
-    "title": "Detection Sensor Settings",
-    "description": "Settings for the Detection Sensor module",
+    "title": "Настройки датчика обнаружения",
+    "description": "Настройки модуля датчика обнаружения",
     "enabled": {
       "label": "Включено",
-      "description": "Enable or disable Detection Sensor Module"
+      "description": "Включить или отключить модуль датчика обнаружения"
     },
     "minimumBroadcastSecs": {
-      "label": "Minimum Broadcast Seconds",
-      "description": "The interval in seconds of how often we can send a message to the mesh when a state change is detected"
+      "label": "Мин. интервал рассылки",
+      "description": "Минимальный интервал в секундах между отправкой сообщений по mesh-сети при изменении состояния"
     },
     "stateBroadcastSecs": {
-      "label": "State Broadcast Seconds",
-      "description": "The interval in seconds of how often we should send a message to the mesh with the current state regardless of changes"
+      "label": "Интервал рассылки состояния",
+      "description": "Интервал в секундах между отправкой сообщений с текущим состоянием, независимо от изменений"
     },
     "sendBell": {
-      "label": "Send Bell",
-      "description": "Send ASCII bell with alert message"
+      "label": "Отправлять звонок",
+      "description": "Отправлять ASCII-звонок с тревожным сообщением"
     },
     "name": {
-      "label": "Friendly Name",
-      "description": "Used to format the message sent to mesh, max 20 Characters"
+      "label": "Понятное имя",
+      "description": "Используется для форматирования сообщения, отправляемого по mesh-сети. Максимум 20 символов"
     },
     "monitorPin": {
-      "label": "Monitor Pin",
-      "description": "The GPIO pin to monitor for state changes"
+      "label": "Пин мониторинга",
+      "description": "GPIO-пин для мониторинга изменений состояния"
     },
     "detectionTriggerType": {
-      "label": "Detection Triggered Type",
-      "description": "The type of trigger event to be used"
+      "label": "Тип триггера",
+      "description": "Тип события-триггера"
     },
     "usePullup": {
-      "label": "Use Pullup",
-      "description": "Whether or not use INPUT_PULLUP mode for GPIO pin"
+      "label": "Использовать подтяжку",
+      "description": "Использовать режим INPUT_PULLUP для GPIO-пина"
     }
   },
   "externalNotification": {
-    "title": "External Notification Settings",
-    "description": "Configure the external notification module",
+    "title": "Настройки внешних уведомлений",
+    "description": "Настройка модуля внешних уведомлений",
     "enabled": {
-      "label": "Module Enabled",
-      "description": "Enable External Notification"
+      "label": "Модуль включён",
+      "description": "Включить внешние уведомления"
     },
     "outputMs": {
-      "label": "Output MS",
-      "description": "Output MS"
+      "label": "Длительность (мс)",
+      "description": "Длительность (мс)"
     },
     "output": {
-      "label": "Output",
-      "description": "Output"
+      "label": "Выход",
+      "description": "Выход"
     },
     "outputVibra": {
-      "label": "Output Vibrate",
-      "description": "Output Vibrate"
+      "label": "Выход вибро",
+      "description": "Выход вибро"
     },
     "outputBuzzer": {
-      "label": "Output Buzzer",
-      "description": "Output Buzzer"
+      "label": "Выход зуммера",
+      "description": "Выход зуммера"
     },
     "active": {
-      "label": "Active",
-      "description": "Active"
+      "label": "Активен",
+      "description": "Активен"
     },
     "alertMessage": {
-      "label": "Alert Message",
-      "description": "Alert Message"
+      "label": "Сообщение тревоги",
+      "description": "Сообщение тревоги"
     },
     "alertMessageVibra": {
-      "label": "Alert Message Vibrate",
-      "description": "Alert Message Vibrate"
+      "label": "Вибро при сообщении",
+      "description": "Вибро при сообщении"
     },
     "alertMessageBuzzer": {
-      "label": "Alert Message Buzzer",
-      "description": "Alert Message Buzzer"
+      "label": "Зуммер при сообщении",
+      "description": "Зуммер при сообщении"
     },
     "alertBell": {
-      "label": "Alert Bell",
-      "description": "Should an alert be triggered when receiving an incoming bell?"
+      "label": "Звонок тревоги",
+      "description": "Запускать тревогу при получении входящего звонка?"
     },
     "alertBellVibra": {
-      "label": "Alert Bell Vibrate",
-      "description": "Alert Bell Vibrate"
+      "label": "Вибро при звонке",
+      "description": "Вибро при звонке"
     },
     "alertBellBuzzer": {
-      "label": "Alert Bell Buzzer",
-      "description": "Alert Bell Buzzer"
+      "label": "Зуммер при звонке",
+      "description": "Зуммер при звонке"
     },
     "usePwm": {
-      "label": "Use PWM",
-      "description": "Use PWM"
+      "label": "Использовать PWM",
+      "description": "Использовать PWM"
     },
     "nagTimeout": {
-      "label": "Nag Timeout",
-      "description": "Nag Timeout"
+      "label": "Тайм-аут напоминания",
+      "description": "Тайм-аут напоминания"
     },
     "useI2sAsBuzzer": {
-      "label": "Use I²S Pin as Buzzer",
-      "description": "Designate I²S Pin as Buzzer Output"
+      "label": "Использовать пин I²S как зуммер",
+      "description": "Назначить пин I²S как выход зуммера"
     }
   },
   "mqtt": {
-    "title": "MQTT Settings",
-    "description": "Settings for the MQTT module",
+    "title": "Настройки MQTT",
+    "description": "Настройки модуля MQTT",
     "enabled": {
       "label": "Включено",
-      "description": "Enable or disable MQTT"
+      "description": "Включить или отключить MQTT"
     },
     "address": {
-      "label": "MQTT Server Address",
-      "description": "MQTT server address to use for default/custom servers"
+      "label": "Адрес сервера MQTT",
+      "description": "Адрес сервера MQTT для стандартных/пользовательских серверов"
     },
     "username": {
-      "label": "MQTT Username",
-      "description": "MQTT username to use for default/custom servers"
+      "label": "Имя пользователя MQTT",
+      "description": "Имя пользователя MQTT для стандартных/пользовательских серверов"
     },
     "password": {
-      "label": "MQTT Password",
-      "description": "MQTT password to use for default/custom servers"
+      "label": "Пароль MQTT",
+      "description": "Пароль MQTT для стандартных/пользовательских серверов"
     },
     "encryptionEnabled": {
-      "label": "Encryption Enabled",
-      "description": "Enable or disable MQTT encryption. Note: All messages are sent to the MQTT broker unencrypted if this option is not enabled, even when your uplink channels have encryption keys set. This includes position data."
+      "label": "Шифрование включено",
+      "description": "Включить или отключить шифрование MQTT. Примечание: если опция не включена, все сообщения отправляются брокеру MQTT без шифрования, даже если на каналах аплинка заданы ключи шифрования. Это включает данные позиции."
     },
     "jsonEnabled": {
-      "label": "JSON Enabled",
-      "description": "Whether to send/consume JSON packets on MQTT"
+      "label": "JSON включён",
+      "description": "Отправлять/получать JSON-пакеты по MQTT"
     },
     "tlsEnabled": {
-      "label": "TLS Enabled",
-      "description": "Enable or disable TLS"
+      "label": "TLS включён",
+      "description": "Включить или отключить TLS"
     },
     "root": {
-      "label": "Корневая тема",
-      "description": "MQTT root topic to use for default/custom servers"
+      "label": "Корневой топик",
+      "description": "Корневой топик MQTT для стандартных/пользовательских серверов"
     },
     "proxyToClientEnabled": {
-      "label": "MQTT Client Proxy Enabled",
-      "description": "Utilizes the network connection to proxy MQTT messages to the client."
+      "label": "Прокси MQTT-клиента",
+      "description": "Использует сетевое подключение для проксирования MQTT-сообщений клиенту."
     },
     "mapReportingEnabled": {
-      "label": "Map Reporting Enabled",
-      "description": "Your node will periodically send an unencrypted map report packet to the configured MQTT server, this includes id, short and long name, approximate location, hardware model, role, firmware version, LoRa region, modem preset and primary channel name."
+      "label": "Отправка отчётов карты включена",
+      "description": "Ваша нода будет периодически отправлять незашифрованный пакет отчёта карты на настроенный MQTT-сервер; он включает ID, короткое и полное имя, приблизительное местоположение, модель оборудования, роль, версию прошивки, регион LoRa, пресет модема и имя первичного канала."
     },
     "mapReportSettings": {
       "publishIntervalSecs": {
-        "label": "Map Report Publish Interval (s)",
-        "description": "Interval in seconds to publish map reports"
+        "label": "Интервал публикации отчёта (с)",
+        "description": "Интервал в секундах для публикации отчётов карты"
       },
       "positionPrecision": {
-        "label": "Approximate Location",
-        "description": "Position shared will be accurate within this distance",
+        "label": "Приблизительное местоположение",
+        "description": "Передаваемая позиция будет точной в пределах этого расстояния",
         "options": {
-          "metric_km23": "Within 23 km",
-          "metric_km12": "Within 12 km",
-          "metric_km5_8": "Within 5.8 km",
-          "metric_km2_9": "Within 2.9 km",
-          "metric_km1_5": "Within 1.5 km",
-          "metric_m700": "Within 700 m",
-          "metric_m350": "Within 350 m",
-          "metric_m200": "Within 200 m",
-          "metric_m90": "Within 90 m",
-          "metric_m50": "Within 50 m",
-          "imperial_mi15": "Within 15 miles",
-          "imperial_mi7_3": "Within 7.3 miles",
-          "imperial_mi3_6": "Within 3.6 miles",
-          "imperial_mi1_8": "Within 1.8 miles",
-          "imperial_mi0_9": "Within 0.9 miles",
-          "imperial_mi0_5": "Within 0.5 miles",
-          "imperial_mi0_2": "Within 0.2 miles",
-          "imperial_ft600": "Within 600 feet",
-          "imperial_ft300": "Within 300 feet",
-          "imperial_ft150": "Within 150 feet"
+          "metric_km23": "В пределах 23 км",
+          "metric_km12": "В пределах 12 км",
+          "metric_km5_8": "В пределах 5,8 км",
+          "metric_km2_9": "В пределах 2,9 км",
+          "metric_km1_5": "В пределах 1,5 км",
+          "metric_m700": "В пределах 700 м",
+          "metric_m350": "В пределах 350 м",
+          "metric_m200": "В пределах 200 м",
+          "metric_m90": "В пределах 90 м",
+          "metric_m50": "В пределах 50 м",
+          "imperial_mi15": "В пределах 15 миль",
+          "imperial_mi7_3": "В пределах 7,3 мили",
+          "imperial_mi3_6": "В пределах 3,6 мили",
+          "imperial_mi1_8": "В пределах 1,8 мили",
+          "imperial_mi0_9": "В пределах 0,9 мили",
+          "imperial_mi0_5": "В пределах 0,5 мили",
+          "imperial_mi0_2": "В пределах 0,2 мили",
+          "imperial_ft600": "В пределах 600 футов",
+          "imperial_ft300": "В пределах 300 футов",
+          "imperial_ft150": "В пределах 150 футов"
         }
       }
     }
   },
   "neighborInfo": {
-    "title": "Neighbor Info Settings",
-    "description": "Settings for the Neighbor Info module",
+    "title": "Настройки информации о соседях",
+    "description": "Настройки модуля информации о соседях",
     "enabled": {
       "label": "Включено",
-      "description": "Enable or disable Neighbor Info Module"
+      "description": "Включить или отключить модуль информации о соседях"
     },
     "updateInterval": {
       "label": "Интервал обновления",
-      "description": "Interval in seconds of how often we should try to send our Neighbor Info to the mesh"
+      "description": "Интервал в секундах между попытками отправки информации о соседях по mesh-сети"
     }
   },
   "paxcounter": {
-    "title": "Paxcounter Settings",
-    "description": "Settings for the Paxcounter module",
+    "title": "Настройки Paxcounter",
+    "description": "Настройки модуля Paxcounter",
     "enabled": {
-      "label": "Module Enabled",
-      "description": "Enable Paxcounter"
+      "label": "Модуль включён",
+      "description": "Включить Paxcounter"
     },
     "paxcounterUpdateInterval": {
-      "label": "Update Interval (seconds)",
-      "description": "How long to wait between sending paxcounter packets"
+      "label": "Интервал обновления (сек.)",
+      "description": "Сколько ждать между отправкой пакетов Paxcounter"
     },
     "wifiThreshold": {
-      "label": "WiFi RSSI Threshold",
-      "description": "At what WiFi RSSI level should the counter increase. Defaults to -80."
+      "label": "Порог WiFi RSSI",
+      "description": "При каком уровне WiFi RSSI увеличивать счётчик. По умолчанию -80."
     },
     "bleThreshold": {
-      "label": "BLE RSSI Threshold",
-      "description": "At what BLE RSSI level should the counter increase. Defaults to -80."
+      "label": "Порог BLE RSSI",
+      "description": "При каком уровне BLE RSSI увеличивать счётчик. По умолчанию -80."
     }
   },
   "rangeTest": {
-    "title": "Range Test Settings",
-    "description": "Settings for the Range Test module",
+    "title": "Настройки теста дальности",
+    "description": "Настройки модуля теста дальности",
     "enabled": {
-      "label": "Module Enabled",
-      "description": "Enable Range Test"
+      "label": "Модуль включён",
+      "description": "Включить тест дальности"
     },
     "sender": {
-      "label": "Message Interval",
-      "description": "How long to wait between sending test packets"
+      "label": "Интервал сообщений",
+      "description": "Сколько ждать между отправкой тестовых пакетов"
     },
     "save": {
-      "label": "Save CSV to storage",
-      "description": "ESP32 Only"
+      "label": "Сохранять CSV в хранилище",
+      "description": "Только ESP32"
     }
   },
   "serial": {
-    "title": "Serial Settings",
-    "description": "Settings for the Serial module",
+    "title": "Настройки COM-порта",
+    "description": "Настройки модуля COM-порта",
     "enabled": {
-      "label": "Module Enabled",
-      "description": "Enable Serial output"
+      "label": "Модуль включён",
+      "description": "Включить вывод в COM-порт"
     },
     "echo": {
-      "label": "Echo",
-      "description": "Any packets you send will be echoed back to your device"
+      "label": "Эхо",
+      "description": "Все отправляемые вами пакеты будут возвращаться на устройство"
     },
     "rxd": {
-      "label": "Receive Pin",
-      "description": "Set the GPIO pin to the RXD pin you have set up."
+      "label": "Пин приёма",
+      "description": "Установите GPIO-пин для RXD."
     },
     "txd": {
-      "label": "Transmit Pin",
-      "description": "Set the GPIO pin to the TXD pin you have set up."
+      "label": "Пин передачи",
+      "description": "Установите GPIO-пин для TXD."
     },
     "baud": {
-      "label": "Baud Rate",
-      "description": "The serial baud rate"
+      "label": "Скорость (бод)",
+      "description": "Скорость передачи по COM-порту"
     },
     "timeout": {
-      "label": "Время ожидания истекло",
-      "description": "Seconds to wait before we consider your packet as 'done'"
+      "label": "Тайм-аут",
+      "description": "Секунды ожидания, прежде чем считать пакет «завершённым»"
     },
     "mode": {
-      "label": "Mode",
-      "description": "Select Mode"
+      "label": "Режим",
+      "description": "Выберите режим"
     },
     "overrideConsoleSerialPort": {
-      "label": "Override Console Serial Port",
-      "description": "If you have a serial port connected to the console, this will override it."
+      "label": "Переопределить консольный COM-порт",
+      "description": "Если к консоли подключён COM-порт, этот параметр его переопределит."
     }
   },
   "storeForward": {
-    "title": "Store & Forward Settings",
-    "description": "Settings for the Store & Forward module",
+    "title": "Настройки Store & Forward",
+    "description": "Настройки модуля Store & Forward",
     "enabled": {
-      "label": "Module Enabled",
-      "description": "Enable Store & Forward"
+      "label": "Модуль включён",
+      "description": "Включить Store & Forward"
     },
     "heartbeat": {
-      "label": "Heartbeat Enabled",
-      "description": "Enable Store & Forward heartbeat"
+      "label": "Heartbeat включён",
+      "description": "Включить heartbeat Store & Forward"
     },
     "records": {
       "label": "Количество записей",
-      "description": "Number of records to store"
+      "description": "Количество записей для хранения"
     },
     "historyReturnMax": {
-      "label": "Макс возврат истории",
-      "description": "Max number of records to return"
+      "label": "Максимум возврата истории",
+      "description": "Максимальное число записей для возврата"
     },
     "historyReturnWindow": {
       "label": "Окно возврата истории",
-      "description": "Return records from this time window (minutes)"
+      "description": "Возвращать записи из этого временного окна (минуты)"
     }
   },
   "telemetry": {
-    "title": "Telemetry Settings",
-    "description": "Settings for the Telemetry module",
+    "title": "Настройки телеметрии",
+    "description": "Настройки модуля телеметрии",
     "deviceUpdateInterval": {
-      "label": "Device Metrics",
-      "description": "Интервал обновления метрик устройства (в секундах)"
+      "label": "Метрики устройства",
+      "description": "Интервал обновления метрик устройства (секунды)"
     },
     "environmentUpdateInterval": {
-      "label": "Интервал обновления метрик окружения (в секундах)",
+      "label": "Интервал обновления метрик окружения (секунды)",
       "description": ""
     },
     "environmentMeasurementEnabled": {
-      "label": "Module Enabled",
-      "description": "Enable the Environment Telemetry"
+      "label": "Модуль включён",
+      "description": "Включить телеметрию окружения"
     },
     "environmentScreenEnabled": {
-      "label": "Displayed on Screen",
-      "description": "Show the Telemetry Module on the OLED"
+      "label": "Показывать на экране",
+      "description": "Показывать модуль телеметрии на OLED-экране"
     },
     "environmentDisplayFahrenheit": {
-      "label": "Display Fahrenheit",
-      "description": "Display temp in Fahrenheit"
+      "label": "Показывать Фаренгейт",
+      "description": "Показывать температуру в Фаренгейтах"
     },
     "airQualityEnabled": {
-      "label": "Air Quality Enabled",
-      "description": "Enable the Air Quality Telemetry"
+      "label": "Качество воздуха включено",
+      "description": "Включить телеметрию качества воздуха"
     },
     "airQualityInterval": {
-      "label": "Air Quality Update Interval",
-      "description": "How often to send Air Quality data over the mesh"
+      "label": "Интервал обновления качества воздуха",
+      "description": "Как часто отправлять данные о качестве воздуха по mesh-сети"
     },
     "powerMeasurementEnabled": {
-      "label": "Power Measurement Enabled",
-      "description": "Enable the Power Measurement Telemetry"
+      "label": "Измерение питания включено",
+      "description": "Включить телеметрию измерения питания"
     },
     "powerUpdateInterval": {
-      "label": "Power Update Interval",
-      "description": "How often to send Power data over the mesh"
+      "label": "Интервал обновления питания",
+      "description": "Как часто отправлять данные о питании по mesh-сети"
     },
     "powerScreenEnabled": {
-      "label": "Power Screen Enabled",
-      "description": "Enable the Power Telemetry Screen"
+      "label": "Экран питания включён",
+      "description": "Включить экран телеметрии питания"
     }
   }
 }

--- a/packages/web/public/i18n/locales/ru-RU/nodes.json
+++ b/packages/web/public/i18n/locales/ru-RU/nodes.json
@@ -1,59 +1,62 @@
 {
   "nodeDetail": {
     "publicKeyEnabled": {
-      "label": "Public Key Enabled"
+      "label": "Публичный ключ включён"
     },
     "noPublicKey": {
-      "label": "No Public Key"
+      "label": "Нет публичного ключа"
     },
     "directMessage": {
-      "label": "Direct Message {{shortName}}"
+      "label": "Личное сообщение {{shortName}}"
     },
     "favorite": {
       "label": "Избранное",
-      "tooltip": "Add or remove this node from your favorites"
+      "tooltip": "Добавить или удалить эту ноду из избранного"
     },
     "notFavorite": {
-      "label": "Not a Favorite"
+      "label": "Не в избранном"
     },
     "error": {
-      "label": "Ошибки",
-      "text": "An error occurred while fetching node details. Please try again later."
+      "label": "Ошибка",
+      "text": "Произошла ошибка при получении сведений о ноде. Повторите попытку позже."
     },
     "status": {
-      "heard": "Heard",
+      "heard": "Слышен",
       "mqtt": "MQTT"
     },
     "elevation": {
-      "label": "Elevation"
+      "label": "Высота"
     },
     "channelUtil": {
-      "label": "Channel Util"
+      "label": "Загрузка канала"
     },
     "airtimeUtil": {
-      "label": "Airtime Util"
+      "label": "Загрузка эфира"
     }
   },
   "nodesTable": {
     "headings": {
       "longName": "Полное имя",
-      "connection": "Соединения",
-      "lastHeard": "Last Heard",
-      "encryption": "Encryption",
-      "model": "Model",
-      "macAddress": "MAC Address"
+      "connection": "Подключение",
+      "lastHeard": "Последний раз слышен",
+      "encryption": "Шифрование",
+      "model": "Модель",
+      "macAddress": "MAC-адрес"
     },
     "connectionStatus": {
-      "direct": "Прямой",
-      "away": "away",
-      "viaMqtt": ", via MQTT"
+      "direct": "Прямое",
+      "away": "от вас",
+      "viaMqtt": ", через MQTT"
+    },
+    "lastHeardStatus": {
+      "never": "Никогда"
     }
   },
   "actions": {
-    "added": "Added",
-    "removed": "Removed",
-    "ignoreNode": "Ignore Node",
-    "unignoreNode": "Unignore Node",
-    "requestPosition": "Request Position"
+    "added": "Добавлено",
+    "removed": "Удалено",
+    "ignoreNode": "Игнорировать ноду",
+    "unignoreNode": "Перестать игнорировать ноду",
+    "requestPosition": "Запросить позицию"
   }
 }

--- a/packages/web/public/i18n/locales/ru-RU/ui.json
+++ b/packages/web/public/i18n/locales/ru-RU/ui.json
@@ -1,111 +1,97 @@
 {
   "navigation": {
-    "title": "Navigation",
+    "title": "Навигация",
     "messages": "Сообщения",
     "map": "Карта",
     "settings": "Настройки",
     "channels": "Каналы",
-    "radioConfig": "Radio Config",
+    "radioConfig": "Настройки радио",
     "deviceConfig": "Настройки устройства",
-    "moduleConfig": "Module Config",
-    "manageConnections": "Manage Connections",
-    "nodes": "Узлы"
+    "moduleConfig": "Настройки модулей",
+    "manageConnections": "Управление подключениями",
+    "nodes": "Ноды"
   },
   "app": {
     "title": "Meshtastic",
-    "logo": "Meshtastic Logo"
+    "logo": "Логотип Meshtastic"
   },
   "sidebar": {
     "collapseToggle": {
       "button": {
-        "open": "Open sidebar",
-        "close": "Close sidebar"
+        "open": "Открыть боковую панель",
+        "close": "Закрыть боковую панель"
       }
     },
     "deviceInfo": {
-      "volts": "{{voltage}} volts",
+      "volts": "{{voltage}} В",
       "firmware": {
         "title": "Прошивка",
         "version": "v{{version}}",
-        "buildDate": "Build date: {{date}}"
+        "buildDate": "Дата сборки: {{date}}"
       }
     }
   },
   "batteryStatus": {
-    "charging": "{{level}}% charging",
-    "pluggedIn": "Plugged in",
+    "charging": "{{level}}% зарядки",
+    "pluggedIn": "Подключено к питанию",
     "title": "Батарея"
   },
   "search": {
-    "nodes": "Search nodes...",
-    "channels": "Search channels...",
-    "commandPalette": "Search commands..."
+    "nodes": "Поиск нод...",
+    "channels": "Поиск каналов...",
+    "commandPalette": "Поиск команд..."
   },
   "toast": {
-    "positionRequestSent": {
-      "title": "Position request sent."
-    },
-    "requestingPosition": {
-      "title": "Requesting position, please wait..."
-    },
-    "sendingTraceroute": {
-      "title": "Sending Traceroute, please wait..."
-    },
-    "tracerouteSent": {
-      "title": "Traceroute sent."
-    },
-    "savedChannel": {
-      "title": "Saved Channel: {{channelName}}"
-    },
+    "positionRequestSent": { "title": "Запрос позиции отправлен." },
+    "requestingPosition": { "title": "Запрашиваем позицию, пожалуйста, подождите..." },
+    "sendingTraceroute": { "title": "Отправляем трассировку, пожалуйста, подождите..." },
+    "tracerouteSent": { "title": "Трассировка отправлена." },
+    "savedChannel": { "title": "Канал сохранён: {{channelName}}" },
     "messages": {
-      "pkiEncryption": {
-        "title": "Chat is using PKI encryption."
-      },
-      "pskEncryption": {
-        "title": "Chat is using PSK encryption."
-      }
+      "pkiEncryption": { "title": "Чат использует шифрование PKI." },
+      "pskEncryption": { "title": "Чат использует шифрование PSK." }
     },
     "configSaveError": {
-      "title": "Error Saving Config",
-      "description": "An error occurred while saving the configuration."
+      "title": "Ошибка сохранения настроек",
+      "description": "При сохранении настроек произошла ошибка."
     },
     "validationError": {
-      "title": "Config Errors Exist",
-      "description": "Please fix the configuration errors before saving."
+      "title": "Есть ошибки в настройках",
+      "description": "Исправьте ошибки конфигурации перед сохранением."
     },
     "saveSuccess": {
-      "title": "Saving Config",
-      "description": "The configuration change {{case}} has been saved."
+      "title": "Сохранение настроек",
+      "description": "Изменение конфигурации {{case}} сохранено."
     },
     "saveAllSuccess": {
-      "title": "Saved",
-      "description": "All configuration changes have been saved."
+      "title": "Сохранено",
+      "description": "Все изменения конфигурации сохранены."
     },
     "favoriteNode": {
-      "title": "{{action}} {{nodeName}} {{direction}} favorites.",
+      "title": "{{action}} {{nodeName}} {{direction}}",
       "action": {
-        "added": "Added",
-        "removed": "Removed",
-        "to": "to",
-        "from": "from"
+        "added": "Добавлено",
+        "removed": "Удалено",
+        "to": "в избранное",
+        "from": "из избранного"
       }
     },
     "ignoreNode": {
-      "title": "{{action}} {{nodeName}} {{direction}} ignore list",
+      "title": "{{action}} {{nodeName}} {{direction}}",
       "action": {
-        "added": "Added",
-        "removed": "Removed",
-        "to": "to",
-        "from": "from"
+        "added": "Добавлено",
+        "removed": "Удалено",
+        "to": "в список игнорирования",
+        "from": "из списка игнорирования"
       }
     }
   },
   "notifications": {
     "copied": {
-      "label": "Copied!"
+      "label": "Скопировано!"
     },
     "copyToClipboard": {
-      "label": "Copy to clipboard"
+      "label": "Копировать в буфер обмена"
     },
     "hidePassword": {
       "label": "Скрыть пароль"
@@ -114,20 +100,20 @@
       "label": "Показать пароль"
     },
     "deliveryStatus": {
-      "delivered": "Delivered",
-      "failed": "Delivery Failed",
-      "waiting": "Waiting",
+      "delivered": "Доставлено",
+      "failed": "Доставка не удалась",
+      "waiting": "Ожидание",
       "unknown": "Неизвестно"
     }
   },
   "general": {
-    "label": "General"
+    "label": "Общие"
   },
   "hardware": {
     "label": "Оборудование"
   },
   "metrics": {
-    "label": "Metrics"
+    "label": "Метрики"
   },
   "role": {
     "label": "Роль"
@@ -136,95 +122,95 @@
     "label": "Фильтр"
   },
   "advanced": {
-    "label": "Расширенные"
+    "label": "Дополнительно"
   },
   "clearInput": {
-    "label": "Clear input"
+    "label": "Очистить ввод"
   },
   "resetFilters": {
-    "label": "Reset Filters"
+    "label": "Сбросить фильтры"
   },
   "nodeName": {
-    "label": "Node name/number",
+    "label": "Имя/номер ноды",
     "placeholder": "Meshtastic 1234"
   },
   "airtimeUtilization": {
-    "label": "Airtime Utilization (%)",
-    "short": "Airtime Util. (%)"
+    "label": "Загрузка эфира (%)",
+    "short": "Загрузка эф. (%)"
   },
   "batteryLevel": {
-    "label": "Battery level (%)",
-    "labelText": "Battery level (%): {{value}}"
+    "label": "Уровень батареи (%)",
+    "labelText": "Уровень батареи (%): {{value}}"
   },
   "batteryVoltage": {
-    "label": "Battery voltage (V)",
+    "label": "Напряжение батареи (В)",
     "title": "Напряжение"
   },
   "channelUtilization": {
-    "label": "Channel Utilization (%)",
-    "short": "Channel Util. (%)"
+    "label": "Загрузка канала (%)",
+    "short": "Загрузка кан. (%)"
   },
   "hops": {
     "direct": "Прямой",
-    "label": "Number of hops",
-    "text": "Number of hops: {{value}}"
+    "label": "Количество прыжков",
+    "text": "Количество прыжков: {{value}}"
   },
   "lastHeard": {
     "label": "Последний раз слышен",
-    "labelText": "Last heard: {{value}}",
-    "nowLabel": "Now"
+    "labelText": "Последний раз слышен: {{value}}",
+    "nowLabel": "Сейчас"
   },
   "snr": {
-    "label": "SNR (db)"
+    "label": "SNR (дБ)"
   },
   "favorites": {
-    "label": "Favorites"
+    "label": "Избранное"
   },
   "hide": {
-    "label": "Hide"
+    "label": "Скрыть"
   },
   "showOnly": {
-    "label": "Show Only"
+    "label": "Показывать только"
   },
   "viaMqtt": {
-    "label": "Connected via MQTT"
+    "label": "Подключено через MQTT"
   },
   "hopsUnknown": {
-    "label": "Unknown number of hops"
+    "label": "Неизвестное число прыжков"
   },
   "showUnheard": {
-    "label": "Unknown last heard"
+    "label": "Неизвестно время последнего приёма"
   },
-  "language": {
+  "languagePicker": {
     "label": "Язык",
-    "changeLanguage": "Change Language"
+    "changeLanguage": "Изменить язык"
   },
   "theme": {
-    "dark": "Темная",
+    "dark": "Тёмная",
     "light": "Светлая",
-    "system": "Automatic",
-    "changeTheme": "Change Color Scheme"
+    "system": "Автоматически",
+    "changeTheme": "Изменить цветовую схему"
   },
   "errorPage": {
-    "title": "This is a little embarrassing...",
-    "description1": "We are really sorry but an error occurred in the web client that caused it to crash. <br /> This is not supposed to happen, and we are working hard to fix it.",
-    "description2": "The best way to prevent this from happening again to you or anyone else is to report the issue to us.",
-    "reportInstructions": "Please include the following information in your report:",
+    "title": "Это немного неловко...",
+    "description1": "Очень жаль, но в веб-клиенте произошла ошибка, из-за которой он аварийно завершился. <br /> Этого не должно быть, и мы работаем над исправлением.",
+    "description2": "Лучший способ предотвратить это в будущем — сообщить нам о проблеме.",
+    "reportInstructions": "Пожалуйста, включите в отчёт следующую информацию:",
     "reportSteps": {
-      "step1": "What you were doing when the error occurred",
-      "step2": "What you expected to happen",
-      "step3": "What actually happened",
-      "step4": "Any other relevant information"
+      "step1": "Что вы делали, когда произошла ошибка",
+      "step2": "Что вы ожидали",
+      "step3": "Что произошло на самом деле",
+      "step4": "Любую другую важную информацию"
     },
-    "reportLink": "You can report the issue to our <0>GitHub</0>",
-    "connectionsLink": "Return to the <0>connections</0>",
-    "detailsSummary": "Error Details",
-    "errorMessageLabel": "Error message:",
-    "stackTraceLabel": "Stack trace:",
+    "reportLink": "Вы можете сообщить о проблеме в нашем <0>GitHub</0>",
+    "connectionsLink": "Вернуться к <0>подключениям</0>",
+    "detailsSummary": "Детали ошибки",
+    "errorMessageLabel": "Сообщение об ошибке:",
+    "stackTraceLabel": "Стек вызовов:",
     "fallbackError": "{{error}}"
   },
   "footer": {
-    "text": "Powered by <0>▲ Vercel</0> | Meshtastic® is a registered trademark of Meshtastic LLC. | <1>Legal Information</1>",
-    "commitSha": "Commit SHA: {{sha}}"
+    "text": "Работает на <0>▲ Vercel</0> | Meshtastic® — зарегистрированный товарный знак Meshtastic LLC. | <1>Юридическая информация</1>",
+    "commitSha": "SHA коммита: {{sha}}"
   }
 }

--- a/packages/web/src/i18n-config.ts
+++ b/packages/web/src/i18n-config.ts
@@ -17,6 +17,7 @@ export const supportedLanguages: Lang[] = [
   { code: "de", name: "Deutsch", flag: "🇩🇪" },
   { code: "en", name: "English", flag: "🇺🇸" },
   { code: "fr", name: "Français", flag: "🇫🇷" },
+  { code: "ru", name: "Русский", flag: "🇷🇺" },
   { code: "sv", name: "Svenska", flag: "🇸🇪" },
 ];
 
@@ -43,6 +44,7 @@ i18next
       default: [FALLBACK_LANGUAGE_CODE],
       fi: ["fi-FI", FALLBACK_LANGUAGE_CODE],
       fr: ["fr-FR", FALLBACK_LANGUAGE_CODE],
+      ru: ["ru-RU", FALLBACK_LANGUAGE_CODE],
       sv: ["sv-SE", FALLBACK_LANGUAGE_CODE],
       de: ["de-DE", FALLBACK_LANGUAGE_CODE],
     },


### PR DESCRIPTION
## Summary
- update ru-RU locale strings for consistency and readability
- align key terms with app usage (нода, прыжки, COM-порт, Primary/Secondary wording)
- keep abbreviations like PSK, LED, OLED in Latin where appropriate
- add Russian locale entry in i18n config (packages/web/src/i18n-config.ts)

## Notes
- this PR intentionally excludes fork-specific CI/CD workflow files (e.g. GHCR workflow)
- scope is only Russian localization + i18n locale config
