### PR TITLE
Use more useful fallback names in Map view too

### DIFF
--- a/packages/web/src/components/PageComponents/Map/Layers/NodesLayer.tsx
+++ b/packages/web/src/components/PageComponents/Map/Layers/NodesLayer.tsx
@@ -16,6 +16,7 @@ import { useMapFitting } from "@core/hooks/useMapFitting";
 import { useNodeDB } from "@core/stores";
 import { hasPos, toLngLat } from "@core/utils/geo.ts";
 import type { Protobuf } from "@meshtastic/core";
+import { numberToHexUnpadded } from "@noble/curves/abstract/utils";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { MapRef } from "react-map-gl/maplibre";
@@ -83,6 +84,14 @@ export const NodesLayer = ({
     for (const [i, node] of nodes.entries()) {
       const isHead = i === 0;
 
+      const shortName =
+        node.user?.shortName ?? numberToHexUnpadded(node.num).slice(-4).toUpperCase();
+      const longName =
+        node.user?.longName ??
+        t("fallbackName", {
+          last4: shortName,
+        });
+
       rendered.push(
         <NodeMarker
           key={`node-${key}-${node.num}`}
@@ -90,8 +99,8 @@ export const NodesLayer = ({
           lng={lng}
           lat={lat}
           offset={expandedOffsets?.[i]}
-          label={node.user?.shortName ?? t("unknown.shortName")}
-          tooltipLabel={node.user?.longName ?? t("unknown.longName")}
+          label={shortName}
+          tooltipLabel={longName}
           hasError={hasNodeError(node.num)}
           isFavorite={node.isFavorite ?? false}
           isVisible={isVisible}

--- a/packages/web/src/components/PageComponents/Map/Popups/NodeDetail.tsx
+++ b/packages/web/src/components/PageComponents/Map/Popups/NodeDetail.tsx
@@ -8,6 +8,7 @@ import { Subtle } from "@components/UI/Typography/Subtle.tsx";
 import { formatQuantity } from "@core/utils/string.ts";
 import type { Protobuf as ProtobufType } from "@meshtastic/core";
 import { Protobuf } from "@meshtastic/core";
+import { numberToHexUnpadded } from "@noble/curves/abstract/utils";
 import {
   Tooltip,
   TooltipContent,
@@ -26,8 +27,12 @@ export interface NodeDetailProps {
 export const NodeDetail = ({ node }: NodeDetailProps) => {
   const navigate = useNavigate();
   const { t } = useTranslation("nodes");
-  const name = node.user?.longName ?? t("unknown.shortName");
-  const shortName = node.user?.shortName ?? t("unknown.shortName");
+  const shortName = node.user?.shortName ?? numberToHexUnpadded(node.num).slice(-4).toUpperCase();
+  const name =
+    node.user?.longName ??
+    t("fallbackName", {
+      last4: shortName,
+    });
   const hwModel = node.user?.hwModel ?? 0;
   const rawHardwareType = Protobuf.Mesh.HardwareModel[hwModel] as
     | keyof typeof Protobuf.Mesh.HardwareModel


### PR DESCRIPTION
<!--
Thank you for your contribution to our project!
-->

## Description

Changed node popups on Map page to use fallbackName instead of unknown.shortName for nodes without explicit names, making them more consistent with the Nodes page.

## Changes Made
- Added fallbackName use to NodeMarker rendering
- Added fallbackName use to NodeDetail popup

## Testing Done

Hovered over and clicked both named and unnamed nodes as a cursory validation of behaviour

## Screenshots (if applicable)
Before:
<img width="684" height="749" alt="image" src="https://github.com/user-attachments/assets/eb08caff-9f45-46db-ab0f-b5746f256d05" />

After:
<img width="753" height="764" alt="image" src="https://github.com/user-attachments/assets/a0bbd718-e504-4c9b-b303-50691c5c6e03" />

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [ ] Code follows project style guidelines - I can't find these
- [ ] Documentation has been updated or added - n/a?
- [ ] Tests have been added or updated - The map page doesn't have any tests as far as I can tell
