### PR TITLE
fix(nodes): correct singular hop label in connection status

### DIFF
--- a/packages/web/src/pages/Nodes/index.tsx
+++ b/packages/web/src/pages/Nodes/index.tsx
@@ -165,7 +165,7 @@ const NodesPage = (): JSX.Element => {
                 ? node?.viaMqtt === false && node.hopsAway === 0
                   ? t("nodesTable.connectionStatus.direct")
                   : `${node.hopsAway?.toString()} ${
-                      (node.hopsAway ?? 0 > 1) ? t("unit.hop.plural") : t("unit.hops_one")
+                      (node.hopsAway ?? 0) > 1 ? t("unit.hop.plural") : t("unit.hop.one")
                     } ${t("nodesTable.connectionStatus.away")}`
                 : t("unknown.longName")}
               {node?.viaMqtt === true ? t("nodesTable.connectionStatus.viaMqtt") : ""}


### PR DESCRIPTION
## Summary
- fix singular/plural selection for hop count in Nodes connection column
- use existing translation key unit.hop.one for singular form
- keep plural form on unit.hop.plural

## Bug
For hopsAway = 1, UI could render the wrong key/form in Russian (for example: `1 прыжков ...`).

## Change
In packages/web/src/pages/Nodes/index.tsx:
- (node.hopsAway ?? 0 > 1) -> (node.hopsAway ?? 0) > 1
- t("unit.hops_one") -> t("unit.hop.one")
