### PR TITLE
Update pnpm to v11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.32.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.32.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release-protobufs.yml
+++ b/.github/workflows/release-protobufs.yml
@@ -70,8 +70,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
       
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -48,13 +48,5 @@
     "typescript": "^5.9.2",
     "vitest": "^4.1.8"
   },
-  "packageManager": "pnpm@10.32.1",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@serialport/bindings-cpp",
-      "@tailwindcss/oxide",
-      "core-js",
-      "esbuild"
-    ]
-  }
+  "packageManager": "pnpm@11.5.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+allowBuilds:
+  '@serialport/bindings-cpp': false
+  '@tailwindcss/oxide': false
+  'core-js': false
+  esbuild: false
 minimumReleaseAge: 2880 # package dependency library must be at least 2 days old
 packages:
   - "packages/*"


### PR DESCRIPTION
Update pnpm to 11.x. Also remove version references in Actions so that the packageManager version can be used.

---

This pull request updates the project's usage of pnpm, including upgrading to a newer version and refactoring related configuration. The main focus is on ensuring consistent and up-to-date package management across the codebase and CI workflows.

**pnpm version upgrade and configuration cleanup:**

* Upgraded the `packageManager` field in `package.json` from `pnpm@10.32.1` to `pnpm@11.5.2`, and removed the `pnpm.onlyBuiltDependencies` field.
* Added an `allowBuilds` section to `pnpm-workspace.yaml` to explicitly disallow builds for certain dependencies, replacing the previous `onlyBuiltDependencies` configuration.

**CI workflow updates:**

* Removed the explicit `version` argument from all `pnpm/action-setup@v6` steps in GitHub Actions workflows, so that the workflows use the default pnpm version instead of pinning to a specific one. This change affects `.github/workflows/ci.yml`, `.github/workflows/pr.yml`, `.github/workflows/nightly.yml`, `.github/workflows/release-packages.yml`, `.github/workflows/release-protobufs.yml`, and `.github/workflows/release-web.yml`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL21-L22) [[2]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L28-L29) [[3]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L25-L26) [[4]](diffhunk://#diff-c05039cf2b03d3d6690bf070ca014b1abb4c45f5d1dc44d2ddcc523fc02ee4cfL29-L30) [[5]](diffhunk://#diff-6e03aaba3927ace10ecee615c1d30e54948ec8c75216d628422b32259a2dea93L73-L74) [[6]](diffhunk://#diff-5c28a943e504547a8208c46cd870b8852ea52bc6aa9ea26eff0c9619f4270ecaL40-L41)