### PR TITLE
Correct typo in excluded directories list in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           set -euo pipefail
 
           # List packages to exclude (full paths under repo root)
-          EXCLUDED_DIRS=("packages/protobufs" "packages/transport-deno" "packages/ui" "pacakges/web")
+          EXCLUDED_DIRS=("packages/protobufs" "packages/transport-deno" "packages/ui" "packages/web")
 
           is_excluded() {
             local dir="$1"


### PR DESCRIPTION
Should fix current CI errors when merging to `main`.

---

This pull request fixes a typo in the list of excluded directories in the CI workflow configuration file. The directory name `pacakges/web` was corrected to `packages/web` to ensure the intended directory is properly excluded.

* Fixed a typo in the `EXCLUDED_DIRS` array in `.github/workflows/ci.yml` so that `packages/web` is correctly excluded from CI jobs.