### PR TITLE
JSR migrations for pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@jsr:registry=https://npm.jsr.io

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "tslog": "^4.9.3"
   },
   "devDependencies": {
+    "@meshtastic/core": "jsr:^2.6.6",
     "@types/node": "^24.3.1",
     "husky": "^9.1.0",
     "lint-staged": "^16.0.0",

--- a/packages/web/.npmrc
+++ b/packages/web/.npmrc
@@ -1,1 +1,0 @@
-@jsr:registry=https://npm.jsr.io

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
         specifier: ^4.9.3
         version: 4.10.2
     devDependencies:
+      '@meshtastic/core':
+        specifier: jsr:^2.6.6
+        version: '@jsr/meshtastic__core@2.6.6'
       '@types/node':
         specifier: ^24.3.1
         version: 24.12.0
@@ -1294,6 +1297,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jsr/meshtastic__core@2.6.6':
+    resolution: {integrity: sha512-f9c/HV6d7fGg+FtsnnC6DSomdGQ7Hr96JiT3epTUduwClYFdi/ftKEadfV55cMhCrp1QK9y6lkPG2S+X1AwN5Q==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__core/2.6.6.tgz}
 
   '@jsr/meshtastic__protobufs@2.7.20':
     resolution: {integrity: sha512-GrHWfOzi9i7xk2Br3MkKWLxbzreZuwgjZKNooednYpa1V/abnSj9e4twNTtKyqXYaAOzthY3Cdk4IXouBN9dbA==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__protobufs/2.7.20.tgz}
@@ -6866,6 +6872,16 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jsr/meshtastic__core@2.6.6':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@jsr/meshtastic__protobufs': 2.7.20
+      crc: 4.3.2
+      ste-simple-events: 3.0.11
+      tslog: 4.10.2
+    transitivePeerDependencies:
+      - buffer
 
   '@jsr/meshtastic__protobufs@2.7.20':
     dependencies:


### PR DESCRIPTION
JSR is now integrated into pnpm since version 10.9, we can remove the `.npmrc` entries.

Additionally, `@meshtastic/core` has been added to `devDependencies` so that it can be properly resolved during `pnpm test`, fixing CI for pull requests.