### PR TITLE
Dependabot: Group react packages together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
       tanstack:
         patterns:
           - "@tanstack/*"
+      react-ecosystem:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react*"


### PR DESCRIPTION
Group react ecosystem packages together for dependabot. Same as we do in meshtastic/meshtastic
