### PR TITLE
fix(infra): use apps/web paths in Containerfile after monorepo move

### DIFF
--- a/apps/web/infra/Containerfile
+++ b/apps/web/infra/Containerfile
@@ -6,9 +6,9 @@ RUN rm -r /usr/share/nginx/html \
 
 WORKDIR /usr/share/nginx/html
 
-ADD ./packages/web/dist .
+ADD ./apps/web/dist .
 
-COPY ./packages/web/infra/default.conf /etc/nginx/conf.d/default.conf
+COPY ./apps/web/infra/default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Problem

The **Release Web** workflow fails at the `Build and push image` step:

```
ERROR: failed to compute cache key: "/packages/web/infra/default.conf": not found
ERROR: "/packages/web/dist": not found
```

(see failed run: https://github.com/meshtastic/web/actions/runs/27570791551)

## Cause

#1097 moved the web app `packages/web → apps/web`. The workflow was updated accordingly (`working-directory: apps/web`, `file: ./apps/web/infra/Containerfile`, `path: apps/web/dist/build.tar`), but the `ADD`/`COPY` paths **inside** `apps/web/infra/Containerfile` still pointed at `./packages/web/...`. Since the image is built with the repo root as context, those paths no longer resolve.

## Fix

Repoint the two lines to `./apps/web/dist` and `./apps/web/infra/default.conf` (both exist).

## Verification

Built the image locally with the repo root as context against the real `apps/web` build output — the previously-failing `ADD`/`COPY` steps now succeed and the image exports cleanly.

Note: the local `apps/web` `docker:build` npm script still uses an `apps/web`-relative context and is independently stale — not touched here to keep this scoped to the release blocker.