### PR TITLE
fix(lint): remove rule for import/no-unused-modules from .oxlintrc.json

### DIFF
--- a/apps/web/.oxlintrc.json
+++ b/apps/web/.oxlintrc.json
@@ -4,8 +4,7 @@
   "rules": {
     "no-debugger": "error",
     "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-unused-vars": "error",
-    "import/no-unused-modules": "error"
+    "@typescript-eslint/no-unused-vars": "error"
   },
   "ignorePatterns": [
     "node_modules",


### PR DESCRIPTION
`import/no-unused-modules` seems to have been removed in more recent oxlint versions. Remove it here to unblock oxlint upgrades.

#1096 