### PR TITLE
fix(connections): increase HTTP reachability probe timeout to 10s

### DIFF
--- a/apps/web/src/pages/Connections/utils.ts
+++ b/apps/web/src/pages/Connections/utils.ts
@@ -40,9 +40,12 @@ export function createConnectionFromInput(input: NewConnection): Connection {
   };
 }
 
+/** Default probe timeout — some devices (e.g. Heltec) can take several seconds on first request. */
+const HTTP_REACHABILITY_TIMEOUT_MS = 10_000;
+
 export async function testHttpReachable(
   url: string,
-  timeoutMs = 2500,
+  timeoutMs = HTTP_REACHABILITY_TIMEOUT_MS,
 ): Promise<boolean> {
   try {
     const controller = new AbortController();


### PR DESCRIPTION
## Summary
- Increase the default `testHttpReachable` timeout from 2.5s to 10s
- Addresses false "not reachable" errors reported in #1015 when devices (e.g. Heltec) are slow to respond on the first request

## Test plan
- [ ] Add an HTTP connection on `client.meshtastic.org` to a device with a trusted/accepted self-signed cert
- [ ] Confirm "Test connection" succeeds on first attempt when the device takes 4–7s to respond
- [ ] Confirm connection still fails promptly when the device is actually unreachable

Fixes #1015 (partial — timeout only; mixed-content and self-signed cert constraints remain)