### PR TITLE
pnpm: Dependabot fix base registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,13 @@
 version: 2
+
+registries:
+  # Workaround https://github.com/dependabot/dependabot-core/issues/15415
+  public:
+    type: npm-registry
+    url: https://registry.npmjs.org/
+    token: ${{ secrets.DEPENDABOT_NULL_TOKEN }}
+    replaces-base: true
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
force dependabot to always use the standard npm registry (not npm.pkg.github.io).

Requires an org-wide **dependabot** secret be created `DEPENDABOT_NULL_TOKEN` containing a single space (effectively empty)

https://github.com/organizations/meshtastic/settings/secrets/dependabot

DRAFT until the dependabot secret is created.


See also: https://github.com/dependabot/dependabot-core/issues/15415