### PR TITLE
chore(deps): update packageManager to pnpm@11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
       "oxfmt"
     ]
   },
-  "packageManager": "pnpm@11.5.2"
+  "packageManager": "pnpm@11.9.0"
 }


### PR DESCRIPTION
This pull request updates the package manager version specified in `package.json` to ensure compatibility with newer features and bug fixes.

* Dependency update:
  * Updated the `packageManager` field to use `pnpm@11.9.0` instead of `pnpm@11.5.2` in `package.json`.