### PR TITLE
Fix blank error message when using Serial on Firefox

### DIFF
--- a/apps/web/src/components/Dialog/AddConnectionDialog/AddConnectionDialog.tsx
+++ b/apps/web/src/components/Dialog/AddConnectionDialog/AddConnectionDialog.tsx
@@ -103,14 +103,6 @@ const FeatureErrorMessage = ({ missingFeatures, tabId }: FeatureErrorProps) => {
     return null;
   }
 
-  if (tabId === "serial" && !missingFeatures.includes("Web Serial")) {
-    return null;
-  }
-
-  if (tabId === "bluetooth" && !missingFeatures.includes("Web Bluetooth")) {
-    return null;
-  }
-
   const browserFeatures = missingFeatures.filter(
     (feature) => feature !== "Secure Context",
   );
@@ -122,6 +114,10 @@ const FeatureErrorMessage = ({ missingFeatures, tabId }: FeatureErrorProps) => {
       : tabId === "serial" && browserFeatures.includes("Web Serial")
         ? "Web Serial"
         : undefined;
+
+  if (!needsFeature && !needsSecureContext) {
+    return null;
+  }
 
   return (
     <div className="flex flex-col items-start gap-2 bg-red-500 p-4 rounded-md text-sm mt-4">

--- a/apps/web/src/components/Dialog/AddConnectionDialog/AddConnectionDialog.tsx
+++ b/apps/web/src/components/Dialog/AddConnectionDialog/AddConnectionDialog.tsx
@@ -103,6 +103,14 @@ const FeatureErrorMessage = ({ missingFeatures, tabId }: FeatureErrorProps) => {
     return null;
   }
 
+  if (tabId === "serial" && !missingFeatures.includes("Web Serial")) {
+    return null;
+  }
+
+  if (tabId === "bluetooth" && !missingFeatures.includes("Web Bluetooth")) {
+    return null;
+  }
+
   const browserFeatures = missingFeatures.filter(
     (feature) => feature !== "Secure Context",
   );


### PR DESCRIPTION
## Description
Fix for #1253 removes blank error box now that Firefox does support Serial

## Related Issues

#1253 

## Changes Made

- Added check to return null if the tab id is "serial" and the unsupported array does not include "Web Serial"
- Added check to return null if the tab id is "bluetooth" and the unsupported array does not include "Web Bluetooth"

## Testing Done

Tested on Firefox on macOS 15.6, will test on Windows tomorrow

## Screenshots (if applicable)

<!--
If your changes affect the UI, include screenshots or screencasts showing the before and after.
-->

## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [x] Code follows project style guidelines
- [x] Documentation has been updated or added
- [x] Tests have been added or updated
- [x] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection dialog messaging so feature warnings are shown only when they apply to the currently selected connection tab and the required security context.
  * Reduced unnecessary “missing feature” notices for unrelated connection options, making the dialog clearer and less cluttered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->