### PR TITLE
fix: workspace build fails on fresh clone (#1252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ Expected domain errors are returned as `Result<T, E>` via [`better-result`](http
 
 ### Prerequisites
 
-You need [pnpm](https://pnpm.io/) installed. If you plan to regenerate
-protobufs, also install the [Buf CLI](https://buf.build/docs/cli/installation/).
+You need [pnpm](https://pnpm.io/) installed. The [Buf CLI](https://buf.build/docs/cli/installation/) is only required if you plan to regenerate protobuf stubs — the generated TypeScript is committed to the repo, so a fresh clone builds without it.
 
 ### Setup
 
@@ -102,8 +101,18 @@ pnpm --filter @meshtastic/web dev
 
 ### Build everything
 
+`@meshtastic/protobufs` has a `build` script that regenerates its stubs with `buf`, so skip it when building the rest of the workspace:
+
 ```bash
-pnpm -r build
+pnpm --filter '!@meshtastic/protobufs' -r build
+```
+
+### Regenerate protobuf stubs
+
+Only needed after bumping the `meshtastic/protobufs` submodule or editing the generator config. Requires the Buf CLI:
+
+```bash
+pnpm --filter @meshtastic/protobufs build
 ```
 
 ### Run tests

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,54 @@
+# @meshtastic/ui
+
+Shared React component library used by [`@meshtastic/web`](../../apps/web). Radix Primitives + Tailwind CSS v4 with a shadcn-flavoured design system.
+
+## What's inside
+
+- **`AppSidebar`** — top-level layout sidebar used by the web client shell.
+- **`ThemeProvider` + `useTheme` + `ThemeToggle`** — light/dark/system theme, persisted to `localStorage`.
+- **`Badge`** — primitive re-exported at the package root.
+- **`theme/default.css`** — Tailwind design tokens (colors, radii, typography) shipped as a standalone stylesheet.
+- **shadcn primitives** under `src/components/ui/` (`Button`, `Input`, `Collapsible`, `DropdownMenu`, `Separator`, `Sheet`, `Skeleton`, `Tooltip`) — bundled but only re-exported through the sidebar surface today. Deep-imports work against the built `dist/`.
+
+The package is framework-agnostic within React 19: no device, transport, or SDK dependencies. It only owns look-and-feel.
+
+## Install
+
+```sh
+pnpm add @meshtastic/ui
+```
+
+Peer dependencies: `react` >=19, `react-dom` >=19, `tailwindcss` ^4.1, `@radix-ui/react-slot`, `class-variance-authority`, `tailwind-merge`.
+
+## Usage
+
+Import the theme stylesheet once at your app entry, then consume components:
+
+```tsx
+import "@meshtastic/ui/theme/default.css";
+import { AppSidebar, Badge, ThemeProvider, ThemeToggle } from "@meshtastic/ui";
+
+export function App() {
+  return (
+    <ThemeProvider defaultTheme="system">
+      <AppSidebar sections={[]} />
+      <Badge>online</Badge>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+}
+```
+
+## Development
+
+From the repo root:
+
+```sh
+pnpm --filter @meshtastic/ui dev      # vite dev server
+pnpm --filter @meshtastic/ui build    # vite build + publint
+pnpm --filter @meshtastic/ui test     # vitest
+```
+
+## License
+
+GPL-3.0-only.

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
         {
           src: "src/lib/theme/default.css",
           dest: "theme",
+          rename: { stripBase: true },
         },
       ],
     }),


### PR DESCRIPTION
Closes #1252.

Two root causes prevented `pnpm -r build` from working on a fresh clone:

## 1. `packages/ui` viteStaticCopy misconfigured

The copy target for `src/lib/theme/default.css` preserved the source path structure, producing `dist/theme/src/lib/theme/default.css` instead of `dist/theme/default.css`. publint then failed on the missing `exports["./theme/default.css"]` file.

Fixed by adding `rename: { stripBase: true }` so the copy flattens onto `dist/theme/`.

## 2. README build step invokes `buf` without saying so

`@meshtastic/protobufs` has a `build` script that runs `buf generate`, which needs the Buf CLI installed. The README suggested `pnpm -r build` and only mentioned Buf as optional for regenerating protobufs.

Generated stubs are already committed under `packages/protobufs/packages/ts/dist/`, so consumers don't need Buf. Updated the README to:
- Filter `@meshtastic/protobufs` out of the default workspace build.
- Move Buf into its own "Regenerate protobuf stubs" section.

## Test plan

- [x] `pnpm --filter @meshtastic/ui build` — publint passes, `dist/theme/default.css` exists at expected path
- [x] `pnpm --filter '!@meshtastic/protobufs' -r build` — full workspace builds green without Buf installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started guidance to clarify when Buf CLI is needed for regenerating protobuf TypeScript stubs.
  * Split instructions into distinct “build workspace” vs “regenerate protobuf stubs” flows, including the workspace build excluding `@meshtastic/protobufs`.
  * Added `@meshtastic/ui` library README with component overview, stylesheet location, and usage instructions.
* **Bug Fixes**
  * Adjusted static asset copying behavior so copied UI assets resolve with correct base paths after build/rename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->