### PR TITLE
chore: remove production console noise

### DIFF
--- a/apps/web/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/apps/web/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -77,7 +77,6 @@ const DateDelimiter = ({ label }: { label: string }) => (
 );
 
 const MessageSkeleton = () => {
-  console.log("[ChannelChat] Showing MessageSkeleton (Suspense fallback)");
   return (
     <li className="group w-full py-2 relative list-none rounded-md">
       <div className="grid grid-cols-[auto_1fr] gap-x-2">

--- a/apps/web/src/core/services/dev-overrides.ts
+++ b/apps/web/src/core/services/dev-overrides.ts
@@ -1,9 +1,9 @@
 import { featureFlags } from "@core/services/featureFlags";
 
 const isDev = typeof import.meta !== "undefined" && import.meta.env?.DEV;
-console.log(`Dev mode: ${isDev}`);
 
 if (isDev) {
+  console.log(`Dev mode: ${isDev}`);
   featureFlags.setOverrides({
     persistMessages: true,
     persistApp: true,


### PR DESCRIPTION
Closes #1275.
Closes #1276.

Two independent debug logs shipped to production:

- `apps/web/src/components/PageComponents/Messages/ChannelChat.tsx` — `MessageSkeleton` logged on every Suspense fallback render. Removed.
- `apps/web/src/core/services/dev-overrides.ts` — logged `Dev mode: ...` at module load unconditionally. Moved inside the `isDev` branch.

## Test plan

- [x] `pnpm --filter @meshtastic/web build` — clean build, no console spam in prod bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary debug messages from chat loading states.
  * Prevented development-mode status messages from appearing outside development mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->