### PR TITLE
Increase dependabot PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 3 # 1 day after pnpm's cutoff, prevent a race
+    open-pull-requests-limit: 10 # Increase PR limit
     groups:
       tanstack:
         patterns:


### PR DESCRIPTION
Dependabot defaults to 5 opened PRs. This big monorepo needs a bit more.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the number of automated dependency update pull requests that can be opened at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->