### PR TITLE
fix(sdk): abort fromDevice pipe on MeshClient.disconnect

### DIFF
--- a/packages/sdk/src/core/client/MeshClient.ts
+++ b/packages/sdk/src/core/client/MeshClient.ts
@@ -148,8 +148,16 @@ export class MeshClient {
     this._fromDevicePipe = this.transport.fromDevice.pipeTo(decodePacket(this), {
       signal: this._fromDeviceAc.signal,
     });
-    // Swallow abort/cancel rejection so an unhandled rejection does not surface.
-    void this._fromDevicePipe.catch(() => {});
+    // Swallow abort/cancel rejection so an unhandled rejection does not
+    // surface, but log unexpected transport/stream failures.
+    void this._fromDevicePipe.catch((err) => {
+      if (err instanceof Error && err.name !== "AbortError") {
+        this.log.error(
+          Emitter[Emitter.ConnectionStatus],
+          `Device decoding pipe failed: ${err.message}`,
+        );
+      }
+    });
   }
 
   public get myNodeNum(): number {
@@ -355,15 +363,28 @@ export class MeshClient {
       clearInterval(this._heartbeatIntervalId);
     }
     this.complete();
-    await this.transport.toDevice.close();
-    if (this._fromDeviceAc) {
-      this._fromDeviceAc.abort();
+
+    // Signal the inbound pipe abort before blocking on IO so teardown still
+    // completes when the transport is already gone (e.g. unplugged serial).
+    this._fromDeviceAc?.abort();
+
+    try {
+      await this.transport.toDevice.close();
+    } catch {
+      this.log.debug(
+        Emitter[Emitter.Disconnect],
+        "Writable stream already closed or errored",
+      );
+    }
+
+    if (this._fromDevicePipe) {
       try {
         await this._fromDevicePipe;
       } catch {
         // Expected when the pipe is aborted during disconnect.
       }
     }
+
     await this.transport.disconnect();
     this.updateDeviceStatus(DeviceStatusEnum.DeviceDisconnected);
   }

--- a/packages/sdk/src/core/client/MeshClient.ts
+++ b/packages/sdk/src/core/client/MeshClient.ts
@@ -111,6 +111,8 @@ export class MeshClient {
   });
 
   private _heartbeatIntervalId: ReturnType<typeof setInterval> | undefined;
+  private _fromDeviceAc: AbortController | undefined;
+  private _fromDevicePipe: Promise<void> | undefined;
 
   constructor(options: MeshClientOptions) {
     this.log = options.logger ?? createLogger("MeshClient");
@@ -142,7 +144,12 @@ export class MeshClient {
       }
     });
 
-    this.transport.fromDevice.pipeTo(decodePacket(this));
+    this._fromDeviceAc = new AbortController();
+    this._fromDevicePipe = this.transport.fromDevice.pipeTo(decodePacket(this), {
+      signal: this._fromDeviceAc.signal,
+    });
+    // Swallow abort/cancel rejection so an unhandled rejection does not surface.
+    void this._fromDevicePipe.catch(() => {});
   }
 
   public get myNodeNum(): number {
@@ -349,6 +356,14 @@ export class MeshClient {
     }
     this.complete();
     await this.transport.toDevice.close();
+    if (this._fromDeviceAc) {
+      this._fromDeviceAc.abort();
+      try {
+        await this._fromDevicePipe;
+      } catch {
+        // Expected when the pipe is aborted during disconnect.
+      }
+    }
     await this.transport.disconnect();
     this.updateDeviceStatus(DeviceStatusEnum.DeviceDisconnected);
   }

--- a/packages/sdk/src/core/client/MeshClient.ts
+++ b/packages/sdk/src/core/client/MeshClient.ts
@@ -151,10 +151,12 @@ export class MeshClient {
     // Swallow abort/cancel rejection so an unhandled rejection does not
     // surface, but log unexpected transport/stream failures.
     void this._fromDevicePipe.catch((err) => {
-      if (err instanceof Error && err.name !== "AbortError") {
+      // Abort rejections may be DOMException, so do not require instanceof Error.
+      if ((err as { name?: string } | null)?.name !== "AbortError") {
+        const message = err instanceof Error ? err.message : String(err);
         this.log.error(
           Emitter[Emitter.ConnectionStatus],
-          `Device decoding pipe failed: ${err.message}`,
+          `Device decoding pipe failed: ${message}`,
         );
       }
     });
@@ -370,10 +372,10 @@ export class MeshClient {
 
     try {
       await this.transport.toDevice.close();
-    } catch {
+    } catch (err) {
       this.log.debug(
         Emitter[Emitter.Disconnect],
-        "Writable stream already closed or errored",
+        `Writable stream already closed or errored: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
 


### PR DESCRIPTION
## Summary

- Start `transport.fromDevice.pipeTo(decodePacket(this))` with an `AbortController` signal.
- On `disconnect()`, abort the inbound pipe and await settlement before `transport.disconnect()`.
- Prevents leaving the transport readable locked after disconnect (serial "port is already open" / BLE reconnect failures).

## Context

Colorado-Mesh/mesh-client carries an equivalent fix as a pnpm patch against `@jsr/meshtastic__core@2.6.6` (`MeshDevice`). The SDK has since moved to `MeshClient` in this monorepo, but the unaborted `pipeTo` pattern remains.

`packages/transport-web-serial` already creates a per-instance `toDeviceStream` and aborts cleanly; this PR aligns `MeshClient` inbound teardown with that pattern.

## Test plan

- [ ] Connect via Web Serial, disconnect, reconnect without "port is already open"
- [ ] Connect via Web Bluetooth (if available), disconnect, reconnect without a stuck GATT session
- [ ] Confirm inbound packets still decode while connected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown reliability by ensuring inbound device data decoding is fully stopped during disconnect.
  * Added controlled cancellation to prevent expected abort/termination errors from surfacing as unhandled failures.
  * Ensured disconnect waits for the inbound decoding pipeline to complete (while safely ignoring expected cancellation outcomes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->