### PR TITLE
feat(web): add safe channel share workflow

### DIFF
--- a/apps/web/public/i18n/locales/en/dialog.json
+++ b/apps/web/public/i18n/locales/en/dialog.json
@@ -4,19 +4,24 @@
     "title": "Clear All Messages"
   },
   "import": {
-    "description": "Import a Channel Set from a Meshtastic URL. <br />Valid Meshtasic URLs start with \"<italic>https://meshtastic.org/e/...</italic>\"",
+    "description": "Import a Channel Set from a Meshtastic URL. <br />Valid Meshtastic URLs start with \"<italic>https://meshtastic.org/e/...</italic>\"",
     "error": {
       "invalidUrl": "Invalid Meshtastic URL"
     },
     "channelPrefix": "Channel ",
     "primary": "Primary ",
-    "doNotImport": "No not import",
     "channelName": "Name",
     "channelSlot": "Slot",
     "channelSetUrl": "Channel Set/QR Code URL",
-    "useLoraConfig": "Import LoRa Config",
-    "presetDescription": "The current LoRa Config will be replaced.",
-    "title": "Import Channels"
+    "title": "Import Channels",
+    "mode": "Channel import mode",
+    "replaceDescription": "Replace changes the selected channel slots and applies LoRa settings when included.",
+    "addDescription": "Add uses free secondary slots and preserves the current channels and LoRa settings.",
+    "addOnly": "This share can only add channels.",
+    "loraWillApply": "LoRa settings from this share will be applied.",
+    "loraWillNotApply": "LoRa settings will not be changed.",
+    "duplicateNames": "Channel names already exist: {{names}}. Resolve the conflict before adding.",
+    "capacity": "Not enough free secondary channel slots: {{available}} available for {{needed}} channels."
   },
   "locationResponse": {
     "title": "Location: {{identifier}}",
@@ -160,9 +165,13 @@
   "qr": {
     "addChannels": "Add Channels",
     "replaceChannels": "Replace Channels",
-    "description": "The current LoRa configuration will also be shared.",
     "sharableUrl": "Sharable URL",
-    "title": "Generate QR Code"
+    "title": "Generate QR Code",
+    "mode": "Channel share mode",
+    "replaceDescription": "Replace shares the selected channels and LoRa settings.",
+    "addDescription": "Add shares selected channels only and preserves the receiver's existing channels and LoRa settings.",
+    "share": "Share",
+    "shareText": "Meshtastic channel share"
   },
   "reboot": {
     "title": "Reboot device",

--- a/apps/web/public/i18n/locales/en/dialog.json
+++ b/apps/web/public/i18n/locales/en/dialog.json
@@ -22,6 +22,7 @@
     "replaceDescription": "Replace changes the selected channel slots and applies LoRa settings when included.",
     "addDescription": "Add uses free secondary slots and preserves the current channels and LoRa settings.",
     "addOnly": "This share can only add channels.",
+    "pendingChanges": "Save or discard pending settings changes before importing channels.",
     "loraWillApply": "LoRa settings from this share will be applied.",
     "loraWillNotApply": "LoRa settings will not be changed.",
     "duplicateNames": "Channel names already exist: {{names}}. Resolve the conflict before adding.",

--- a/apps/web/public/i18n/locales/en/dialog.json
+++ b/apps/web/public/i18n/locales/en/dialog.json
@@ -6,7 +6,11 @@
   "import": {
     "description": "Import a Channel Set from a Meshtastic URL. <br />Valid Meshtastic URLs start with \"<italic>https://meshtastic.org/e/...</italic>\"",
     "error": {
-      "invalidUrl": "Invalid Meshtastic URL"
+      "invalidUrl": "Invalid Meshtastic URL",
+      "applyFailed": {
+        "title": "Channel import failed",
+        "description": "The device did not accept the channel changes. Please try again."
+      }
     },
     "channelPrefix": "Channel ",
     "primary": "Primary ",

--- a/apps/web/src/components/Dialog/DialogManager.tsx
+++ b/apps/web/src/components/Dialog/DialogManager.tsx
@@ -31,7 +31,6 @@ export const DialogManager = () => {
         onOpenChange={(open) => {
           setDialogOpen("import", open);
         }}
-        loraConfig={config.lora}
       />
       <ShutdownDialog
         open={dialog.shutdown}

--- a/apps/web/src/components/Dialog/ImportDialog.tsx
+++ b/apps/web/src/components/Dialog/ImportDialog.tsx
@@ -18,8 +18,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@components/UI/Select.tsx";
-import { useDevice } from "@core/stores";
 import { useToast } from "@core/hooks/useToast.ts";
+import { useDevice } from "@core/stores";
 import {
   applyChannelImport,
   createChannelImportPlan,
@@ -28,7 +28,7 @@ import {
   type ParsedChannelShare,
 } from "@core/utils/channelShare.ts";
 import { Protobuf } from "@meshtastic/sdk";
-import { useChannels, useConfigEditor } from "@meshtastic/sdk-react";
+import { useChannels, useConfigEditor, useSignal } from "@meshtastic/sdk-react";
 import { useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
@@ -37,10 +37,17 @@ export interface ImportDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+const CLEAN_EDITOR_SIGNAL = {
+  value: false,
+  peek: () => false,
+  subscribe: () => () => {},
+} as const;
+
 export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
   const { config } = useDevice();
   const editor = useConfigEditor();
   const channels = useChannels();
+  const editorIsDirty = useSignal(editor?.isDirty ?? CLEAN_EDITOR_SIGNAL);
   const { toast } = useToast();
   const { t } = useTranslation("dialog");
   const [input, setInput] = useState("");
@@ -101,7 +108,7 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
   };
 
   const apply = async () => {
-    if (!editor || !share || !plan || !plan.canApply) return;
+    if (!editor || !share || !plan || !plan.canApply || editorIsDirty) return;
     setIsApplying(true);
     try {
       await applyChannelImport(editor, share, plan, config.lora);
@@ -159,6 +166,11 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
                     : "import.addDescription",
                 )}
               </p>
+              {editorIsDirty && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {t("import.pendingChanges")}
+                </p>
+              )}
               {share.addOnly && (
                 <p className="text-sm text-text-secondary">
                   {t("import.addOnly")}
@@ -245,7 +257,7 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
         </div>
         <DialogFooter>
           <Button
-            disabled={!plan?.canApply || isApplying}
+            disabled={!plan?.canApply || isApplying || editorIsDirty}
             name="apply"
             onClick={() => void apply()}
           >

--- a/apps/web/src/components/Dialog/ImportDialog.tsx
+++ b/apps/web/src/components/Dialog/ImportDialog.tsx
@@ -1,4 +1,4 @@
-import { create, fromBinary } from "@bufbuild/protobuf";
+import { create } from "@bufbuild/protobuf";
 import { Button } from "@components/UI/Button.tsx";
 import {
   Dialog,
@@ -18,113 +18,114 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@components/UI/Select.tsx";
-import { Switch } from "@components/UI/Switch.tsx";
 import { useDevice } from "@core/stores";
+import {
+  createChannelImportPlan,
+  parseChannelShare,
+  type ChannelShareMode,
+  type ParsedChannelShare,
+} from "@core/utils/channelShare.ts";
 import { Protobuf } from "@meshtastic/sdk";
-import { useConfigEditor } from "@meshtastic/sdk-react";
-import { toByteArray } from "base64-js";
-import { useEffect, useState } from "react";
+import { useChannels, useConfigEditor } from "@meshtastic/sdk-react";
+import { useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 export interface ImportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  loraConfig?: Protobuf.Config.Config_LoRaConfig;
 }
 
 export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
   const { config } = useDevice();
   const editor = useConfigEditor();
+  const channels = useChannels();
   const { t } = useTranslation("dialog");
-  const [importDialogInput, setImportDialogInput] = useState<string>("");
-  const [channelSet, setChannelSet] = useState<Protobuf.AppOnly.ChannelSet>();
-  const [validUrl, setValidUrl] = useState<boolean>(false);
-  const [updateConfig, setUpdateConfig] = useState<boolean>(true);
-  const [importIndex, setImportIndex] = useState<number[]>([]);
+  const [input, setInput] = useState("");
+  const [share, setShare] = useState<ParsedChannelShare>();
+  const [mode, setMode] = useState<ChannelShareMode>("replace");
+  const [selectedSlots, setSelectedSlots] = useState<number[]>();
 
-  useEffect(() => {
-    // the channel information is contained in the URL's fragment, which will be present after a
-    // non-URL encoded `#`.
-    try {
-      const channelsUrl = new URL(importDialogInput);
-      if (
-        (channelsUrl.hostname !== "meshtastic.org" &&
-          channelsUrl.pathname !== "/e/") ||
-        !channelsUrl.hash
-      ) {
-        throw t("import.error.invalidUrl");
-      }
+  const existingChannels = useMemo(
+    () =>
+      channels.map((channel) =>
+        create(Protobuf.Channel.ChannelSchema, {
+          index: channel.index,
+          role: channel.role,
+          settings: channel.settings,
+        }),
+      ),
+    [channels],
+  );
+  const plan = useMemo(
+    () =>
+      share
+        ? createChannelImportPlan(share, existingChannels, mode, selectedSlots)
+        : undefined,
+    [existingChannels, mode, selectedSlots, share],
+  );
 
-      const encodedChannelConfig = channelsUrl.hash.substring(1);
-      const paddedString = encodedChannelConfig
-        .padEnd(
-          encodedChannelConfig.length +
-            ((4 - (encodedChannelConfig.length % 4)) % 4),
-          "=",
-        )
-        .replace(/-/g, "+")
-        .replace(/_/g, "/");
-
-      const newChannelSet = fromBinary(
-        Protobuf.AppOnly.ChannelSetSchema,
-        toByteArray(paddedString),
-      );
-
-      const newImportChannelArray = newChannelSet.settings.map((_, idx) => idx);
-
-      setChannelSet(newChannelSet);
-      setImportIndex(newImportChannelArray);
-      setUpdateConfig(newChannelSet?.loraConfig !== undefined);
-      setValidUrl(true);
-    } catch {
-      setValidUrl(false);
-      setChannelSet(undefined);
+  const parse = (value: string) => {
+    setInput(value);
+    if (!value) {
+      setShare(undefined);
+      setSelectedSlots(undefined);
+      return;
     }
-  }, [importDialogInput, t]);
+    try {
+      const parsed = parseChannelShare(value);
+      setShare(parsed);
+      setMode(parsed.addOnly ? "add" : "replace");
+      setSelectedSlots(undefined);
+    } catch {
+      setShare(undefined);
+      setSelectedSlots(undefined);
+    }
+  };
+
+  const changeMode = (nextMode: ChannelShareMode) => {
+    setMode(nextMode);
+    setSelectedSlots(undefined);
+  };
+
+  const changeSlot = (incomingIndex: number, targetIndex: number) => {
+    if (!plan) return;
+    const nextSlots = plan.assignments.map(
+      (assignment) => assignment.targetIndex,
+    );
+    nextSlots[incomingIndex] = targetIndex;
+    setSelectedSlots(nextSlots);
+  };
 
   const apply = () => {
-    if (!editor) return;
-    channelSet?.settings.forEach(
-      (ch: Protobuf.Channel.ChannelSettings, index: number) => {
-        if (importIndex[index] === -1) {
-          return;
-        }
-
-        const payload = create(Protobuf.Channel.ChannelSchema, {
-          index: importIndex[index],
+    if (!editor || !share || !plan || !plan.canApply) return;
+    for (const assignment of plan.assignments) {
+      const settings = share.channelSet.settings[assignment.incomingIndex];
+      if (!settings || assignment.targetIndex < 0) continue;
+      editor.setChannel(
+        create(Protobuf.Channel.ChannelSchema, {
+          index: assignment.targetIndex,
           role:
-            importIndex[index] === 0
+            assignment.targetIndex === 0
               ? Protobuf.Channel.Channel_Role.PRIMARY
               : Protobuf.Channel.Channel_Role.SECONDARY,
-          settings: ch,
-        });
-
-        editor.setChannel(payload);
-      },
-    );
-
-    if (channelSet?.loraConfig && updateConfig) {
-      const payload = {
-        ...config.lora,
-        ...channelSet.loraConfig,
-      } as Protobuf.Config.Config_LoRaConfig;
-      editor.setRadioSection("lora", payload);
+          settings,
+        }),
+      );
     }
-    // Reset state after import
-    setImportDialogInput("");
-    setChannelSet(undefined);
-    setValidUrl(false);
-    setImportIndex([]);
-    setUpdateConfig(true);
-
+    if (plan.applyLora && share.channelSet.loraConfig) {
+      editor.setRadioSection("lora", {
+        ...config.lora,
+        ...share.channelSet.loraConfig,
+      } as Protobuf.Config.Config_LoRaConfig);
+    }
+    parse("");
     onOpenChange(false);
   };
 
-  const onSelectChange = (value: string, index: number) => {
-    const newImportIndex = [...importIndex];
-    newImportIndex[index] = Number.parseInt(value, 10);
-    setImportIndex(newImportIndex);
-  };
+  const slotOptions =
+    plan?.mode === "add"
+      ? plan.availableSlots
+      : Array.from({ length: 8 }, (_, index) => index);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -134,7 +135,7 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
           <DialogTitle>{t("import.title")}</DialogTitle>
           <DialogDescription>
             <Trans
-              i18nKey={"import.description"}
+              i18nKey="import.description"
               components={{ italic: <i />, br: <br /> }}
             />
           </DialogDescription>
@@ -142,87 +143,145 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
         <div className="flex flex-col gap-3">
           <Label>{t("import.channelSetUrl")}</Label>
           <Input
-            value={importDialogInput}
-            variant={
-              importDialogInput === ""
-                ? "default"
-                : validUrl
-                  ? "dirty"
-                  : "invalid"
-            }
-            onChange={(e) => {
-              setImportDialogInput(e.target.value);
-            }}
+            value={input}
+            variant={input === "" ? "default" : share ? "dirty" : "invalid"}
+            onChange={(event) => parse(event.target.value)}
           />
-          {validUrl && (
-            <div className="flex flex-col gap-6 mt-2">
-              <div className="flex w-full gap-2">
-                <div className=" flex items-center">
-                  <Switch
-                    className="ml-3 mr-4"
-                    checked={updateConfig}
-                    onCheckedChange={(next) => setUpdateConfig(next)}
-                  />
-                  <Label className="">
-                    {t("import.useLoraConfig")}
-                    <span className="block pt-2 font-normal text-s">
-                      {t("import.presetDescription")}
-                    </span>
-                  </Label>
-                </div>
-              </div>
-
+          {share && plan && (
+            <div className="flex flex-col gap-4 mt-2">
+              <ModePicker
+                addOnly={share.addOnly}
+                mode={plan.mode}
+                onChange={changeMode}
+              />
+              <p className="text-sm text-text-secondary">
+                {t(
+                  plan.mode === "replace"
+                    ? "import.replaceDescription"
+                    : "import.addDescription",
+                )}
+              </p>
+              {share.addOnly && (
+                <p className="text-sm text-text-secondary">
+                  {t("import.addOnly")}
+                </p>
+              )}
+              <p className="text-sm text-text-secondary">
+                {t(
+                  plan.applyLora
+                    ? "import.loraWillApply"
+                    : "import.loraWillNotApply",
+                )}
+              </p>
+              {plan.duplicateNames.length > 0 && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {t("import.duplicateNames", {
+                    names: plan.duplicateNames.join(", "),
+                  })}
+                </p>
+              )}
+              {plan.capacityShortfall > 0 && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {t("import.capacity", {
+                    available: plan.availableSlots.length,
+                    needed: share.channelSet.settings.length,
+                  })}
+                </p>
+              )}
               <div className="flex w-full flex-col gap-2">
                 <div className="flex items-center font-semibold text-sm">
                   <span className="flex-1">{t("import.channelName")}</span>
                   <span className="flex-1">{t("import.channelSlot")}</span>
                 </div>
-                {channelSet?.settings.map((channel, index) => (
-                  <div
-                    className="flex items-center"
-                    key={`channel_${channel.id}_${index}`}
-                  >
-                    <Label className="flex-1">
-                      {channel.name.length
-                        ? channel.name
-                        : `${t("import.channelPrefix")}${channel.id}`}
-                    </Label>
-                    <Select
-                      onValueChange={(value) => onSelectChange(value, index)}
-                      value={importIndex[index]?.toString()}
+                {plan.assignments.map((assignment) => {
+                  const channel =
+                    share.channelSet.settings[assignment.incomingIndex];
+                  if (!channel) return null;
+                  return (
+                    <div
+                      className="flex items-center"
+                      key={assignment.incomingIndex}
                     >
-                      <SelectTrigger className="flex-1">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {Array.from({ length: 8 }, (_, i) => i).map((i) => (
-                          <SelectItem
-                            key={`index_${i}`}
-                            disabled={importIndex.includes(i) && index !== i}
-                            value={i.toString()}
-                          >
-                            {i === 0
-                              ? t("import.primary")
-                              : `${t("import.channelPrefix")}${i}`}
-                          </SelectItem>
-                        ))}
-                        <SelectItem value="-1">
-                          {t("import.doNotImport")}
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                ))}
+                      <Label className="flex-1">
+                        {channel.name.length
+                          ? channel.name
+                          : `${t("import.channelPrefix")}${channel.id}`}
+                      </Label>
+                      <Select
+                        onValueChange={(value) =>
+                          changeSlot(
+                            assignment.incomingIndex,
+                            Number.parseInt(value, 10),
+                          )
+                        }
+                        value={assignment.targetIndex.toString()}
+                      >
+                        <SelectTrigger className="flex-1">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {slotOptions.map((slot) => (
+                            <SelectItem
+                              disabled={plan.assignments.some(
+                                (other) =>
+                                  other.incomingIndex !==
+                                    assignment.incomingIndex &&
+                                  other.targetIndex === slot,
+                              )}
+                              key={slot}
+                              value={slot.toString()}
+                            >
+                              {slot === 0
+                                ? t("import.primary")
+                                : `${t("import.channelPrefix")}${slot}`}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}
         </div>
         <DialogFooter>
-          <Button onClick={apply} disabled={!validUrl} name="apply">
+          <Button disabled={!plan?.canApply} name="apply" onClick={apply}>
             {t("button.apply")}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+};
+
+const ModePicker = ({
+  addOnly,
+  mode,
+  onChange,
+}: {
+  addOnly: boolean;
+  mode: ChannelShareMode;
+  onChange: (mode: ChannelShareMode) => void;
+}) => {
+  const { t } = useTranslation("dialog");
+  return (
+    <fieldset className="flex border-0 p-0" aria-label={t("import.mode")}>
+      {(["replace", "add"] as const).map((modeOption) => (
+        <button
+          className={`h-10 border-slate-900 border-t border-b px-4 py-2 text-sm font-medium focus:outline-hidden focus:ring-2 focus:ring-offset-2 first:rounded-l last:rounded-r disabled:cursor-not-allowed disabled:opacity-50 ${
+            mode === modeOption
+              ? "bg-green-800 text-white focus:ring-green-800"
+              : "bg-slate-400 hover:bg-green-600 focus:ring-slate-400"
+          }`}
+          disabled={addOnly && modeOption === "replace"}
+          key={modeOption}
+          onClick={() => onChange(modeOption)}
+          type="button"
+        >
+          {t(`qr.${modeOption}Channels`)}
+        </button>
+      ))}
+    </fieldset>
   );
 };

--- a/apps/web/src/components/Dialog/ImportDialog.tsx
+++ b/apps/web/src/components/Dialog/ImportDialog.tsx
@@ -19,7 +19,9 @@ import {
   SelectValue,
 } from "@components/UI/Select.tsx";
 import { useDevice } from "@core/stores";
+import { useToast } from "@core/hooks/useToast.ts";
 import {
+  applyChannelImport,
   createChannelImportPlan,
   parseChannelShare,
   type ChannelShareMode,
@@ -39,11 +41,13 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
   const { config } = useDevice();
   const editor = useConfigEditor();
   const channels = useChannels();
+  const { toast } = useToast();
   const { t } = useTranslation("dialog");
   const [input, setInput] = useState("");
   const [share, setShare] = useState<ParsedChannelShare>();
   const [mode, setMode] = useState<ChannelShareMode>("replace");
   const [selectedSlots, setSelectedSlots] = useState<number[]>();
+  const [isApplying, setIsApplying] = useState(false);
 
   const existingChannels = useMemo(
     () =>
@@ -96,30 +100,24 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
     setSelectedSlots(nextSlots);
   };
 
-  const apply = () => {
+  const apply = async () => {
     if (!editor || !share || !plan || !plan.canApply) return;
-    for (const assignment of plan.assignments) {
-      const settings = share.channelSet.settings[assignment.incomingIndex];
-      if (!settings || assignment.targetIndex < 0) continue;
-      editor.setChannel(
-        create(Protobuf.Channel.ChannelSchema, {
-          index: assignment.targetIndex,
-          role:
-            assignment.targetIndex === 0
-              ? Protobuf.Channel.Channel_Role.PRIMARY
-              : Protobuf.Channel.Channel_Role.SECONDARY,
-          settings,
-        }),
-      );
+    setIsApplying(true);
+    try {
+      await applyChannelImport(editor, share, plan, config.lora);
+      parse("");
+      onOpenChange(false);
+    } catch (error) {
+      toast({
+        title: t("import.error.applyFailed.title"),
+        description:
+          error instanceof Error
+            ? error.message
+            : t("import.error.applyFailed.description"),
+      });
+    } finally {
+      setIsApplying(false);
     }
-    if (plan.applyLora && share.channelSet.loraConfig) {
-      editor.setRadioSection("lora", {
-        ...config.lora,
-        ...share.channelSet.loraConfig,
-      } as Protobuf.Config.Config_LoRaConfig);
-    }
-    parse("");
-    onOpenChange(false);
   };
 
   const slotOptions =
@@ -246,7 +244,11 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
           )}
         </div>
         <DialogFooter>
-          <Button disabled={!plan?.canApply} name="apply" onClick={apply}>
+          <Button
+            disabled={!plan?.canApply || isApplying}
+            name="apply"
+            onClick={() => void apply()}
+          >
             {t("button.apply")}
           </Button>
         </DialogFooter>

--- a/apps/web/src/components/Dialog/QRDialog.tsx
+++ b/apps/web/src/components/Dialog/QRDialog.tsx
@@ -1,4 +1,3 @@
-import { create, toBinary } from "@bufbuild/protobuf";
 import {
   Dialog,
   DialogClose,
@@ -8,12 +7,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@components/UI/Dialog.tsx";
+import { Button } from "@components/UI/Button.tsx";
 import { Input } from "@components/UI/Input.tsx";
 import { Label } from "@components/UI/Label.tsx";
+import { useCopyToClipboard } from "@core/hooks/useCopyToClipboard.ts";
+import {
+  encodeChannelShare,
+  type ChannelShareMode,
+} from "@core/utils/channelShare.ts";
 import { Protobuf } from "@meshtastic/sdk";
 import { useChannels } from "@meshtastic/sdk-react";
-import { fromByteArray } from "base64-js";
-import { useEffect, useState } from "react";
+import { Share2 } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { QRCode } from "react-qrcode-logo";
 import { Checkbox } from "../UI/Checkbox/index.tsx";
@@ -26,35 +31,46 @@ export interface QRDialogProps {
 
 export const QRDialog = ({ open, onOpenChange, loraConfig }: QRDialogProps) => {
   const { t } = useTranslation("dialog");
+  const { copy } = useCopyToClipboard();
   const [selectedChannels, setSelectedChannels] = useState<number[]>([0]);
-  const [qrCodeUrl, setQrCodeUrl] = useState<string>("");
-  const [qrCodeAdd, setQrCodeAdd] = useState<boolean>();
-
+  const [mode, setMode] = useState<ChannelShareMode>("replace");
   const allChannels = useChannels();
 
-  useEffect(() => {
-    const channelsToEncode = allChannels
-      .filter((ch) => selectedChannels.includes(ch.index))
+  const qrCodeUrl = useMemo(() => {
+    const settings = allChannels
+      .filter((channel) => selectedChannels.includes(channel.index))
       .map((channel) => channel.settings)
-      .filter((ch): ch is Protobuf.Channel.ChannelSettings => !!ch);
-    const encoded = create(
-      Protobuf.AppOnly.ChannelSetSchema,
-      create(Protobuf.AppOnly.ChannelSetSchema, {
-        loraConfig,
-        settings: channelsToEncode,
-      }),
-    );
-    const base64 = fromByteArray(
-      toBinary(Protobuf.AppOnly.ChannelSetSchema, encoded),
-    )
-      .replace(/=/g, "")
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_");
+      .filter(
+        (channel): channel is Protobuf.Channel.ChannelSettings => !!channel,
+      );
 
-    setQrCodeUrl(
-      `https://meshtastic.org/e/${qrCodeAdd ? "?add=true" : ""}#${base64}`,
-    );
-  }, [allChannels, selectedChannels, qrCodeAdd, loraConfig]);
+    return settings.length > 0
+      ? encodeChannelShare({ mode, settings, loraConfig })
+      : "";
+  }, [allChannels, loraConfig, mode, selectedChannels]);
+
+  const share = async () => {
+    if (!qrCodeUrl) return;
+    if (
+      typeof navigator !== "undefined" &&
+      typeof navigator.share === "function"
+    ) {
+      try {
+        await navigator.share({
+          title: t("qr.title"),
+          text: t("qr.shareText"),
+          url: qrCodeUrl,
+        });
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
+      }
+    }
+    await copy(qrCodeUrl);
+  };
+
+  const selectMode = (nextMode: ChannelShareMode) => setMode(nextMode);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -62,9 +78,18 @@ export const QRDialog = ({ open, onOpenChange, loraConfig }: QRDialogProps) => {
         <DialogClose />
         <DialogHeader>
           <DialogTitle>{t("qr.title")}</DialogTitle>
-          <DialogDescription>{t("qr.description")}</DialogDescription>
+          <DialogDescription>
+            {t(
+              mode === "replace"
+                ? "qr.replaceDescription"
+                : "qr.addDescription",
+            )}
+          </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
+          <div className="flex justify-center">
+            <ModePicker mode={mode} onChange={selectMode} />
+          </div>
           <div className="flex gap-3 px-4 py-5 sm:p-6">
             <div className="flex w-40 flex-col gap-2">
               {allChannels.map((channel) => (
@@ -80,13 +105,16 @@ export const QRDialog = ({ open, onOpenChange, loraConfig }: QRDialogProps) => {
                           })}`}
                   </Label>
                   <Checkbox
-                    key={channel.index}
                     checked={selectedChannels.includes(channel.index)}
                     onChange={() => {
                       if (selectedChannels.includes(channel.index)) {
-                        setSelectedChannels(
-                          selectedChannels.filter((c) => c !== channel.index),
-                        );
+                        if (selectedChannels.length > 1) {
+                          setSelectedChannels(
+                            selectedChannels.filter(
+                              (selected) => selected !== channel.index,
+                            ),
+                          );
+                        }
                       } else {
                         setSelectedChannels([
                           ...selectedChannels,
@@ -100,38 +128,45 @@ export const QRDialog = ({ open, onOpenChange, loraConfig }: QRDialogProps) => {
             </div>
             <QRCode value={qrCodeUrl} size={200} qrStyle="dots" />
           </div>
-          <div className="flex justify-center">
-            <button
-              type="button"
-              className={`border-slate-900 border-t border-l border-b rounded-l h-10 px-7 py-2 text-sm font-medium focus:outline-hidden focus:ring-2 focus:ring-offset-2 ${
-                qrCodeAdd
-                  ? "focus:ring-green-800 bg-green-800 text-white"
-                  : "focus:ring-slate-400 bg-slate-400 hover:bg-green-600"
-              }`}
-              name="addChannels"
-              onClick={() => setQrCodeAdd(true)}
-            >
-              {t("qr.addChannels")}
-            </button>
-            <button
-              type="button"
-              className={`border-slate-900 border-t border-r border-b rounded-r h-10 px-4 py-2 text-sm font-medium focus:outline-hidden focus:ring-2 focus:ring-offset-2 ${
-                !qrCodeAdd
-                  ? "focus:ring-green-800 bg-green-800 text-white"
-                  : "focus:ring-slate-400 bg-slate-400 hover:bg-green-600"
-              }`}
-              name="replaceChannels"
-              onClick={() => setQrCodeAdd(false)}
-            >
-              {t("qr.replaceChannels")}
-            </button>
-          </div>
         </div>
-        <DialogFooter>
+        <DialogFooter className="gap-2">
           <Label>{t("qr.sharableUrl")}</Label>
-          <Input value={qrCodeUrl} disabled />
+          <Input value={qrCodeUrl} disabled showCopyButton />
+          <Button onClick={() => void share()} disabled={!qrCodeUrl}>
+            <Share2 className="mr-2" size={16} />
+            {t("qr.share")}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+};
+
+const ModePicker = ({
+  mode,
+  onChange,
+}: {
+  mode: ChannelShareMode;
+  onChange: (mode: ChannelShareMode) => void;
+}) => {
+  const { t } = useTranslation("dialog");
+  return (
+    <fieldset className="flex border-0 p-0" aria-label={t("qr.mode")}>
+      {(["replace", "add"] as const).map((modeOption) => (
+        <button
+          className={`h-10 border-slate-900 border-t border-b px-4 py-2 text-sm font-medium focus:outline-hidden focus:ring-2 focus:ring-offset-2 first:rounded-l last:rounded-r ${
+            mode === modeOption
+              ? "bg-green-800 text-white focus:ring-green-800"
+              : "bg-slate-400 hover:bg-green-600 focus:ring-slate-400"
+          }`}
+          key={modeOption}
+          name={`${modeOption}Channels`}
+          onClick={() => onChange(modeOption)}
+          type="button"
+        >
+          {t(`qr.${modeOption}Channels`)}
+        </button>
+      ))}
+    </fieldset>
   );
 };

--- a/apps/web/src/core/utils/channelShare.test.ts
+++ b/apps/web/src/core/utils/channelShare.test.ts
@@ -1,0 +1,187 @@
+import { create } from "@bufbuild/protobuf";
+import { Protobuf } from "@meshtastic/sdk";
+import { describe, expect, it } from "vitest";
+import {
+  createChannelImportPlan,
+  encodeChannelShare,
+  parseChannelShare,
+} from "./channelShare.ts";
+
+function settings(name: string) {
+  return create(Protobuf.Channel.ChannelSettingsSchema, {
+    name,
+    psk: new Uint8Array([1]),
+  });
+}
+
+function channel(
+  index: number,
+  role: Protobuf.Channel.Channel_Role,
+  name?: string,
+) {
+  return create(Protobuf.Channel.ChannelSchema, {
+    index,
+    role,
+    settings: name ? settings(name) : undefined,
+  });
+}
+
+const loraConfig = create(Protobuf.Config.Config_LoRaConfigSchema, {
+  region: Protobuf.Config.Config_LoRaConfig_RegionCode.US,
+});
+
+describe("channel share URLs", () => {
+  it("encodes a Replace share with its LoRa configuration", () => {
+    const url = encodeChannelShare({
+      mode: "replace",
+      settings: [settings("Primary")],
+      loraConfig,
+    });
+
+    expect(url).toMatch(/^https:\/\/meshtastic\.org\/e\/#/);
+    expect(parseChannelShare(url)).toMatchObject({
+      mode: "replace",
+      addOnly: false,
+      channelSet: { loraConfig, settings: [{ name: "Primary" }] },
+    });
+  });
+
+  it("encodes an Add share without LoRa configuration", () => {
+    const url = encodeChannelShare({
+      mode: "add",
+      settings: [settings("Secondary")],
+      loraConfig,
+    });
+
+    expect(url).toContain("/e/?add=true#");
+    const parsed = parseChannelShare(url);
+    expect(parsed).toMatchObject({
+      mode: "add",
+      addOnly: true,
+      channelSet: { settings: [{ name: "Secondary" }] },
+    });
+    expect(parsed.channelSet.loraConfig).toBeUndefined();
+  });
+
+  it("accepts the historic add marker after the fragment", () => {
+    const canonical = encodeChannelShare({
+      mode: "add",
+      settings: [settings("Legacy")],
+    });
+    const legacy = canonical.replace("?add=true#", "#") + "?add=true";
+
+    expect(parseChannelShare(legacy)).toMatchObject({
+      mode: "add",
+      addOnly: true,
+      channelSet: { settings: [{ name: "Legacy" }] },
+    });
+  });
+
+  it("rejects foreign, malformed, ambiguous, and empty channel shares", () => {
+    const valid = encodeChannelShare({
+      mode: "replace",
+      settings: [settings("Valid")],
+    });
+
+    expect(() => parseChannelShare("https://example.com/e/#AA")).toThrow();
+    expect(() =>
+      parseChannelShare(valid.replace("https://", "https://user@")),
+    ).toThrow();
+    expect(() =>
+      parseChannelShare(valid.replace("#", "?add=true&add=true#")),
+    ).toThrow();
+    expect(() =>
+      parseChannelShare("https://meshtastic.org/e/#not base64"),
+    ).toThrow();
+    expect(() => parseChannelShare("https://meshtastic.org/e/#")).toThrow();
+  });
+});
+
+describe("channel import plans", () => {
+  const existing = [
+    channel(0, Protobuf.Channel.Channel_Role.PRIMARY, "Primary"),
+    channel(1, Protobuf.Channel.Channel_Role.SECONDARY, "Existing"),
+    channel(2, Protobuf.Channel.Channel_Role.DISABLED),
+    channel(3, Protobuf.Channel.Channel_Role.DISABLED),
+  ];
+
+  it("defaults a replace-capable share to Replace and applies LoRa", () => {
+    const parsed = parseChannelShare(
+      encodeChannelShare({
+        mode: "replace",
+        settings: [settings("Replacement")],
+        loraConfig,
+      }),
+    );
+
+    expect(createChannelImportPlan(parsed, existing, "replace")).toMatchObject({
+      mode: "replace",
+      canApply: true,
+      applyLora: true,
+      assignments: [{ incomingIndex: 0, targetIndex: 0 }],
+    });
+  });
+
+  it("locks add-only shares to Add and preserves LoRa", () => {
+    const parsed = parseChannelShare(
+      encodeChannelShare({ mode: "add", settings: [settings("New")] }),
+    );
+
+    expect(createChannelImportPlan(parsed, existing, "replace")).toMatchObject({
+      mode: "add",
+      addOnly: true,
+      canApply: true,
+      applyLora: false,
+      assignments: [{ incomingIndex: 0, targetIndex: 2 }],
+    });
+  });
+
+  it("blocks Add before writes when a channel name conflicts", () => {
+    const parsed = parseChannelShare(
+      encodeChannelShare({ mode: "replace", settings: [settings("existing")] }),
+    );
+
+    expect(createChannelImportPlan(parsed, existing, "add")).toMatchObject({
+      mode: "add",
+      canApply: false,
+      applyLora: false,
+      duplicateNames: ["existing"],
+    });
+  });
+
+  it("blocks Add when there are not enough free secondary slots", () => {
+    const full = Array.from({ length: 8 }, (_, index) =>
+      channel(
+        index,
+        index === 0
+          ? Protobuf.Channel.Channel_Role.PRIMARY
+          : Protobuf.Channel.Channel_Role.SECONDARY,
+        `Existing ${index}`,
+      ),
+    );
+    const parsed = parseChannelShare(
+      encodeChannelShare({ mode: "replace", settings: [settings("New")] }),
+    );
+
+    expect(createChannelImportPlan(parsed, full, "add")).toMatchObject({
+      mode: "add",
+      canApply: false,
+      availableSlots: [],
+      capacityShortfall: 1,
+    });
+  });
+
+  it("treats missing secondary channel indexes as free slots", () => {
+    const parsed = parseChannelShare(
+      encodeChannelShare({ mode: "replace", settings: [settings("New")] }),
+    );
+
+    expect(
+      createChannelImportPlan(parsed, existing.slice(0, 2), "add"),
+    ).toMatchObject({
+      availableSlots: [2, 3, 4, 5, 6, 7],
+      assignments: [{ incomingIndex: 0, targetIndex: 2 }],
+      canApply: true,
+    });
+  });
+});

--- a/apps/web/src/core/utils/channelShare.test.ts
+++ b/apps/web/src/core/utils/channelShare.test.ts
@@ -203,6 +203,7 @@ describe("channel import plans", () => {
     const plan = createChannelImportPlan(parsed, existing, "replace");
     const calls: string[] = [];
     const editor = {
+      isDirty: { value: false },
       setChannel: (value: Protobuf.Channel.Channel) => {
         calls.push(`channel:${value.index}:${value.role}`);
       },
@@ -236,6 +237,7 @@ describe("channel import plans", () => {
     const plan = createChannelImportPlan(parsed, existing, "replace");
     const error = new Error("device rejected import");
     const editor = {
+      isDirty: { value: false },
       setChannel: () => {},
       setRadioSection: () => {},
       commit: async () => ({ status: "error" as const, error }),
@@ -244,5 +246,29 @@ describe("channel import plans", () => {
     await expect(
       applyChannelImport(editor, parsed, plan, undefined),
     ).rejects.toThrow(error);
+  });
+
+  it("does not commit an import through an editor with unrelated pending changes", async () => {
+    const parsed = parseChannelShare(
+      encodeChannelShare({ mode: "replace", settings: [settings("New")] }),
+    );
+    const plan = createChannelImportPlan(parsed, existing, "replace");
+    const calls: string[] = [];
+    const editor = {
+      isDirty: { value: true },
+      setChannel: () => calls.push("channel"),
+      setRadioSection: () => calls.push("lora"),
+      commit: async () => {
+        calls.push("commit");
+        return { status: "ok" as const };
+      },
+    };
+
+    await expect(
+      applyChannelImport(editor, parsed, plan, undefined),
+    ).rejects.toThrow(
+      "Save or discard pending settings changes before importing channels.",
+    );
+    expect(calls).toEqual([]);
   });
 });

--- a/apps/web/src/core/utils/channelShare.test.ts
+++ b/apps/web/src/core/utils/channelShare.test.ts
@@ -2,6 +2,7 @@ import { create } from "@bufbuild/protobuf";
 import { Protobuf } from "@meshtastic/sdk";
 import { describe, expect, it } from "vitest";
 import {
+  applyChannelImport,
   createChannelImportPlan,
   encodeChannelShare,
   parseChannelShare,
@@ -88,6 +89,11 @@ describe("channel share URLs", () => {
       parseChannelShare(valid.replace("https://", "https://user@")),
     ).toThrow();
     expect(() =>
+      parseChannelShare(
+        valid.replace("https://meshtastic.org", "https://meshtastic.org:8443"),
+      ),
+    ).toThrow();
+    expect(() =>
       parseChannelShare(valid.replace("#", "?add=true&add=true#")),
     ).toThrow();
     expect(() =>
@@ -105,7 +111,7 @@ describe("channel import plans", () => {
     channel(3, Protobuf.Channel.Channel_Role.DISABLED),
   ];
 
-  it("defaults a replace-capable share to Replace and applies LoRa", () => {
+  it("defaults a replace-capable share to Replace, clears stale secondary slots, and applies LoRa", () => {
     const parsed = parseChannelShare(
       encodeChannelShare({
         mode: "replace",
@@ -119,6 +125,7 @@ describe("channel import plans", () => {
       canApply: true,
       applyLora: true,
       assignments: [{ incomingIndex: 0, targetIndex: 0 }],
+      disabledIndexes: [1, 2, 3, 4, 5, 6, 7],
     });
   });
 
@@ -183,5 +190,59 @@ describe("channel import plans", () => {
       assignments: [{ incomingIndex: 0, targetIndex: 2 }],
       canApply: true,
     });
+  });
+
+  it("stages a complete Replace and commits it as one editor transaction", async () => {
+    const parsed = parseChannelShare(
+      encodeChannelShare({
+        mode: "replace",
+        settings: [settings("Replacement")],
+        loraConfig,
+      }),
+    );
+    const plan = createChannelImportPlan(parsed, existing, "replace");
+    const calls: string[] = [];
+    const editor = {
+      setChannel: (value: Protobuf.Channel.Channel) => {
+        calls.push(`channel:${value.index}:${value.role}`);
+      },
+      setRadioSection: () => calls.push("lora"),
+      commit: async () => {
+        calls.push("commit");
+        return { status: "ok" as const };
+      },
+    };
+
+    await applyChannelImport(editor, parsed, plan, undefined);
+
+    expect(calls).toEqual([
+      `channel:0:${Protobuf.Channel.Channel_Role.PRIMARY}`,
+      `channel:1:${Protobuf.Channel.Channel_Role.DISABLED}`,
+      `channel:2:${Protobuf.Channel.Channel_Role.DISABLED}`,
+      `channel:3:${Protobuf.Channel.Channel_Role.DISABLED}`,
+      `channel:4:${Protobuf.Channel.Channel_Role.DISABLED}`,
+      `channel:5:${Protobuf.Channel.Channel_Role.DISABLED}`,
+      `channel:6:${Protobuf.Channel.Channel_Role.DISABLED}`,
+      `channel:7:${Protobuf.Channel.Channel_Role.DISABLED}`,
+      "lora",
+      "commit",
+    ]);
+  });
+
+  it("propagates an editor commit error without clearing the staged import", async () => {
+    const parsed = parseChannelShare(
+      encodeChannelShare({ mode: "replace", settings: [settings("New")] }),
+    );
+    const plan = createChannelImportPlan(parsed, existing, "replace");
+    const error = new Error("device rejected import");
+    const editor = {
+      setChannel: () => {},
+      setRadioSection: () => {},
+      commit: async () => ({ status: "error" as const, error }),
+    };
+
+    await expect(
+      applyChannelImport(editor, parsed, plan, undefined),
+    ).rejects.toThrow(error);
   });
 });

--- a/apps/web/src/core/utils/channelShare.ts
+++ b/apps/web/src/core/utils/channelShare.ts
@@ -32,6 +32,7 @@ export interface ChannelImportPlan {
 }
 
 export interface ChannelImportEditor {
+  isDirty: { value: boolean };
   setChannel(channel: Protobuf.Channel.Channel): void;
   setRadioSection(
     section: "lora",
@@ -241,6 +242,11 @@ export async function applyChannelImport(
 ): Promise<void> {
   if (!plan.canApply) {
     throw new Error("Channel import plan cannot be applied.");
+  }
+  if (editor.isDirty.value) {
+    throw new Error(
+      "Save or discard pending settings changes before importing channels.",
+    );
   }
 
   for (const assignment of plan.assignments) {

--- a/apps/web/src/core/utils/channelShare.ts
+++ b/apps/web/src/core/utils/channelShare.ts
@@ -1,0 +1,229 @@
+import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+import { Protobuf } from "@meshtastic/sdk";
+import { fromByteArray, toByteArray } from "base64-js";
+
+const CHANNEL_SHARE_HOST = "meshtastic.org";
+const CHANNEL_SHARE_PATH = "/e/";
+const MAX_CHANNELS = 8;
+
+export type ChannelShareMode = "replace" | "add";
+
+export interface ParsedChannelShare {
+  channelSet: Protobuf.AppOnly.ChannelSet;
+  mode: ChannelShareMode;
+  addOnly: boolean;
+}
+
+export interface ChannelImportAssignment {
+  incomingIndex: number;
+  targetIndex: number;
+}
+
+export interface ChannelImportPlan {
+  mode: ChannelShareMode;
+  addOnly: boolean;
+  applyLora: boolean;
+  assignments: ChannelImportAssignment[];
+  availableSlots: number[];
+  duplicateNames: string[];
+  capacityShortfall: number;
+  canApply: boolean;
+}
+
+export function encodeChannelShare({
+  mode,
+  settings,
+  loraConfig,
+}: {
+  mode: ChannelShareMode;
+  settings: readonly Protobuf.Channel.ChannelSettings[];
+  loraConfig?: Protobuf.Config.Config_LoRaConfig;
+}): string {
+  if (settings.length === 0 || settings.length > MAX_CHANNELS) {
+    throw new Error(
+      "A channel share must include between one and eight channels.",
+    );
+  }
+
+  const channelSet = create(Protobuf.AppOnly.ChannelSetSchema, {
+    settings: [...settings],
+    loraConfig: mode === "replace" ? loraConfig : undefined,
+  });
+  const payload = fromByteArray(
+    toBinary(Protobuf.AppOnly.ChannelSetSchema, channelSet),
+  )
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+
+  return `https://${CHANNEL_SHARE_HOST}${CHANNEL_SHARE_PATH}${
+    mode === "add" ? "?add=true" : ""
+  }#${payload}`;
+}
+
+export function parseChannelShare(input: string): ParsedChannelShare {
+  const url = new URL(input);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== CHANNEL_SHARE_HOST ||
+    url.pathname !== CHANNEL_SHARE_PATH ||
+    url.username ||
+    url.password ||
+    !url.hash
+  ) {
+    throw new Error("Invalid Meshtastic channel URL.");
+  }
+
+  const queryMode = parseShareMode(url.searchParams);
+  let payload = url.hash.substring(1);
+  const legacyAdd = payload.endsWith("?add=true");
+  if (legacyAdd) payload = payload.slice(0, -"?add=true".length);
+
+  if (!payload || !/^[A-Za-z0-9_-]+$/.test(payload)) {
+    throw new Error("Invalid Meshtastic channel payload.");
+  }
+
+  const paddedPayload = payload
+    .padEnd(payload.length + ((4 - (payload.length % 4)) % 4), "=")
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  const decoded = fromBinary(
+    Protobuf.AppOnly.ChannelSetSchema,
+    toByteArray(paddedPayload),
+  );
+
+  if (decoded.settings.length === 0 || decoded.settings.length > MAX_CHANNELS) {
+    throw new Error("Channel share does not contain a valid channel set.");
+  }
+
+  const mode: ChannelShareMode =
+    queryMode === "add" || legacyAdd ? "add" : "replace";
+  return {
+    mode,
+    addOnly: mode === "add",
+    // A malformed add-only payload can never carry LoRa settings into an Add import.
+    channelSet:
+      mode === "add"
+        ? create(Protobuf.AppOnly.ChannelSetSchema, {
+            settings: decoded.settings,
+          })
+        : decoded,
+  };
+}
+
+export function createChannelImportPlan(
+  share: ParsedChannelShare,
+  existingChannels: readonly Protobuf.Channel.Channel[],
+  requestedMode: ChannelShareMode,
+  selectedSlots?: readonly number[],
+): ChannelImportPlan {
+  const mode = share.addOnly ? "add" : requestedMode;
+  const channelsByIndex = new Map(
+    existingChannels.map((channel) => [channel.index, channel]),
+  );
+  const availableSlots = Array.from(
+    { length: MAX_CHANNELS - 1 },
+    (_, index) => index + 1,
+  ).filter((index) => {
+    const channel = channelsByIndex.get(index);
+    return (
+      channel === undefined ||
+      channel.role === Protobuf.Channel.Channel_Role.DISABLED ||
+      channel.settings === undefined
+    );
+  });
+
+  if (mode === "replace") {
+    const assignments = share.channelSet.settings.map((_, incomingIndex) => ({
+      incomingIndex,
+      targetIndex: selectedSlots?.[incomingIndex] ?? incomingIndex,
+    }));
+    const duplicateTargets = new Set<number>();
+    const seenTargets = new Set<number>();
+    for (const assignment of assignments) {
+      if (assignment.targetIndex < 0) continue;
+      if (seenTargets.has(assignment.targetIndex)) {
+        duplicateTargets.add(assignment.targetIndex);
+      }
+      seenTargets.add(assignment.targetIndex);
+    }
+
+    return {
+      mode,
+      addOnly: false,
+      applyLora: share.channelSet.loraConfig !== undefined,
+      assignments,
+      availableSlots,
+      duplicateNames: [],
+      capacityShortfall: 0,
+      canApply:
+        duplicateTargets.size === 0 &&
+        assignments.some((assignment) => assignment.targetIndex >= 0),
+    };
+  }
+
+  const existingNames = new Set(
+    existingChannels
+      .map((channel) => channel.settings?.name.trim().toLocaleLowerCase())
+      .filter((name): name is string => Boolean(name)),
+  );
+  const incomingNames = new Set<string>();
+  const duplicateNames = new Set<string>();
+  for (const channel of share.channelSet.settings) {
+    const name = channel.name.trim().toLocaleLowerCase();
+    if (!name) continue;
+    if (existingNames.has(name) || incomingNames.has(name))
+      duplicateNames.add(name);
+    incomingNames.add(name);
+  }
+
+  const assignments = share.channelSet.settings.map((_, incomingIndex) => ({
+    incomingIndex,
+    targetIndex:
+      selectedSlots?.[incomingIndex] ?? availableSlots[incomingIndex] ?? -1,
+  }));
+  const invalidTarget = assignments.some(
+    (assignment) =>
+      assignment.targetIndex !== -1 &&
+      !availableSlots.includes(assignment.targetIndex),
+  );
+  const selectedTargets = assignments
+    .map((assignment) => assignment.targetIndex)
+    .filter((targetIndex) => targetIndex >= 0);
+  const hasDuplicateTargets =
+    new Set(selectedTargets).size !== selectedTargets.length;
+  const capacityShortfall = Math.max(
+    0,
+    share.channelSet.settings.length - availableSlots.length,
+  );
+
+  return {
+    mode,
+    addOnly: true,
+    applyLora: false,
+    assignments,
+    availableSlots,
+    duplicateNames: [...duplicateNames],
+    capacityShortfall,
+    canApply:
+      duplicateNames.size === 0 &&
+      capacityShortfall === 0 &&
+      !invalidTarget &&
+      !hasDuplicateTargets &&
+      assignments.every((assignment) => assignment.targetIndex >= 0),
+  };
+}
+
+function parseShareMode(search: URLSearchParams): ChannelShareMode {
+  if (
+    [...search.keys()].some((key) => key !== "add") ||
+    search.getAll("add").length > 1
+  ) {
+    throw new Error("Invalid Meshtastic channel URL.");
+  }
+  const add = search.get("add");
+  if (add !== null && add !== "true") {
+    throw new Error("Invalid Meshtastic channel URL.");
+  }
+  return add === "true" ? "add" : "replace";
+}

--- a/apps/web/src/core/utils/channelShare.ts
+++ b/apps/web/src/core/utils/channelShare.ts
@@ -24,10 +24,20 @@ export interface ChannelImportPlan {
   addOnly: boolean;
   applyLora: boolean;
   assignments: ChannelImportAssignment[];
+  disabledIndexes: number[];
   availableSlots: number[];
   duplicateNames: string[];
   capacityShortfall: number;
   canApply: boolean;
+}
+
+export interface ChannelImportEditor {
+  setChannel(channel: Protobuf.Channel.Channel): void;
+  setRadioSection(
+    section: "lora",
+    config: Protobuf.Config.Config_LoRaConfig,
+  ): void;
+  commit(): Promise<{ status: "ok" } | { status: "error"; error: Error }>;
 }
 
 export function encodeChannelShare({
@@ -67,6 +77,7 @@ export function parseChannelShare(input: string): ParsedChannelShare {
     url.protocol !== "https:" ||
     url.hostname !== CHANNEL_SHARE_HOST ||
     url.pathname !== CHANNEL_SHARE_PATH ||
+    url.port !== "" ||
     url.username ||
     url.password ||
     !url.hash
@@ -153,6 +164,13 @@ export function createChannelImportPlan(
       addOnly: false,
       applyLora: share.channelSet.loraConfig !== undefined,
       assignments,
+      disabledIndexes: Array.from(
+        { length: MAX_CHANNELS - 1 },
+        (_, index) => index + 1,
+      ).filter(
+        (index) =>
+          !assignments.some((assignment) => assignment.targetIndex === index),
+      ),
       availableSlots,
       duplicateNames: [],
       capacityShortfall: 0,
@@ -202,6 +220,7 @@ export function createChannelImportPlan(
     addOnly: true,
     applyLora: false,
     assignments,
+    disabledIndexes: [],
     availableSlots,
     duplicateNames: [...duplicateNames],
     capacityShortfall,
@@ -212,6 +231,51 @@ export function createChannelImportPlan(
       !hasDuplicateTargets &&
       assignments.every((assignment) => assignment.targetIndex >= 0),
   };
+}
+
+export async function applyChannelImport(
+  editor: ChannelImportEditor,
+  share: ParsedChannelShare,
+  plan: ChannelImportPlan,
+  currentLora: Protobuf.Config.Config_LoRaConfig | undefined,
+): Promise<void> {
+  if (!plan.canApply) {
+    throw new Error("Channel import plan cannot be applied.");
+  }
+
+  for (const assignment of plan.assignments) {
+    const settings = share.channelSet.settings[assignment.incomingIndex];
+    if (!settings || assignment.targetIndex < 0) continue;
+    editor.setChannel(
+      create(Protobuf.Channel.ChannelSchema, {
+        index: assignment.targetIndex,
+        role:
+          assignment.targetIndex === 0
+            ? Protobuf.Channel.Channel_Role.PRIMARY
+            : Protobuf.Channel.Channel_Role.SECONDARY,
+        settings,
+      }),
+    );
+  }
+
+  for (const index of plan.disabledIndexes) {
+    editor.setChannel(
+      create(Protobuf.Channel.ChannelSchema, {
+        index,
+        role: Protobuf.Channel.Channel_Role.DISABLED,
+      }),
+    );
+  }
+
+  if (plan.applyLora && share.channelSet.loraConfig) {
+    editor.setRadioSection("lora", {
+      ...currentLora,
+      ...share.channelSet.loraConfig,
+    } as Protobuf.Config.Config_LoRaConfig);
+  }
+
+  const result = await editor.commit();
+  if (result.status === "error") throw result.error;
 }
 
 function parseShareMode(search: URLSearchParams): ChannelShareMode {


### PR DESCRIPTION
Closes #1313
Design: https://github.com/meshtastic/design/issues/128

## Summary
- Add a strict, reusable channel-share URL encoder/parser for canonical URLs and the documented legacy Add marker.
- Make Replace the default in both QR sharing and pasted-link intake; Add links contain no LoRa configuration and lock intake to Add.
- Plan imports before writing: Add preserves existing channels and LoRa settings, and blocks duplicate names or insufficient secondary-slot capacity.
- Make Replace complete by staging disabled records for every secondary slot not in the incoming set.
- Commit channel and LoRa changes through the SDK editor's single edit transaction; failed commits keep the import open and surface an error toast.
- Block import while the shared configuration editor has pending settings changes, so a channel import cannot commit unrelated radio, module, channel, or owner edits.
- Align share and intake terminology, add copy and Web Share fallback, and leave reconnect/reboot behavior event-driven and unchanged.

## Validation
- `vitest run src/core/utils/channelShare.test.ts` (12 passing fixtures, including dirty-editor commit prevention)
- `oxfmt --check` and `oxlint` on touched TypeScript files
- `vite build` completed; this isolated checkout emits a non-fatal missing-tag warning from the existing version step and the existing chunk-size warning.
- Full `tsc --noEmit` remains blocked by pre-existing SDK/type mismatches outside this change; it produced no diagnostics in touched files.

## Verification pending
- No connected-node hardware import/share session was available.
- No browser visual pass was captured; this remains a draft for that follow-up.
