### PR TITLE
Prompt when serial devices share USB identifiers

### DIFF
--- a/apps/web/src/core/connections/transports.test.ts
+++ b/apps/web/src/core/connections/transports.test.ts
@@ -1,0 +1,51 @@
+import { TransportWebSerial } from "@meshtastic/transport-web-serial";
+import { Result } from "better-result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { openTransport } from "./transports.ts";
+
+vi.mock("@meshtastic/transport-web-serial", () => ({
+  SerialConnectError: class SerialConnectError extends Error {},
+  TransportWebSerial: { createFromPort: vi.fn() },
+}));
+
+describe("openTransport serial selection", () => {
+  const info = { usbVendorId: 0x303a, usbProductId: 0x1001 };
+  const portA = { getInfo: () => info } as SerialPort;
+  const portB = { getInfo: () => info } as SerialPort;
+  const selectedPort = { getInfo: () => info } as SerialPort;
+  const requestPort = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requestPort.mockResolvedValue(selectedPort);
+    Object.defineProperty(navigator, "serial", {
+      configurable: true,
+      value: {
+        getPorts: vi.fn().mockResolvedValue([portA, portB]),
+        requestPort,
+      },
+    });
+    vi.mocked(TransportWebSerial.createFromPort).mockResolvedValue(
+      Result.ok({} as never),
+    );
+  });
+
+  it("prompts when multiple permitted ports share the saved VID/PID", async () => {
+    await openTransport(
+      {
+        id: 1,
+        name: "Serial: 303a:1001",
+        type: "serial",
+        status: "disconnected",
+        usbVendorId: info.usbVendorId,
+        usbProductId: info.usbProductId,
+      },
+      { allowPrompt: true },
+    );
+
+    expect(requestPort).toHaveBeenCalledOnce();
+    expect(TransportWebSerial.createFromPort).toHaveBeenCalledWith(
+      selectedPort,
+    );
+  });
+});

--- a/apps/web/src/core/connections/transports.test.ts
+++ b/apps/web/src/core/connections/transports.test.ts
@@ -44,6 +44,14 @@ describe("openTransport serial selection", () => {
     );
 
     expect(requestPort).toHaveBeenCalledOnce();
+    expect(requestPort).toHaveBeenCalledWith({
+      filters: [
+        {
+          usbVendorId: info.usbVendorId,
+          usbProductId: info.usbProductId,
+        },
+      ],
+    });
     expect(TransportWebSerial.createFromPort).toHaveBeenCalledWith(
       selectedPort,
     );

--- a/apps/web/src/core/connections/transports.ts
+++ b/apps/web/src/core/connections/transports.ts
@@ -160,7 +160,7 @@ async function openSerial(
     const ports = await serial.getPorts();
     log.debug("openSerial: getPorts", { count: ports.length });
     if (ports && conn.usbVendorId && conn.usbProductId) {
-      port = ports.find((p: SerialPort) => {
+      const matchingPorts = ports.filter((p: SerialPort) => {
         const info =
           (
             p as SerialPort & {
@@ -172,6 +172,17 @@ async function openSerial(
           info.usbProductId === conn.usbProductId
         );
       });
+      if (matchingPorts.length === 1) {
+        port = matchingPorts[0];
+      } else if (matchingPorts.length > 1) {
+        log.info(
+          "openSerial: multiple permitted ports share VID/PID; user selection required",
+          { count: matchingPorts.length },
+        );
+        if (opts.allowPrompt) {
+          port = await serial.requestPort({});
+        }
+      }
     }
   }
   if (!port && opts.allowPrompt) {

--- a/apps/web/src/core/connections/transports.ts
+++ b/apps/web/src/core/connections/transports.ts
@@ -154,6 +154,17 @@ async function openSerial(
       };
     }
   ).serial;
+  const requestPortOptions =
+    conn.usbVendorId !== undefined && conn.usbProductId !== undefined
+      ? {
+          filters: [
+            {
+              usbVendorId: conn.usbVendorId,
+              usbProductId: conn.usbProductId,
+            },
+          ],
+        }
+      : {};
 
   let port = opts.cachedSerialPort;
   if (!port) {
@@ -180,14 +191,14 @@ async function openSerial(
           { count: matchingPorts.length },
         );
         if (opts.allowPrompt) {
-          port = await serial.requestPort({});
+          port = await serial.requestPort(requestPortOptions);
         }
       }
     }
   }
   if (!port && opts.allowPrompt) {
     log.debug("openSerial: requesting port via picker");
-    port = await serial.requestPort({});
+    port = await serial.requestPort(requestPortOptions);
   }
   if (!port) {
     log.warn("openSerial: no port resolved");


### PR DESCRIPTION
## Summary
- Auto-select a serial port only when exactly one authorized device matches the saved USB vendor/product identifiers.
- Fall back to the browser's serial chooser when multiple authorized devices share the same identifiers.
- Add regression coverage for duplicate VID/PID devices.

## Root cause
The transport used `find()` and silently selected the first authorized match. Multiple Meshtastic boards can expose identical USB vendor/product identifiers, so a saved connection could attach to the wrong physical node.

## Impact
Users with multiple identical boards are prompted to select the intended device instead of being connected to an arbitrary match.

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage pnpm vitest run apps/web/src/core/connections/transports.test.ts`: 1 test passed.
- `pnpm --filter meshtastic-web build`: passed.
- `pnpm lint`: passed with existing warnings.
- `git diff --check`: passed.
- GitHub `E2E (real device)`: passed in 1m48s.

## Notes
- Vercel preview requires Meshtastic team authorization for fork deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial-port discovery using saved USB VID/PID filters when resolving available serial devices.
  * Automatically selects and connects when exactly one matching port is found.
  * When multiple matches exist, only prompts for user selection if prompting is enabled.
* **Tests**
  * Added a Vitest suite covering multi-port VID/PID matching and ensuring the correct port is passed to the serial transport when prompting is allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->