### PR TITLE
update queue status log message

### DIFF
--- a/packages/sdk/src/core/packet-codec/decodePacket.ts
+++ b/packages/sdk/src/core/packet-codec/decodePacket.ts
@@ -200,7 +200,7 @@ export const decodePacket = (sink: PacketSink): WritableStream<DeviceOutput> =>
             case "queueStatus": {
               sink.log.trace(
                 Emitter[Emitter.HandleFromRadio],
-                `🚧 Received Queue Status: ${decodedMessage.payloadVariant.value}`,
+                `🚧 Received Queue Status: last status: ${decodedMessage.payloadVariant.value.res}, free entries: ${decodedMessage.payloadVariant.value.free} out of ${decodedMessage.payloadVariant.value.maxlen}`,
               );
               sink.events.onQueueStatus.dispatch(
                 decodedMessage.payloadVariant.value,


### PR DESCRIPTION
## Description

When receiving queue log-messages via node-serial the output for the `.value` would be `[object Object]`

Full example:

```
11:54:58:432    TRACE   [iMeshDevice]   HandleFromRadio 🚧 Received Queue Status: [object Object]
fromRadio {
  '$typeName': 'meshtastic.FromRadio',
  id: 0,
  payloadVariant: {
    case: 'queueStatus',
    value: {
      '$typeName': 'meshtastic.QueueStatus',
      res: 0,
      free: 16,
      maxlen: 16,
      meshPacketId: 0
    }
  }
}
```

## Changes Made

- updated the log message to make use of the different relevant keys in the value object


## Checklist

<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->

- [ ] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All i18n translation labels have been added (read
      CONTRIBUTING_I18N_DEVELOPER_GUIDE.md for more details)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue-status logging to include the status result and available versus maximum queue entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->