### PR TITLE
docs: fix build steps and package paths in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ send commands to a Meshtastic device lives here.
 
 ## Packages
 
-All projects live under `packages/`.
+Libraries live under `packages/`; the reference web client lives under `apps/`.
 
 | Package | Purpose |
 | --- | --- |
@@ -83,8 +83,12 @@ Expected domain errors are returned as `Result<T, E>` via [`better-result`](http
 
 ### Prerequisites
 
-You need [pnpm](https://pnpm.io/) installed. If you plan to regenerate
-protobufs, also install the [Buf CLI](https://buf.build/docs/cli/installation/).
+- [pnpm](https://pnpm.io/) — package manager for the workspace.
+- [Buf CLI](https://buf.build/docs/cli/installation/) — required whenever
+  `@meshtastic/protobufs` needs to build (which happens on a full
+  `pnpm -r build`, since it runs `buf generate`). If you only want to run
+  the web client in dev, `pnpm --filter meshtastic-web dev` does not need
+  Buf as long as the protobuf stubs are already generated.
 
 ### Setup
 
@@ -97,13 +101,24 @@ pnpm install
 ### Run the web client
 
 ```bash
-pnpm --filter @meshtastic/web dev
+pnpm --filter meshtastic-web dev
 ```
 
 ### Build everything
 
+`pnpm -r` walks the workspace in topological order, so `@meshtastic/protobufs`
+runs first and every downstream package (including `packages/ui`) sees the
+generated stubs. Requires the Buf CLI (see Prerequisites).
+
 ```bash
 pnpm -r build
+```
+
+If you only need the web client, build it and its dependency graph without
+touching every publishable package:
+
+```bash
+pnpm --filter meshtastic-web... build
 ```
 
 ### Run tests

--- a/README.md
+++ b/README.md
@@ -106,13 +106,19 @@ pnpm --filter meshtastic-web dev
 
 ### Build everything
 
-`pnpm -r` walks the workspace in topological order, so `@meshtastic/protobufs`
-runs first and every downstream package (including `packages/ui`) sees the
-generated stubs. Requires the Buf CLI (see Prerequisites).
+Requires the Buf CLI (see Prerequisites) — `@meshtastic/protobufs` runs
+`buf generate` as part of its `build` script.
 
 ```bash
 pnpm -r build
 ```
+
+`pnpm -r` sorts packages by their `workspace:` dependencies (dependencies
+before dependents) and runs up to `--workspace-concurrency` packages in
+parallel. Packages linked over other protocols (for example `jsr:`) are
+not sequenced against workspace peers, so run `pnpm --filter
+@meshtastic/protobufs build` first if you are iterating on generated
+stubs consumed via a non-workspace protocol.
 
 If you only need the web client, build it and its dependency graph without
 touching every publishable package:

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -86,17 +86,16 @@ instructions listed on the home page.
 
 ### Development
 
-Install the dependencies.
+Install the dependencies from the repo root (pnpm workspaces installs every package in one pass).
 
 ```bash
-cd packages/web &&
 pnpm install
 ```
 
-Start the development server:
+Start the development server for the web client:
 
 ```bash
-pnpm run dev
+pnpm --filter meshtastic-web dev
 ```
 
 ### Building and Packaging
@@ -104,13 +103,13 @@ pnpm run dev
 Build the project:
 
 ```bash
-pnpm run build
+pnpm --filter meshtastic-web build
 ```
 
 GZip the output:
 
 ```bash
-pnpm run package
+pnpm --filter meshtastic-web run package
 ```
 
 ### Why pnpm?
@@ -151,6 +150,6 @@ requests:
     Meshtastic nodes.
 
 Please review our
-[Contribution Guidelines](https://github.com/meshtastic/web/blob/main/packages/web/CONTRIBUTING.md)
+[Contribution Guidelines](https://github.com/meshtastic/web/blob/main/apps/web/CONTRIBUTING.md)
 before submitting a pull request. We appreciate your help in making the project
 better!


### PR DESCRIPTION
## Summary

- Root README and `apps/web/README.md` still pointed at the pre-monorepo `packages/web` path and used the filter `@meshtastic/web`, which resolves to the workspace root package rather than the web app. Following the docs did not build the app.
- Buf CLI was listed as optional in Prerequisites even though `pnpm -r build` invokes `buf generate` in `@meshtastic/protobufs` unconditionally, so a fresh clone + `pnpm -r build` fails with `sh: buf: command not found` unless Buf is installed.
- `apps/web/README.md` linked its Contributing guide via `packages/web/CONTRIBUTING.md` (broken).

Fixes #1252.

### Changes
- **Root `README.md`**: clarify that libraries live under `packages/` and the reference web client under `apps/`; mark Buf CLI required for `pnpm -r build`; document topological build order; add web-only build path `pnpm --filter meshtastic-web... build`; fix filter name (`@meshtastic/web` → `meshtastic-web`).
- **`apps/web/README.md`**: replace `cd packages/web && pnpm install` with a root-level `pnpm install`; use `pnpm --filter meshtastic-web` for `dev`, `build`, and `run package`; fix Contributing link (`packages/web` → `apps/web`).

## Test plan
- [ ] Fresh clone → `pnpm install` at repo root succeeds
- [ ] With Buf CLI installed → `pnpm -r build` succeeds
- [ ] `pnpm --filter meshtastic-web dev` starts the web client
- [ ] `pnpm --filter meshtastic-web... build` builds the web client + its workspace deps without touching every publishable package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between workspace libraries and the web client.
  * Updated setup instructions to install dependencies from the repository root.
  * Documented workspace-wide and web-client-specific build and packaging commands.
  * Added Buf CLI prerequisites and updated the web development command to `meshtastic-web`.
  * Corrected the contribution guidelines link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->