### PR TITLE
fix(web): batch of small bug fixes and UX polish

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,14 +9,30 @@ import { ErrorPage } from "@components/UI/ErrorPage.tsx";
 import Footer from "@components/UI/Footer.tsx";
 import { useTheme } from "@core/hooks/useTheme.ts";
 import { SidebarProvider, useAppStore, useDeviceStore } from "@core/stores";
+import { useTotalUnread } from "@meshtastic/sdk-react";
 import { Connections } from "@pages/Connections/index.tsx";
 import { Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { useEffect, useRef } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { MapProvider } from "react-map-gl/maplibre";
 
+function useUnreadTitleIndicator() {
+  const baseTitleRef = useRef<string>("");
+  const unread = useTotalUnread();
+
+  useEffect(() => {
+    if (!baseTitleRef.current) {
+      baseTitleRef.current = document.title.replace(/^●\s*/, "");
+    }
+    document.title =
+      unread > 0 ? `● ${baseTitleRef.current}` : baseTitleRef.current;
+  }, [unread]);
+}
+
 export function App() {
   useTheme();
+  useUnreadTitleIndicator();
 
   const { getDevice } = useDeviceStore();
   const { selectedDeviceId } = useAppStore();

--- a/apps/web/src/components/Form/FormInput.tsx
+++ b/apps/web/src/components/Form/FormInput.tsx
@@ -59,11 +59,9 @@ export function GenericInput<T extends FieldValues>({
       field.inputChange(e);
     }
 
-    controllerField.onChange(
-      field.type === "number"
-        ? Number.parseFloat(newValue).toString()
-        : newValue,
-    );
+    // Forward the raw string so partial input like "-" or "0." isn't
+    // mangled mid-type; the schema coerces on submit.
+    controllerField.onChange(newValue);
   };
 
   const currentLength = controllerField.value
@@ -76,9 +74,9 @@ export function GenericInput<T extends FieldValues>({
         type={field.type}
         step={field.properties?.step}
         value={
-          field.type === "number"
-            ? String(controllerField.value)
-            : controllerField.value
+          controllerField.value === undefined || controllerField.value === null
+            ? ""
+            : String(controllerField.value)
         }
         id={field.name}
         onChange={handleInputChange}

--- a/apps/web/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/apps/web/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -148,10 +148,7 @@ export const ChannelChat = ({ messages = [] }: ChannelChatProps) => {
         <Fragment key={dayKey}>
           {/* Render messages first, then delimiter — with flex-col-reverse this shows the delimiter above that day's messages */}
           {items.map((message) => (
-            <Suspense
-              key={message.messageId ?? `${message.from}-${message.date}`}
-              fallback={<MessageSkeleton />}
-            >
+            <Suspense key={message.messageId} fallback={<MessageSkeleton />}>
               <MessageItem message={message} />
             </Suspense>
           ))}

--- a/apps/web/src/components/PageComponents/Messages/MessageItem.tsx
+++ b/apps/web/src/components/PageComponents/Messages/MessageItem.tsx
@@ -19,48 +19,46 @@ import { AlertCircle, CheckCircle2, CircleEllipsis } from "lucide-react";
 import { type ReactNode, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-// Cache for pending promises
-const myNodePromises = new Map<string, Promise<Protobuf.Mesh.NodeInfo>>();
+const myNodePromises = new Map<string, Promise<void>>();
+const myNodeDeadlines = new Map<string, number>();
+const MY_NODE_TIMEOUT_MS = 10_000;
 
-// Hook that suspends when myNode is not available. Reads from the SDK
-// (NodesClient signal hydrated by sqlocal + live packets) instead of the
-// legacy Zustand nodeDB. The polling fallback remains because there is a
-// gap between mount and first onMyNodeInfo packet on a fresh connect.
+// Suspends until myNode hydrates. Times out after 10s.
 function useSuspendingMyNode() {
   const selectedDeviceId = useAppStore((s) => s.selectedDeviceId);
   const myNode = useMyNodeAsProto();
 
-  if (!myNode) {
+  if (myNode) {
     const deviceKey = `device-${selectedDeviceId}`;
-
-    if (!myNodePromises.has(deviceKey)) {
-      const promise = new Promise<Protobuf.Mesh.NodeInfo>((resolve, reject) => {
-        // setTimeout with a 100ms tick lets React re-render this component
-        // (and therefore re-run the hook) until myNode resolves through the
-        // SDK signal. Suspense re-throws the promise on each retry until
-        // the value is available.
-        const start = Date.now();
-        const tick = () => {
-          if (Date.now() - start > 10000) {
-            myNodePromises.delete(deviceKey);
-            reject(new Error("myNode not available after 10s"));
-            return;
-          }
-          // Resolve a no-op promise to retrigger the Suspense boundary;
-          // the next render will call useMyNodeAsProto again.
-          resolve({} as Protobuf.Mesh.NodeInfo);
-          myNodePromises.delete(deviceKey);
-        };
-        setTimeout(tick, 100);
-      });
-
-      myNodePromises.set(deviceKey, promise);
-    }
-
-    throw myNodePromises.get(deviceKey);
+    myNodePromises.delete(deviceKey);
+    myNodeDeadlines.delete(deviceKey);
+    return myNode;
   }
 
-  return myNode;
+  const deviceKey = `device-${selectedDeviceId}`;
+  const deadline =
+    myNodeDeadlines.get(deviceKey) ?? Date.now() + MY_NODE_TIMEOUT_MS;
+  myNodeDeadlines.set(deviceKey, deadline);
+
+  if (Date.now() > deadline) {
+    myNodePromises.delete(deviceKey);
+    myNodeDeadlines.delete(deviceKey);
+    throw new Error("myNode not available after 10s");
+  }
+
+  if (!myNodePromises.has(deviceKey)) {
+    myNodePromises.set(
+      deviceKey,
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          myNodePromises.delete(deviceKey);
+          resolve();
+        }, 100);
+      }),
+    );
+  }
+
+  throw myNodePromises.get(deviceKey);
 }
 
 // import { MessageActionsMenu } from "@components/PageComponents/Messages/MessageActionsMenu.tsx"; // TODO: Uncomment when actions menu is implemented
@@ -148,7 +146,8 @@ export const MessageItem = ({ message }: MessageItemProps) => {
     message.from != null ? (messageUserNode ?? null) : null;
 
   const { displayName, isFavorite, nodeNum } = useMemo(() => {
-    const userIdHex = message.from.toString(16).toUpperCase().padStart(2, "0");
+    const fromNum = message.from ?? 0;
+    const userIdHex = fromNum.toString(16).toUpperCase().padStart(2, "0");
     const last4 = userIdHex.slice(-4);
     const fallbackName = t("fallbackName", { last4 });
     const longName = messageUser?.user?.longName;
@@ -160,7 +159,7 @@ export const MessageItem = ({ message }: MessageItemProps) => {
       displayName: derivedDisplayName,
       shortName: derivedShortName,
       isFavorite: isFavorite,
-      nodeNum: message.from,
+      nodeNum: fromNum,
     };
   }, [messageUser, message.from, t, myNodeNum]);
 

--- a/apps/web/src/components/PageComponents/Settings/Position.tsx
+++ b/apps/web/src/components/PageComponents/Settings/Position.tsx
@@ -27,12 +27,17 @@ interface PositionConfigProps {
   onFormInit: DynamicFormFormInit<PositionValidation>;
 }
 
+// Firmware stores altitude in meters; form displays user's chosen unit.
+const METERS_PER_FOOT = 0.3048;
+const metersToFeet = (m: number) => m / METERS_PER_FOOT;
+const feetToMeters = (ft: number) => ft * METERS_PER_FOOT;
+
 /**
  * Renders inside the Device GPS card. Pulls the browser's current location
  * via navigator.geolocation and writes lat/lng/altitude into the form.
  * No-op without a geolocation API (e.g. insecure context).
  */
-function UseBrowserLocationButton() {
+function UseBrowserLocationButton({ isImperial }: { isImperial: boolean }) {
   const { setValue } = useFormContext<PositionValidation>();
   const { toast } = useToast();
   const { t } = useTranslation("config");
@@ -57,7 +62,10 @@ function UseBrowserLocationButton() {
           pos.coords.altitude !== null &&
           !Number.isNaN(pos.coords.altitude)
         ) {
-          setValue("altitude", Math.round(pos.coords.altitude), {
+          const altitude = isImperial
+            ? metersToFeet(pos.coords.altitude)
+            : pos.coords.altitude;
+          setValue("altitude", Math.round(altitude), {
             shouldDirty: true,
           });
         }
@@ -113,8 +121,11 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
 
   const currentPosition = myNode?.position;
   const displayUnits = getEffectiveConfig("display")?.units;
+  const isImperial =
+    displayUnits === Protobuf.Config.Config_DisplayConfig_DisplayUnits.IMPERIAL;
 
   const formValues = useMemo(() => {
+    const altitudeMeters = currentPosition?.altitude ?? 0;
     return {
       ...config.position,
       ...effectivePosition,
@@ -124,9 +135,11 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
       longitude: currentPosition?.longitudeI
         ? currentPosition.longitudeI / 1e7
         : undefined,
-      altitude: currentPosition?.altitude ?? 0,
+      altitude: isImperial
+        ? Math.round(metersToFeet(altitudeMeters))
+        : altitudeMeters,
     } as PositionValidation;
-  }, [config.position, effectivePosition, currentPosition]);
+  }, [config.position, effectivePosition, currentPosition, isImperial]);
 
   const onSubmit = (data: PositionValidation) => {
     const {
@@ -149,13 +162,16 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
       data.latitude !== undefined &&
       data.longitude !== undefined
     ) {
+      const altitudeMeters = isImperial
+        ? Math.round(feetToMeters(data.altitude ?? 0))
+        : Math.round(data.altitude ?? 0);
       const message = create(Protobuf.Admin.AdminMessageSchema, {
         payloadVariant: {
           case: "setFixedPosition",
           value: create(Protobuf.Mesh.PositionSchema, {
             latitudeI: Math.round(data.latitude * 1e7),
             longitudeI: Math.round(data.longitude * 1e7),
-            altitude: data.altitude || 0,
+            altitude: altitudeMeters,
             time: Math.floor(Date.now() / 1000),
           }),
         },
@@ -220,7 +236,7 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
         {
           label: t("position.deviceGps.label"),
           description: t("position.deviceGps.description"),
-          footer: <UseBrowserLocationButton />,
+          footer: <UseBrowserLocationButton isImperial={isImperial} />,
           fields: [
             {
               type: "toggle",
@@ -236,7 +252,7 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
               properties: {
                 step: 0.0000001,
                 suffix: "Degrees",
-                fieldLength: { max: 10 },
+                fieldLength: { max: 12 },
               },
               disabledBy: [{ fieldName: "fixedPosition" }],
             },
@@ -248,7 +264,7 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
               properties: {
                 step: 0.0000001,
                 suffix: "Degrees",
-                fieldLength: { max: 10 },
+                fieldLength: { max: 13 },
               },
               disabledBy: [{ fieldName: "fixedPosition" }],
             },
@@ -257,19 +273,11 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
               name: "altitude",
               label: t("position.fixedPosition.altitude.label"),
               description: t("position.fixedPosition.altitude.description", {
-                unit:
-                  displayUnits ===
-                  Protobuf.Config.Config_DisplayConfig_DisplayUnits.IMPERIAL
-                    ? "Feet"
-                    : "Meters",
+                unit: isImperial ? "Feet" : "Meters",
               }),
               properties: {
-                step: 0.0000001,
-                suffix:
-                  displayUnits ===
-                  Protobuf.Config.Config_DisplayConfig_DisplayUnits.IMPERIAL
-                    ? "Feet"
-                    : "Meters",
+                step: 1,
+                suffix: isImperial ? "Feet" : "Meters",
               },
               disabledBy: [{ fieldName: "fixedPosition" }],
             },

--- a/apps/web/src/pages/Connections/useConnections.ts
+++ b/apps/web/src/pages/Connections/useConnections.ts
@@ -88,7 +88,15 @@ export function useConnections() {
       if (conn?.meshDeviceId) {
         try {
           useDeviceStore.getState().removeDevice(conn.meshDeviceId);
-        } catch {}
+        } catch (e) {
+          const err = e as Error;
+          log.error("removeConnection: removeDevice threw", {
+            id,
+            meshDeviceId: conn.meshDeviceId,
+            name: err?.name,
+            message: err?.message,
+          });
+        }
       }
       meshRegistry.unregister(id);
       removeSavedConnectionFromStore(id);

--- a/apps/web/src/pages/Map/index.tsx
+++ b/apps/web/src/pages/Map/index.tsx
@@ -31,12 +31,13 @@ import {
 } from "@core/hooks/useNodesAsProto.ts";
 import { cn } from "@core/utils/cn.ts";
 import { hasPos, toLngLat } from "@core/utils/geo.ts";
-import type { Protobuf } from "@meshtastic/sdk";
+import { createLogger, type Protobuf } from "@meshtastic/sdk";
 import { numberToHexUnpadded } from "@noble/curves/utils.js";
 import { FunnelIcon, LocateFixedIcon } from "lucide-react";
 import {
   useCallback,
   useDeferredValue,
+  useEffect,
   useId,
   useMemo,
   useRef,
@@ -44,6 +45,35 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { type MapLayerMouseEvent, useMap } from "react-map-gl/maplibre";
+
+const log = createLogger("MapPage");
+const MAP_VIEW_STORAGE_KEY = "meshtastic:mapView";
+
+type SavedMapView = { longitude: number; latitude: number; zoom: number };
+
+function loadSavedMapView(): SavedMapView | undefined {
+  if (typeof localStorage === "undefined") return undefined;
+  try {
+    const raw = localStorage.getItem(MAP_VIEW_STORAGE_KEY);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<SavedMapView>;
+    if (
+      typeof parsed.longitude === "number" &&
+      typeof parsed.latitude === "number" &&
+      typeof parsed.zoom === "number"
+    ) {
+      return parsed as SavedMapView;
+    }
+    log.warn("saved map view has unexpected shape; ignoring", parsed);
+  } catch (e) {
+    const err = e as Error;
+    log.warn("failed to read saved map view", {
+      name: err?.name,
+      message: err?.message,
+    });
+  }
+  return undefined;
+}
 
 const MapPage = () => {
   const { t } = useTranslation("map");
@@ -64,7 +94,36 @@ const MapPage = () => {
   const { default: mapRef } = useMap();
   const { focusLngLat, fitToNodes } = useMapFitting(mapRef);
 
-  const hasFitBoundsOnce = useRef(false);
+  // Read once so the ref is stable across renders.
+  const savedView = useRef<SavedMapView | undefined>(loadSavedMapView());
+  // Skip auto-fit-to-nodes if a saved view already positioned the map.
+  const hasFitBoundsOnce = useRef<boolean>(!!savedView.current);
+
+  useEffect(() => {
+    const map = mapRef?.getMap();
+    if (!map) return;
+    const handler = () => {
+      const center = map.getCenter();
+      const view: SavedMapView = {
+        longitude: center.lng,
+        latitude: center.lat,
+        zoom: map.getZoom(),
+      };
+      try {
+        localStorage.setItem(MAP_VIEW_STORAGE_KEY, JSON.stringify(view));
+      } catch (e) {
+        const err = e as Error;
+        log.warn("failed to persist map view", {
+          name: err?.name,
+          message: err?.message,
+        });
+      }
+    };
+    map.on("moveend", handler);
+    return () => {
+      map.off("moveend", handler);
+    };
+  }, [mapRef]);
   const [snrHover, setSnrHover] = useState<SNRTooltipProps>();
   const [expandedCluster, setExpandedCluster] = useState<string | undefined>();
   const [popupState, setPopupState] = useState<PopupState | undefined>();
@@ -240,6 +299,7 @@ const MapPage = () => {
   return (
     <PageLayout label="Map" noPadding actions={[]} leftBar={<Sidebar />}>
       <BaseMap
+        initialViewState={savedView.current}
         onLoad={getMapBounds}
         onMouseMove={onMouseMove}
         onClick={onMapBackgroundClick}

--- a/apps/web/src/pages/Nodes/index.tsx
+++ b/apps/web/src/pages/Nodes/index.tsx
@@ -282,6 +282,9 @@ const NodesPage = (): JSX.Element => {
             }
           />
         </div>
+        <div className="flex items-center pr-2 text-sm text-slate-500 dark:text-slate-400 tabular-nums">
+          {filteredNodes.length}/{allSdkNodes.length}
+        </div>
         <div className="flex justify-end">
           <FilterControl
             filterState={filterState}

--- a/apps/web/src/validation/config/lora.ts
+++ b/apps/web/src/validation/config/lora.ts
@@ -15,7 +15,8 @@ export const LoRaValidationSchema = z.object({
   region: RegionCodeEnum,
   hopLimit: z.coerce.number().int().min(0).max(7),
   txEnabled: z.boolean(),
-  txPower: z.coerce.number().int().min(0),
+  // Negative dBm supported for external PA attenuation, floor -18.
+  txPower: z.coerce.number().int().min(-18),
   channelNum: z.coerce.number().int(),
   overrideDutyCycle: z.boolean(),
   sx126xRxBoostedGain: z.boolean(),


### PR DESCRIPTION
Bundles a set of narrow, independent fixes across the web client.

### Position config — fixes #1051, #1308
- Altitude field converts between meters (firmware) and feet (display) based on the display-units setting. Browser geolocation altitude is likewise converted before it lands in the form. Altitude step corrected from the copy-pasted lat/lon precision (0.0000001) to whole-unit steps.
- Latitude/longitude field length caps widened so signed 7-decimal values (\`-90.1234567\` / \`-180.1234567\`) are typeable.

### Numeric form input — fixes #1308, #1404
- \`FormInput\` no longer runs every keystroke through \`Number.parseFloat(...).toString()\`, which turned partial input like \`-\`, \`0.\`, or an empty string into \`\"NaN\"\` and made it impossible to type a negative or a decimal. The controller now holds the raw string; the schema's \`z.coerce.number()\` converts on submit.
- Fixed a display bug where \`String(undefined)\` rendered the literal text \`\"undefined\"\` in empty number inputs.
- \`txPower\` schema floor lowered from 0 to -18 dBm — firmware already accepts negative attenuation values.

### Messages — fixes #1270, #1271, #1277
- \`MessageItem\` no longer crashes when \`message.from\` is null; the hex-id derivation guards against it.
- \`useSuspendingMyNode\` stops resolving Suspense with an empty object cast to \`NodeInfo\`. It resolves a plain void promise per tick and tracks a shared deadline so the 10s timeout is honoured across renders.
- Message list key uses \`message.messageId\` directly; the \`\${from}-\${date}\` fallback collided on same-second sends.

### Connections — fixes #1272
- \`removeConnection\` used to swallow every \`removeDevice\` error in a bare \`catch {}\`. Failures are logged with name/message so partial-cleanup bugs are debuggable.

### Nodes page — fixes #911
- Show \`filtered/total\` count next to the search + filter controls.

### Unread indicator — fixes #96
- Prefix \`document.title\` with a bullet when the SDK reports any unread messages, so a background tab surfaces new activity without cluttering the title with per-conversation names.

### Map page — fixes #1041
- Persist the last viewed longitude / latitude / zoom to \`localStorage\` on \`moveend\` and restore it as the initial view state on next mount. When a saved view exists, the one-shot fit-to-nodes bootstrap is skipped so the user's chosen framing isn't clobbered.

## Test plan
- [ ] Position: set display units to Imperial, enter altitude in feet, save, reconnect — verify firmware stores meters equivalent.
- [ ] Position: type negative latitude/longitude down to 7 decimals; verify no character is blocked.
- [ ] LoRa config: enter negative \`txPower\` (down to -18); verify accepted.
- [ ] Messages: reboot device with unread queued — verify no crash, verify tab title shows leading bullet, verify no duplicate-key React warnings on rapid sends.
- [ ] Remove a saved connection — check console logs on failure paths.
- [ ] Nodes page: apply filters — count updates as \`X/Y\`.
- [ ] Map: pan/zoom, navigate away and back — view restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unread messages now appear as a dot indicator in the browser tab title.
  - Map view position and zoom are remembered between visits.
  - Node search results now show filtered and total node counts.
  - Position settings support altitude in feet or meters with improved location input.

- **Bug Fixes**
  - Numeric fields now preserve partial values such as `-` and `0.` while editing.
  - Improved message loading reliability and handling of incomplete sender data.
  - Negative LoRa transmit power values down to -18 dBm are now accepted.
  - Connection removal errors are now reported instead of silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->