### PR TITLE
fix(web): avoid duplicate keys for same-second messages

### DIFF
--- a/apps/web/src/components/PageComponents/Messages/ChannelChat.tsx
+++ b/apps/web/src/components/PageComponents/Messages/ChannelChat.tsx
@@ -147,9 +147,11 @@ export const ChannelChat = ({ messages = [] }: ChannelChatProps) => {
       {groups.map(({ dayKey, label, items }) => (
         <Fragment key={dayKey}>
           {/* Render messages first, then delimiter — with flex-col-reverse this shows the delimiter above that day's messages */}
-          {items.map((message) => (
+          {items.map((message, index) => (
             <Suspense
-              key={message.messageId ?? `${message.from}-${message.date}`}
+              key={
+                message.messageId ?? `${message.from}-${message.date}-${index}`
+              }
               fallback={<MessageSkeleton />}
             >
               <MessageItem message={message} />


### PR DESCRIPTION
Fixes #1277

Fallback key `from-date` collides when two messages share sender and second-precision date. Append array index as discriminator so same-second bursts render as distinct DOM nodes. Stable messageId path untouched.

Testing:
- vitest 247/247
- tsc clean (only pre-existing App.tsx error)
- oxlint clean

Research: React docs + CopilotKit #3258 (duplicate keys during streaming) — stable ID first, index only as fallback disambiguator, never Math.random()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message display reliability when multiple messages share the same sender and date.
  * Prevented duplicate message rendering issues in channel chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->