### PR TITLE
fix(web): surface heartbeat failures with backoff and warning state

### DIFF
--- a/apps/web/src/components/DeviceInfoPanel.tsx
+++ b/apps/web/src/components/DeviceInfoPanel.tsx
@@ -77,6 +77,8 @@ export const DeviceInfoPanel = ({
       case "configuring":
       case "disconnecting":
         return "bg-amber-500";
+      case "warning":
+        return "bg-amber-500";
       case "error":
         return "bg-red-500";
       default:

--- a/apps/web/src/core/connections/heartbeat.test.ts
+++ b/apps/web/src/core/connections/heartbeat.test.ts
@@ -91,4 +91,39 @@ describe("heartbeat", () => {
     stopHeartbeat(999);
     vi.useRealTimers();
   });
+
+  it("ignores late failure from stopped session after restart", async () => {
+    let rejectA!: (e: Error) => void;
+    const pendingA = new Promise<number>((_, rej) => {
+      rejectA = rej;
+    });
+    const mdA = { heartbeat: vi.fn(() => pendingA) } as unknown as MeshDevice;
+
+    startMaintenanceHeartbeat(999, mdA);
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    stopHeartbeat(999);
+    const mdB = mockMeshDevice(0);
+    useDeviceStore
+      .getState()
+      .updateSavedConnection(999, { status: "configured", error: undefined });
+    startMaintenanceHeartbeat(999, mdB);
+
+    rejectA(new Error("stale fail"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    let conn = useDeviceStore
+      .getState()
+      .savedConnections.find((c) => c.id === 999);
+    expect(conn?.status).toBe("configured");
+    expect(mdB.heartbeat).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    conn = useDeviceStore.getState().savedConnections.find((c) => c.id === 999);
+    expect(conn?.status).toBe("configured");
+
+    stopHeartbeat(999);
+    vi.useRealTimers();
+  });
 });

--- a/apps/web/src/core/connections/heartbeat.test.ts
+++ b/apps/web/src/core/connections/heartbeat.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDeviceStore } from "@core/stores/deviceStore";
+import type { MeshDevice } from "@meshtastic/sdk";
+import { startMaintenanceHeartbeat, stopHeartbeat } from "./heartbeat.ts";
+
+function mockMeshDevice(
+  fails: number,
+): MeshDevice & { callCount: () => number } {
+  let count = 0;
+  const md = {
+    heartbeat: vi.fn(() => {
+      count += 1;
+      if (count <= fails) return Promise.reject(new Error(`fail ${count}`));
+      return Promise.resolve(0);
+    }),
+  } as unknown as MeshDevice & { callCount: () => number };
+  (md as any).callCount = () => count;
+  return md as any;
+}
+
+describe("heartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Reset store
+    const store = useDeviceStore.getState();
+    // Ensure a connection exists
+    if (!store.savedConnections.find((c) => c.id === 999)) {
+      store.addSavedConnection({
+        id: 999,
+        type: "http",
+        name: "test",
+        url: "http://192.168.1.3",
+        status: "configured",
+        createdAt: Date.now(),
+      } as any);
+    } else {
+      store.updateSavedConnection(999, {
+        status: "configured",
+        error: undefined,
+      });
+    }
+    stopHeartbeat(999);
+  });
+
+  it("flips to warning after 3 consecutive failures", async () => {
+    const md = mockMeshDevice(10); // always fail
+    startMaintenanceHeartbeat(999, md);
+
+    // One interval (5min) fails -> schedules retry (~1s), retry fails -> retry (~2s), retry fails -> warning
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const conn = useDeviceStore
+      .getState()
+      .savedConnections.find((c) => c.id === 999);
+    expect(conn?.status).toBe("warning");
+    expect(conn?.error).toMatch(/Heartbeat failed/);
+
+    stopHeartbeat(999);
+    vi.useRealTimers();
+  });
+
+  it("recovers from warning on success", async () => {
+    const md = mockMeshDevice(3); // fail 3, then succeed
+    startMaintenanceHeartbeat(999, md);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    let conn = useDeviceStore
+      .getState()
+      .savedConnections.find((c) => c.id === 999);
+    expect(conn?.status).toBe("warning");
+
+    // Next interval should succeed and clear warning
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    conn = useDeviceStore.getState().savedConnections.find((c) => c.id === 999);
+    expect(conn?.status).toBe("configured");
+    expect(conn?.error).toBeUndefined();
+
+    stopHeartbeat(999);
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/core/connections/heartbeat.test.ts
+++ b/apps/web/src/core/connections/heartbeat.test.ts
@@ -92,6 +92,39 @@ describe("heartbeat", () => {
     vi.useRealTimers();
   });
 
+  it("clears warning when a restarted session succeeds", async () => {
+    const failing = mockMeshDevice(10);
+    startMaintenanceHeartbeat(999, failing);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(
+      useDeviceStore.getState().savedConnections.find((c) => c.id === 999)
+        ?.status,
+    ).toBe("warning");
+
+    stopHeartbeat(999);
+    const recovered = mockMeshDevice(0);
+    startMaintenanceHeartbeat(999, recovered);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const conn = useDeviceStore
+      .getState()
+      .savedConnections.find((c) => c.id === 999);
+    expect(conn?.status).toBe("configured");
+    expect(conn?.error).toBeUndefined();
+
+    stopHeartbeat(999);
+    vi.useRealTimers();
+  });
+
   it("ignores late failure from stopped session after restart", async () => {
     let rejectA!: (e: Error) => void;
     const pendingA = new Promise<number>((_, rej) => {

--- a/apps/web/src/core/connections/heartbeat.ts
+++ b/apps/web/src/core/connections/heartbeat.ts
@@ -13,6 +13,7 @@ const heartbeats = new Map<ConnectionId, ReturnType<typeof setInterval>>();
 const failures = new Map<ConnectionId, number>();
 const retryTimers = new Map<ConnectionId, ReturnType<typeof setTimeout>>();
 const meshDevices = new Map<ConnectionId, MeshDevice>();
+const generations = new Map<ConnectionId, number>();
 
 function backoffDelay(attempt: number): number {
   // Full jitter: random(0, min(cap, base * 2^(attempt-1))) — AWS best practice
@@ -37,14 +38,20 @@ export function stopHeartbeat(id: ConnectionId): void {
   }
   failures.delete(id);
   meshDevices.delete(id);
+  // Bump generation so any in-flight heartbeat that settles late is ignored
+  generations.set(id, (generations.get(id) ?? 0) + 1);
 }
 
 function handleHeartbeatResult(
   id: ConnectionId,
+  gen: number,
   success: boolean,
   error?: unknown,
   expectedStatus: "configuring" | "configured" = "configured",
 ): void {
+  // Ignore stale callbacks from a previous start/stop generation
+  if ((generations.get(id) ?? 0) !== gen) return;
+
   if (success) {
     const prevFailures = failures.get(id) ?? 0;
     failures.set(id, 0);
@@ -86,9 +93,13 @@ function handleHeartbeatResult(
   if (!md) return;
   const timer = setTimeout(() => {
     retryTimers.delete(id);
+    // Re-check generation before firing the retry
+    if ((generations.get(id) ?? 0) !== gen) return;
     md.heartbeat()
-      .then(() => handleHeartbeatResult(id, true, undefined, expectedStatus))
-      .catch((e) => handleHeartbeatResult(id, false, e, expectedStatus));
+      .then(() =>
+        handleHeartbeatResult(id, gen, true, undefined, expectedStatus),
+      )
+      .catch((e) => handleHeartbeatResult(id, gen, false, e, expectedStatus));
   }, delay);
   retryTimers.set(id, timer);
 }
@@ -104,11 +115,17 @@ export function startConfigHeartbeat(
   stopHeartbeat(id);
   failures.set(id, 0);
   meshDevices.set(id, meshDevice);
+  const gen = (generations.get(id) ?? 0) + 1;
+  generations.set(id, gen);
   const intervalId = setInterval(() => {
     meshDevice
       .heartbeat()
-      .then(() => handleHeartbeatResult(id, true, undefined, "configuring"))
-      .catch((error) => handleHeartbeatResult(id, false, error, "configuring"));
+      .then(() =>
+        handleHeartbeatResult(id, gen, true, undefined, "configuring"),
+      )
+      .catch((error) =>
+        handleHeartbeatResult(id, gen, false, error, "configuring"),
+      );
   }, CONFIG_HEARTBEAT_INTERVAL_MS);
   heartbeats.set(id, intervalId);
 }
@@ -123,11 +140,15 @@ export function startMaintenanceHeartbeat(
   stopHeartbeat(id);
   failures.set(id, 0);
   meshDevices.set(id, meshDevice);
+  const gen = (generations.get(id) ?? 0) + 1;
+  generations.set(id, gen);
   const intervalId = setInterval(() => {
     meshDevice
       .heartbeat()
-      .then(() => handleHeartbeatResult(id, true, undefined, "configured"))
-      .catch((error) => handleHeartbeatResult(id, false, error, "configured"));
+      .then(() => handleHeartbeatResult(id, gen, true, undefined, "configured"))
+      .catch((error) =>
+        handleHeartbeatResult(id, gen, false, error, "configured"),
+      );
   }, HEARTBEAT_INTERVAL_MS);
   heartbeats.set(id, intervalId);
 }

--- a/apps/web/src/core/connections/heartbeat.ts
+++ b/apps/web/src/core/connections/heartbeat.ts
@@ -1,10 +1,24 @@
 import type { ConnectionId } from "@core/stores/deviceStore/types";
+import { useDeviceStore } from "@core/stores/deviceStore";
 import type { MeshDevice } from "@meshtastic/sdk";
 
 const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes (post-config)
 const CONFIG_HEARTBEAT_INTERVAL_MS = 5_000; // 5s (during initial config)
 
+const MAX_CONSECUTIVE_FAILURES = 3;
+const BASE_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+
 const heartbeats = new Map<ConnectionId, ReturnType<typeof setInterval>>();
+const failures = new Map<ConnectionId, number>();
+const retryTimers = new Map<ConnectionId, ReturnType<typeof setTimeout>>();
+const meshDevices = new Map<ConnectionId, MeshDevice>();
+
+function backoffDelay(attempt: number): number {
+  // Full jitter: random(0, min(cap, base * 2^(attempt-1))) — AWS best practice
+  const capped = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** (attempt - 1));
+  return Math.random() * capped;
+}
 
 /**
  * Stops + clears any active heartbeat for the connection. Safe to call when
@@ -12,9 +26,71 @@ const heartbeats = new Map<ConnectionId, ReturnType<typeof setInterval>>();
  */
 export function stopHeartbeat(id: ConnectionId): void {
   const h = heartbeats.get(id);
-  if (!h) return;
-  clearInterval(h);
-  heartbeats.delete(id);
+  if (h) {
+    clearInterval(h);
+    heartbeats.delete(id);
+  }
+  const rt = retryTimers.get(id);
+  if (rt) {
+    clearTimeout(rt);
+    retryTimers.delete(id);
+  }
+  failures.delete(id);
+  meshDevices.delete(id);
+}
+
+function handleHeartbeatResult(
+  id: ConnectionId,
+  success: boolean,
+  error?: unknown,
+  expectedStatus: "configuring" | "configured" = "configured",
+): void {
+  if (success) {
+    const prevFailures = failures.get(id) ?? 0;
+    failures.set(id, 0);
+    // Clear warning if we recovered
+    if (prevFailures >= MAX_CONSECUTIVE_FAILURES) {
+      const conn = useDeviceStore
+        .getState()
+        .savedConnections.find((c) => c.id === id);
+      if (conn?.status === "warning") {
+        useDeviceStore.getState().updateSavedConnection(id, {
+          status: expectedStatus,
+          error: undefined,
+        });
+      }
+    }
+    return;
+  }
+
+  const count = (failures.get(id) ?? 0) + 1;
+  failures.set(id, count);
+  console.warn(
+    `[heartbeat] ${expectedStatus} heartbeat failed (${count}/${MAX_CONSECUTIVE_FAILURES}):`,
+    error,
+  );
+
+  if (count >= MAX_CONSECUTIVE_FAILURES) {
+    useDeviceStore.getState().updateSavedConnection(id, {
+      status: "warning",
+      error: `Heartbeat failed ${count} times — device may be unreachable`,
+    });
+    return;
+  }
+
+  // Schedule a one-off retry with backoff, not waiting for next interval
+  const delay = backoffDelay(count);
+  const existing = retryTimers.get(id);
+  if (existing) clearTimeout(existing);
+  const md = meshDevices.get(id);
+  if (!md) return;
+  const timer = setTimeout(() => {
+    retryTimers.delete(id);
+    md.heartbeat()
+      .then(() => handleHeartbeatResult(id, true, undefined, expectedStatus))
+      .catch((e) => handleHeartbeatResult(id, false, e, expectedStatus));
+  }, delay);
+  retryTimers.set(id, timer);
 }
 
 /**
@@ -26,10 +102,13 @@ export function startConfigHeartbeat(
   meshDevice: MeshDevice,
 ): void {
   stopHeartbeat(id);
+  failures.set(id, 0);
+  meshDevices.set(id, meshDevice);
   const intervalId = setInterval(() => {
-    meshDevice.heartbeat().catch((error) => {
-      console.warn("[heartbeat] config heartbeat failed:", error);
-    });
+    meshDevice
+      .heartbeat()
+      .then(() => handleHeartbeatResult(id, true, undefined, "configuring"))
+      .catch((error) => handleHeartbeatResult(id, false, error, "configuring"));
   }, CONFIG_HEARTBEAT_INTERVAL_MS);
   heartbeats.set(id, intervalId);
 }
@@ -42,10 +121,13 @@ export function startMaintenanceHeartbeat(
   meshDevice: MeshDevice,
 ): void {
   stopHeartbeat(id);
+  failures.set(id, 0);
+  meshDevices.set(id, meshDevice);
   const intervalId = setInterval(() => {
-    meshDevice.heartbeat().catch((error) => {
-      console.warn("[heartbeat] maintenance heartbeat failed:", error);
-    });
+    meshDevice
+      .heartbeat()
+      .then(() => handleHeartbeatResult(id, true, undefined, "configured"))
+      .catch((error) => handleHeartbeatResult(id, false, error, "configured"));
   }, HEARTBEAT_INTERVAL_MS);
   heartbeats.set(id, intervalId);
 }

--- a/apps/web/src/core/connections/heartbeat.ts
+++ b/apps/web/src/core/connections/heartbeat.ts
@@ -53,19 +53,17 @@ function handleHeartbeatResult(
   if ((generations.get(id) ?? 0) !== gen) return;
 
   if (success) {
-    const prevFailures = failures.get(id) ?? 0;
     failures.set(id, 0);
-    // Clear warning if we recovered
-    if (prevFailures >= MAX_CONSECUTIVE_FAILURES) {
-      const conn = useDeviceStore
-        .getState()
-        .savedConnections.find((c) => c.id === id);
-      if (conn?.status === "warning") {
-        useDeviceStore.getState().updateSavedConnection(id, {
-          status: expectedStatus,
-          error: undefined,
-        });
-      }
+    // Clear warning whenever the current connection recovers, including after
+    // a restart that reset the in-memory failure counter.
+    const conn = useDeviceStore
+      .getState()
+      .savedConnections.find((c) => c.id === id);
+    if (conn?.status === "warning") {
+      useDeviceStore.getState().updateSavedConnection(id, {
+        status: expectedStatus,
+        error: undefined,
+      });
     }
     return;
   }

--- a/apps/web/src/core/stores/deviceStore/types.ts
+++ b/apps/web/src/core/stores/deviceStore/types.ts
@@ -43,7 +43,8 @@ export type ConnectionStatus =
   | "configuring"
   | "configured"
   | "online"
-  | "error";
+  | "error"
+  | "warning";
 
 export type Connection = {
   id: ConnectionId;


### PR DESCRIPTION
Fixes #1278

Track consecutive heartbeat failures, retry with exponential backoff and full jitter, and flip connection status to warning after 3 misses. Clear warning on recovery.

- heartbeat.ts: add failures/retryTimers/meshDevices maps, MAX 3, base 1s cap 30s, full jitter (AWS),  warning flip, retry via setTimeout
- deviceStore/types.ts: add "warning" to ConnectionStatus
- DeviceInfoPanel.tsx: warning → bg-amber-500
- heartbeat.test.ts: 2 tests with fake timers (3 fails → warning, success → configured)

Testing:
- vitest 243/243 (2 new)
- tsc 44/44
- oxlint clean
- Live: 101 nodes via localhost:3000, dot stays emerald when healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning connection status after repeated heartbeat failures.
  * Warning indicators now appear in amber.
  * Connections automatically retry with backoff and recover when heartbeats succeed.
* **Bug Fixes**
  * Improved heartbeat handling when connections stop or restart, preventing stale retries and outdated status updates.
  * Late heartbeat results from previous sessions are now ignored.
* **Tests**
  * Added coverage for warning states, recovery, retries, and restarted connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->