### PR TITLE
fix: allow negative latitude and longitude in position config

### DIFF
--- a/apps/web/src/components/Form/FormInput.test.tsx
+++ b/apps/web/src/components/Form/FormInput.test.tsx
@@ -1,0 +1,94 @@
+import { PositionValidationSchema } from "@app/validation/config/position.ts";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+import { GenericInput, type InputFieldProps } from "./FormInput.tsx";
+
+type LatitudeForm = { latitude: number | undefined };
+
+/**
+ * Mirrors how Position.tsx uses the latitude field: an optional numeric value
+ * that starts out `undefined` when the node has no fixed position. The stored
+ * form value is echoed into a test-only node, since the bug in #1308 was about
+ * what the field committed, not only what it displayed.
+ */
+function Harness({
+  properties,
+}: {
+  properties: InputFieldProps<LatitudeForm>["properties"];
+}) {
+  const { control, watch } = useForm<LatitudeForm>({
+    defaultValues: { latitude: undefined },
+  });
+
+  return (
+    <>
+      <GenericInput<LatitudeForm>
+        control={control}
+        field={{
+          type: "number",
+          name: "latitude",
+          label: "Latitude",
+          properties,
+        }}
+      />
+      <output data-testid="stored">{String(watch("latitude"))}</output>
+    </>
+  );
+}
+
+// Matches the real latitude/longitude field config in Position.tsx.
+const latitudeProperties = { step: 0.0000001, fieldLength: { max: 12 } };
+
+/** GenericInput renders no <label> of its own, so address the input by its id. */
+const getInput = () => document.getElementById("latitude") as HTMLInputElement;
+
+const stored = () => screen.getByTestId("stored").textContent;
+
+describe("GenericInput - negative coordinates (issue #1308)", () => {
+  it("accepts a pasted negative latitude", async () => {
+    const user = userEvent.setup();
+    render(<Harness properties={latitudeProperties} />);
+
+    await user.click(getInput());
+    await user.paste("-34.1147648");
+
+    expect(stored()).toBe("-34.1147648");
+  });
+
+  it("accepts a negative latitude typed one key at a time", async () => {
+    const user = userEvent.setup();
+    render(<Harness properties={latitudeProperties} />);
+
+    await user.type(getInput(), "-34.1147648");
+
+    expect(stored()).toBe("-34.1147648");
+  });
+
+  it("still accepts a positive latitude", async () => {
+    const user = userEvent.setup();
+    render(<Harness properties={latitudeProperties} />);
+
+    await user.click(getInput());
+    await user.paste("34.1147648");
+
+    expect(stored()).toBe("34.1147648");
+  });
+
+  it("still rejects input longer than fieldLength.max", async () => {
+    const user = userEvent.setup();
+    render(<Harness properties={latitudeProperties} />);
+
+    await user.click(getInput());
+    await user.paste("-1234.567890123");
+
+    expect(stored()).toBe("undefined");
+  });
+
+  it("validates a negative latitude against the position schema", () => {
+    expect(PositionValidationSchema.shape.latitude.parse("-34.1147648")).toBe(
+      -34.1147648,
+    );
+  });
+});

--- a/apps/web/src/components/Form/FormInput.tsx
+++ b/apps/web/src/components/Form/FormInput.tsx
@@ -75,11 +75,7 @@ export function GenericInput<T extends FieldValues>({
       <Input
         type={field.type}
         step={field.properties?.step}
-        value={
-          field.type === "number"
-            ? String(controllerField.value)
-            : controllerField.value
-        }
+        value={controllerField.value ?? ""}
         id={field.name}
         onChange={handleInputChange}
         showCopyButton={field.properties?.showCopyButton}

--- a/apps/web/src/components/PageComponents/Settings/Position.tsx
+++ b/apps/web/src/components/PageComponents/Settings/Position.tsx
@@ -236,7 +236,7 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
               properties: {
                 step: 0.0000001,
                 suffix: "Degrees",
-                fieldLength: { max: 10 },
+                fieldLength: { max: 12 },
               },
               disabledBy: [{ fieldName: "fixedPosition" }],
             },
@@ -248,7 +248,7 @@ export const Position = ({ onFormInit }: PositionConfigProps) => {
               properties: {
                 step: 0.0000001,
                 suffix: "Degrees",
-                fieldLength: { max: 10 },
+                fieldLength: { max: 12 },
               },
               disabledBy: [{ fieldName: "fixedPosition" }],
             },


### PR DESCRIPTION
## Description

The fixed-position latitude and longitude fields on the position config
page rejected negative coordinates, making the page unusable for anyone
in the southern or western hemisphere.

Two independent defects were at play, which is why the reporter saw
latitude fail while longitude appeared to work — their longitude value
happened to be short enough to slip under the character cap.

**1. `fieldLength.max` is a character count, not a value bound.**
`-34.1147648` is 11 characters; with `max: 10` the change was discarded
outright, leaving the field empty. The positive `34.1147648` is 10
characters and was accepted — hence "I can only enter positive values".

**2. The minus sign was swallowed while typing.** `GenericInput`
rendered `String(controllerField.value)` into an `<input type="number">`.
For an optional field with no value yet that produces the literal string
`"undefined"`. The DOM sanitises it to `""`, but React's value tracker
still holds `"undefined"`; the desync causes the first keystroke — the
minus sign — to be dropped.

## Related Issues

Fixes #1308

## Changes Made

- Raise `fieldLength.max` from 10 to 12 on the latitude and longitude
  fields in `Position.tsx`. 12 is the length of `-180.0000000`, the
  longest value the field's documented 7-decimal precision allows.
- In `GenericInput`, render `controllerField.value ?? ""` instead of
  `String(controllerField.value)`, so an unset optional numeric field
  stays in sync with the DOM.
- Add `FormInput.test.tsx` covering negative coordinate entry.

## Testing Done

Added `apps/web/src/components/Form/FormInput.test.tsx`, which drives a
real `react-hook-form` instance with `latitude` defaulting to
`undefined`, mirroring how `Position.tsx` uses the field.

- Pasting `-34.1147648` (the exact value from the issue) stores it
  correctly — fails on `main` due to defect 1.
- Typing `-34.1147648` one key at a time stores it correctly — fails on
  `main` due to defect 2.
- A positive latitude still works, and input exceeding
  `fieldLength.max` is still rejected, guarding the raised cap.
- The stored string still coerces to `-34.1147648` through
  `PositionValidationSchema`.

Each fix was confirmed to be load-bearing by reintroducing the
corresponding defect and observing the matching test fail. Full
`apps/web` suite passes (246 tests).

I do not have Meshtastic hardware, so this was verified through the
test suite rather than against a physical device.

## Checklist

- [x] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [x] Tests have been added or updated
- [ ] All i18n translation labels have been added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed latitude and longitude fields mishandling negative coordinate values when pasted or entered manually.
  * Preserved empty coordinate fields correctly when no value has been entered.
* **Improvements**
  * Increased the maximum coordinate input length to support higher-precision values.
  * Improved handling of numeric input values in position settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->