### PR TITLE
feat(ui): minimal mobile layout below the md breakpoint

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,7 +25,7 @@ export function App() {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorPage}>
-      <Toaster />
+      <Toaster className={device ? "max-sm:top-16" : undefined} />
       <TanStackRouterDevtools position="bottom-right" />
       <DeviceWrapper deviceId={selectedDeviceId}>
         {/* Overlay sits outside the device-conditional branch so it shows
@@ -39,7 +39,8 @@ export function App() {
           <SidebarProvider>
             <div className="h-full flex flex-1 flex-col">
               {device ? (
-                <div className="h-full flex w-full">
+                // dvh here only: the shell stays h-screen so the connection screen is untouched.
+                <div className="h-dvh flex w-full">
                   <DialogManager />
                   <KeyBackupReminder />
                   <RegionSetupReminder />

--- a/apps/web/src/components/Form/FormWrapper.tsx
+++ b/apps/web/src/components/Form/FormWrapper.tsx
@@ -31,7 +31,9 @@ export const FieldWrapper = ({
             {validationText}
           </p>
           <div className="mt-4 space-y-4 sm:col-span-2">
-            <div className="flex items-center">{children}</div>
+            <div className="flex items-center max-md:flex-wrap max-md:gap-y-2">
+              {children}
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/Map.tsx
+++ b/apps/web/src/components/Map.tsx
@@ -1,3 +1,4 @@
+import { useIsMobile } from "@core/hooks/useIsMobile.ts";
 import { useTheme } from "@core/hooks/useTheme.ts";
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -34,6 +35,7 @@ export const BaseMap = ({
   const { t } = useTranslation("map");
 
   const darkMode = theme === "dark";
+  const isMobile = useIsMobile();
   const mapRef = useRef<MapRef | null>(null);
 
   useEffect(() => {
@@ -72,7 +74,7 @@ export const BaseMap = ({
       renderWorldCopies={false}
       maxPitch={0}
       dragRotate={false}
-      touchZoomRotate={false}
+      touchZoomRotate={isMobile}
       initialViewState={
         initialViewState ?? {
           zoom: 1.8,

--- a/apps/web/src/components/PageComponents/Channels/Channels.tsx
+++ b/apps/web/src/components/PageComponents/Channels/Channels.tsx
@@ -74,12 +74,12 @@ export const Channels = ({ onFormInit }: ConfigProps) => {
 
   return (
     <Tabs defaultValue="channel_0">
-      <TabsList className="w-full dark:bg-slate-700">
+      <TabsList className="w-full max-md:flex-nowrap max-md:overflow-x-auto dark:bg-slate-700">
         {allChannels.map((channel) => (
           <TabsTrigger
             key={`channel_${channel.index}`}
             value={`channel_${channel.index}`}
-            className="dark:text-white relative"
+            className="dark:text-white relative max-md:shrink-0"
           >
             {getChannelName(channel)}
             {flags.get(channel.index) && (
@@ -106,6 +106,7 @@ export const Channels = ({ onFormInit }: ConfigProps) => {
         <TabsContent
           key={`channel_${channel.index}`}
           value={`channel_${channel.index}`}
+          className="max-md:px-2"
         >
           <Suspense fallback={<Spinner size="lg" className="my-5" />}>
             <Channel

--- a/apps/web/src/components/PageComponents/Messages/MessageInput.tsx
+++ b/apps/web/src/components/PageComponents/Messages/MessageInput.tsx
@@ -70,7 +70,7 @@ export const MessageInput = ({
           <label
             data-testid="byte-counter"
             htmlFor="messageInput"
-            className="flex items-center w-20 p-1 text-sm place-content-end"
+            className="flex items-center w-14 md:w-20 p-1 text-sm place-content-end"
           >
             {messageBytes}/{maxBytes}
           </label>

--- a/apps/web/src/components/PageLayout.test.tsx
+++ b/apps/web/src/components/PageLayout.test.tsx
@@ -1,0 +1,216 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { SaveIcon } from "lucide-react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PageLayout } from "./PageLayout.tsx";
+
+let pathname = "/messages/broadcast/0";
+
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: ({
+    select,
+  }: {
+    select: (location: { pathname: string }) => string;
+  }) => select({ pathname }),
+}));
+
+const realMatchMedia = globalThis.matchMedia;
+let listeners: Array<() => void> = [];
+let mobile = false;
+
+/** Pin the viewport the `useIsMobile` media query reports. */
+function setViewport(isMobile: boolean) {
+  mobile = isMobile;
+  globalThis.matchMedia = ((query: string) => ({
+    get matches() {
+      return mobile;
+    },
+    media: query,
+    addEventListener: (_: string, cb: () => void) => {
+      listeners.push(cb);
+    },
+    removeEventListener: (_: string, cb: () => void) => {
+      listeners = listeners.filter((l) => l !== cb);
+    },
+  })) as unknown as typeof globalThis.matchMedia;
+}
+
+/** Cross the breakpoint the way a window resize would. */
+function resizeTo(isMobile: boolean) {
+  mobile = isMobile;
+  act(() => {
+    for (const l of [...listeners]) l();
+  });
+}
+
+const page = () => (
+  <PageLayout
+    label="Conversation"
+    leftBar={<div>left bar content</div>}
+    rightBar={<div>right bar content</div>}
+    actions={[
+      { key: "save", icon: SaveIcon, label: "Save", onClick: () => {} },
+    ]}
+  >
+    <div>page content</div>
+  </PageLayout>
+);
+
+function renderPage() {
+  return render(page());
+}
+
+afterEach(() => {
+  globalThis.matchMedia = realMatchMedia;
+  listeners = [];
+  pathname = "/messages/broadcast/0";
+});
+
+describe("PageLayout", () => {
+  describe("desktop", () => {
+    it("leaves focus alone", () => {
+      setViewport(false);
+      renderPage();
+
+      expect(document.activeElement).toBe(document.body);
+    });
+
+    it("renders both side bars as columns, with no drawer triggers", () => {
+      setViewport(false);
+      renderPage();
+
+      expect(screen.getByText("left bar content")).toBeInTheDocument();
+      expect(screen.getByText("right bar content")).toBeInTheDocument();
+      expect(screen.getByText("page content")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Navigation" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Nodes" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("mobile", () => {
+    it("keeps the side bars out of the page and reaches them from the header", () => {
+      setViewport(true);
+      renderPage();
+
+      expect(screen.getByText("page content")).toBeInTheDocument();
+      expect(screen.queryByText("left bar content")).not.toBeInTheDocument();
+      expect(screen.queryByText("right bar content")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Navigation" }));
+      expect(screen.getByText("left bar content")).toBeInTheDocument();
+    });
+
+    it("opens the secondary panel independently", () => {
+      setViewport(true);
+      renderPage();
+
+      fireEvent.click(screen.getByRole("button", { name: "Nodes" }));
+      expect(screen.getByText("right bar content")).toBeInTheDocument();
+      expect(screen.queryByText("left bar content")).not.toBeInTheDocument();
+    });
+
+    it("closes an open drawer once navigation changes the route", () => {
+      setViewport(true);
+      const { rerender } = renderPage();
+
+      fireEvent.click(screen.getByRole("button", { name: "Navigation" }));
+      expect(screen.getByText("left bar content")).toBeInTheDocument();
+
+      pathname = "/messages/direct/42";
+      rerender(
+        <PageLayout label="Conversation" leftBar={<div>left bar content</div>}>
+          <div>page content</div>
+        </PageLayout>,
+      );
+
+      expect(screen.queryByText("left bar content")).not.toBeInTheDocument();
+    });
+
+    it("gives the bars back as columns when the viewport grows, and keeps no drawer open on the way back", () => {
+      setViewport(true);
+      renderPage();
+
+      fireEvent.click(screen.getByRole("button", { name: "Navigation" }));
+      expect(screen.getByText("left bar content")).toBeInTheDocument();
+
+      resizeTo(false);
+      expect(
+        screen.queryByRole("button", { name: "Navigation" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("left bar content")).toBeInTheDocument();
+      expect(screen.getByText("right bar content")).toBeInTheDocument();
+
+      resizeTo(true);
+      expect(screen.queryByText("left bar content")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Navigation" }),
+      ).toBeInTheDocument();
+    });
+
+    it("leaves a focused control alone when the viewport crosses into mobile", () => {
+      setViewport(false);
+      renderPage();
+
+      const save = screen.getByRole("button", { name: "Save" });
+      save.focus();
+
+      resizeTo(true);
+
+      expect(document.activeElement).toBe(save);
+    });
+
+    it("keeps focus reachable when the breakpoint takes the drawer away", () => {
+      setViewport(true);
+      renderPage();
+      fireEvent.click(screen.getByRole("button", { name: "Navigation" }));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      const closeBtn = screen.getByRole("button", { name: "Close" });
+      closeBtn.focus();
+      expect(document.activeElement).toBe(closeBtn);
+
+      resizeTo(false);
+
+      expect(document.activeElement).toBe(screen.getByRole("main"));
+    });
+
+    it("moves focus into the page the drawer navigated to", () => {
+      setViewport(true);
+      const { unmount } = renderPage();
+      fireEvent.click(screen.getByRole("button", { name: "Navigation" }));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      // The route the drawer belongs to unmounts, taking its trigger with it.
+      unmount();
+      pathname = "/nodes";
+      renderPage();
+
+      expect(document.activeElement).toBe(screen.getByRole("main"));
+    });
+
+    it("names an icon action by its label once the label is hidden", () => {
+      setViewport(true);
+      renderPage();
+
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    it("does not render a drawer trigger for a bar the page does not supply", () => {
+      setViewport(true);
+      render(
+        <PageLayout label="Nodes" leftBar={<div>left bar content</div>}>
+          <div>page content</div>
+        </PageLayout>,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Navigation" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Nodes" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/PageLayout.tsx
+++ b/apps/web/src/components/PageLayout.tsx
@@ -1,10 +1,15 @@
 import { ErrorPage } from "@components/UI/ErrorPage.tsx";
 import Footer from "@components/UI/Footer.tsx";
 import { Spinner } from "@components/UI/Spinner.tsx";
+import { useIsMobile } from "@core/hooks/useIsMobile.ts";
 import { cn } from "@core/utils/cn.ts";
-import type { LucideIcon } from "lucide-react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { useLocation } from "@tanstack/react-router";
+import { type LucideIcon, MenuIcon, UsersIcon, XIcon } from "lucide-react";
 import type React from "react";
+import { useEffect, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import { useTranslation } from "react-i18next";
 
 export interface ActionItem {
   key: string;
@@ -31,6 +36,57 @@ export interface PageLayoutProps {
   contentClassName?: string;
 }
 
+interface MobileBarProps {
+  side: "left" | "right";
+  label: string;
+  closeLabel: string;
+  icon: LucideIcon;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+const MobileBar = ({
+  side,
+  label,
+  closeLabel,
+  icon: Icon,
+  open,
+  onOpenChange,
+  children,
+}: MobileBarProps) => (
+  <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+    <DialogPrimitive.Trigger
+      aria-label={label}
+      className="flex shrink-0 items-center rounded-md p-3 text-foreground"
+    >
+      <Icon className="h-5 w-5" />
+    </DialogPrimitive.Trigger>
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs" />
+      <DialogPrimitive.Content
+        aria-describedby={undefined}
+        className={cn(
+          "fixed inset-y-0 z-50 flex w-72 max-w-[85vw] flex-col overflow-y-auto",
+          "bg-background-primary text-text-primary shadow-xl",
+          side === "left" ? "left-0" : "right-0",
+        )}
+      >
+        <DialogPrimitive.Title className="sr-only">
+          {label}
+        </DialogPrimitive.Title>
+        <DialogPrimitive.Close
+          aria-label={closeLabel}
+          className="absolute top-2 right-2 z-10 flex items-center rounded-md p-3 text-foreground"
+        >
+          <XIcon className="h-5 w-5" />
+        </DialogPrimitive.Close>
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  </DialogPrimitive.Root>
+);
+
 export const PageLayout = ({
   label,
   actions,
@@ -43,11 +99,31 @@ export const PageLayout = ({
   topBarClassName,
   contentClassName,
 }: PageLayoutProps) => {
+  const isMobile = useIsMobile();
+  const { t } = useTranslation("ui");
+  const [leftBarOpen, setLeftBarOpen] = useState(false);
+  const [rightBarOpen, setRightBarOpen] = useState(false);
+  const pathname = useLocation({ select: (location) => location.pathname });
+  const mainRef = useRef<HTMLElement>(null);
+  const wasMobile = useRef(isMobile);
+
+  useEffect(() => {
+    setLeftBarOpen(false);
+    setRightBarOpen(false);
+    // Only adopt orphaned focus: the drawer and its trigger unmount with the old
+    // route, and again when the breakpoint takes the drawer away.
+    const leftMobile = wasMobile.current && !isMobile;
+    wasMobile.current = isMobile;
+    if ((isMobile || leftMobile) && document.activeElement === document.body) {
+      mainRef.current?.focus();
+    }
+  }, [pathname, isMobile]);
+
   return (
     <ErrorBoundary FallbackComponent={ErrorPage}>
       <div className="flex flex-1 bg-background text-foreground overflow-hidden">
         {/* Left Sidebar */}
-        {leftBar && (
+        {leftBar && !isMobile && (
           <aside
             className={cn(
               "px-2 pr-0 shrink-0 border-r-[0.5px] border-slate-300 dark:border-slate-700 ",
@@ -66,12 +142,25 @@ export const PageLayout = ({
               topBarClassName,
             )}
           >
+            {isMobile && leftBar && (
+              <MobileBar
+                side="left"
+                label={t("navigation.title")}
+                closeLabel={t("button.close", { ns: "common" })}
+                icon={MenuIcon}
+                open={leftBarOpen}
+                onOpenChange={setLeftBarOpen}
+              >
+                {leftBar}
+              </MobileBar>
+            )}
+
             {/* Header Content */}
             <div className="flex flex-1 items-center justify-between min-w-0">
               <span className="text-lg font-medium text-foreground truncate px-2">
                 {label}
               </span>
-              <div className="flex items-center space-x-1 md:space-x-2 shrink-0 pr-6">
+              <div className="flex items-center space-x-1 md:space-x-2 shrink-0 pr-2 md:pr-6">
                 {actions?.map((action) => {
                   return (
                     <button
@@ -79,13 +168,18 @@ export const PageLayout = ({
                       type="button"
                       disabled={action.disabled || action.isLoading}
                       className={cn(
-                        "flex items-center space-x-2 py-2 px-3 rounded-md",
+                        "flex items-center space-x-2 py-2 px-3 rounded-md max-md:py-3",
                         "text-foreground transition-colors duration-200",
                         "disabled:opacity-50 disabled:cursor-not-allowed",
+                        !action.icon && "max-md:hidden",
                         action.className,
                       )}
                       onClick={action.onClick}
-                      aria-label={action.ariaLabel || `Action ${action.key}`}
+                      aria-label={
+                        action.ariaLabel ||
+                        action.label ||
+                        `Action ${action.key}`
+                      }
                       aria-disabled={action.disabled}
                       aria-busy={action.isLoading}
                     >
@@ -98,20 +192,35 @@ export const PageLayout = ({
                           />
                         ))}
                       {action.label && (
-                        <span className="text-sm px-1 pt-0.5">
+                        <span className="text-sm px-1 pt-0.5 hidden md:inline">
                           {action.label}
                         </span>
                       )}
                     </button>
                   );
                 })}
+
+                {isMobile && rightBar && (
+                  <MobileBar
+                    side="right"
+                    label={t("navigation.nodes")}
+                    closeLabel={t("button.close", { ns: "common" })}
+                    icon={UsersIcon}
+                    open={rightBarOpen}
+                    onOpenChange={setRightBarOpen}
+                  >
+                    {rightBar}
+                  </MobileBar>
+                )}
               </div>
             </div>
           </header>
 
           <main
+            ref={mainRef}
+            tabIndex={-1}
             className={cn(
-              "flex-1 flex flex-col",
+              "flex-1 flex flex-col outline-none",
               "overflow-hidden",
               !noPadding && "px-2",
               contentClassName,
@@ -123,7 +232,7 @@ export const PageLayout = ({
         </div>
 
         {/* Right Sidebar */}
-        {rightBar && (
+        {rightBar && !isMobile && (
           <aside
             className={cn(
               "w-56 lg:w-[270px] text-balance shrink-0 border-l border-slate-300 dark:border-slate-700 px-2 overflow-hidden",

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   useDevice,
   useSidebar,
 } from "@core/stores";
+import { useIsMobile } from "@core/hooks/useIsMobile.ts";
 import { cn } from "@core/utils/cn.ts";
 import { useTotalUnread } from "@meshtastic/sdk-react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
@@ -56,6 +57,7 @@ const CollapseToggleButton = () => {
       onClick={toggleSidebar}
       className={cn(
         "absolute top-20 right-0 z-10 p-0.5 rounded-full transform translate-x-1/2",
+        "max-md:hidden",
         "transition-colors duration-300 ease-in-out",
         "border border-slate-300 dark:border-slate-200",
         "text-slate-500 dark:text-slate-200 hover:text-slate-400 dark:hover:text-slate-400",
@@ -80,7 +82,9 @@ export const Sidebar = ({ children }: SidebarProps) => {
   const { setCommandPaletteOpen } = useAppStore();
   const myNode = useMyNodeAsProto();
   const getNodesLength = () => allNodes.length;
-  const { isCollapsed } = useSidebar();
+  const { isCollapsed: isCollapsedPreference } = useSidebar();
+  const isMobile = useIsMobile();
+  const isCollapsed = isCollapsedPreference && !isMobile;
   const { t } = useTranslation("ui");
   const navigate = useNavigate({ from: "/" });
 
@@ -144,6 +148,7 @@ export const Sidebar = ({ children }: SidebarProps) => {
         "relative border-slate-300 dark:border-slate-700",
         "transition-all duration-300 ease-in-out flex-shrink-0",
         isCollapsed ? "w-24" : "w-52 lg:w-64",
+        "max-md:w-full",
       )}
     >
       <CollapseToggleButton />

--- a/apps/web/src/components/Toaster.tsx
+++ b/apps/web/src/components/Toaster.tsx
@@ -8,7 +8,7 @@ import {
 } from "@components/UI/Toast.tsx";
 import { useToast } from "@core/hooks/useToast.ts";
 
-export function Toaster() {
+export function Toaster({ className }: { className?: string }) {
   const { toasts } = useToast();
 
   return (
@@ -28,7 +28,7 @@ export function Toaster() {
           <ToastClose />
         </Toast>
       ))}
-      <ToastViewport />
+      <ToastViewport className={className} />
     </ToastProvider>
   );
 }

--- a/apps/web/src/components/UI/Dialog.tsx
+++ b/apps/web/src/components/UI/Dialog.tsx
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed z-50 grid w-full bg-white dark:bg-slate-800 dark:text-slate-200 text-slate-900 max-w-[512px] max-h-[100vh] overflow-y-auto scale-100 gap-4 p-6 opacity-100 animate-in fade-in-90 slide-in-from-bottom-10 sm:max-w-lg sm:rounded-lg sm:zoom-in-90 sm:slide-in-from-bottom-0",
+        "fixed z-50 grid w-full bg-white dark:bg-slate-800 dark:text-slate-200 text-slate-900 max-w-[512px] max-h-[100dvh] overflow-y-auto scale-100 gap-4 p-6 opacity-100 animate-in fade-in-90 slide-in-from-bottom-10 sm:max-w-lg sm:rounded-lg sm:zoom-in-90 sm:slide-in-from-bottom-0",
         className,
       )}
       {...props}

--- a/apps/web/src/components/generic/Filter/FilterControl.tsx
+++ b/apps/web/src/components/generic/Filter/FilterControl.tsx
@@ -228,6 +228,7 @@ export function FilterControl({
         {...parameters?.popoverContentProps}
         className={cn(
           "dark:text-slate-300",
+          "max-md:max-h-[var(--radix-popover-content-available-height)] max-md:overflow-y-auto",
           parameters?.popoverContentProps?.className,
         )}
       >

--- a/apps/web/src/core/hooks/useIsMobile.test.ts
+++ b/apps/web/src/core/hooks/useIsMobile.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useIsMobile } from "./useIsMobile.ts";
+
+const realMatchMedia = globalThis.matchMedia;
+let listeners: Array<() => void> = [];
+let matches = false;
+let queries: string[] = [];
+
+/** Pin what the media query reports, and record the query it was asked. */
+function setViewport(isMobile: boolean) {
+  matches = isMobile;
+  globalThis.matchMedia = ((query: string) => {
+    queries.push(query);
+    return {
+      get matches() {
+        return matches;
+      },
+      media: query,
+      addEventListener: (_: string, cb: () => void) => {
+        listeners.push(cb);
+      },
+      removeEventListener: (_: string, cb: () => void) => {
+        listeners = listeners.filter((l) => l !== cb);
+      },
+    };
+  }) as unknown as typeof globalThis.matchMedia;
+}
+
+/** Cross the breakpoint the way a window resize would. */
+function resizeTo(isMobile: boolean) {
+  matches = isMobile;
+  act(() => {
+    for (const l of [...listeners]) l();
+  });
+}
+
+afterEach(() => {
+  globalThis.matchMedia = realMatchMedia;
+  listeners = [];
+  queries = [];
+});
+
+describe("useIsMobile", () => {
+  it("should report false at or above the md breakpoint", () => {
+    setViewport(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it("should report true below the md breakpoint", () => {
+    setViewport(true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it("should query the md breakpoint in rem, matching the Tailwind theme", () => {
+    setViewport(false);
+    renderHook(() => useIsMobile());
+    expect(queries[0]).toBe("not all and (min-width: 48rem)");
+  });
+
+  it("should follow the viewport across the breakpoint", () => {
+    setViewport(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    resizeTo(true);
+    expect(result.current).toBe(true);
+
+    resizeTo(false);
+    expect(result.current).toBe(false);
+  });
+
+  it("should stop listening once unmounted", () => {
+    setViewport(true);
+    const { unmount } = renderHook(() => useIsMobile());
+    expect(listeners).toHaveLength(1);
+
+    unmount();
+    expect(listeners).toHaveLength(0);
+  });
+});

--- a/apps/web/src/core/hooks/useIsMobile.ts
+++ b/apps/web/src/core/hooks/useIsMobile.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_QUERY = "not all and (min-width: 48rem)";
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => globalThis.matchMedia(MOBILE_QUERY).matches,
+  );
+
+  useEffect(() => {
+    const query = globalThis.matchMedia(MOBILE_QUERY);
+    const onChange = () => setIsMobile(query.matches);
+
+    query.addEventListener("change", onChange);
+    setIsMobile(query.matches);
+
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  return isMobile;
+}

--- a/apps/web/src/pages/Connections/index.tsx
+++ b/apps/web/src/pages/Connections/index.tsx
@@ -94,7 +94,7 @@ export const Connections = () => {
 
   return (
     <div className="space-y-6 p-6">
-      <header className="flex items-start justify-between">
+      <header className="flex items-start justify-between max-md:flex-col max-md:gap-4">
         <div className="flex items-stretch gap-3">
           <button
             type="button"
@@ -113,7 +113,7 @@ export const Connections = () => {
             </p>
           </div>
         </div>
-        <div className="flex flex-col items-end ml-2 gap-2">
+        <div className="flex flex-col items-end ml-2 gap-2 max-md:w-full max-md:flex-row max-md:flex-wrap max-md:items-center max-md:ml-0">
           <Button onClick={() => setAddOpen(true)} className="gap-2">
             <RouterIcon className="size-5" />
             {t("button.addConnection")}

--- a/apps/web/src/pages/Settings/DeviceConfig.tsx
+++ b/apps/web/src/pages/Settings/DeviceConfig.tsx
@@ -106,12 +106,12 @@ export const DeviceConfig = ({ onFormInit }: ConfigProps) => {
 
   return (
     <Tabs defaultValue={t("page.tabUser")}>
-      <TabsList className="w-full dark:bg-slate-700">
+      <TabsList className="w-full max-md:flex-nowrap max-md:overflow-x-auto dark:bg-slate-700">
         {tabs.map((tab) => (
           <TabsTrigger
             key={tab.label}
             value={tab.label}
-            className="dark:text-white relative"
+            className="dark:text-white relative max-md:shrink-0"
           >
             {tab.label}
             {flags.get(tab.case) && (
@@ -124,7 +124,7 @@ export const DeviceConfig = ({ onFormInit }: ConfigProps) => {
         ))}
       </TabsList>
       {tabs.map((tab) => (
-        <TabsContent key={tab.label} value={tab.label}>
+        <TabsContent key={tab.label} value={tab.label} className="max-md:px-2">
           <Suspense fallback={<Spinner size="lg" className="my-5" />}>
             <tab.element onFormInit={onFormInit} />
           </Suspense>

--- a/apps/web/src/pages/Settings/ModuleConfig.tsx
+++ b/apps/web/src/pages/Settings/ModuleConfig.tsx
@@ -140,12 +140,12 @@ export const ModuleConfig = ({ onFormInit }: ConfigProps) => {
 
   return (
     <Tabs defaultValue={t("page.tabMqtt")}>
-      <TabsList className="w-full dark:bg-slate-800">
+      <TabsList className="w-full max-md:flex-nowrap max-md:overflow-x-auto dark:bg-slate-800">
         {tabs.map((tab) => (
           <TabsTrigger
             key={tab.label}
             value={tab.label}
-            className="dark:text-white relative"
+            className="dark:text-white relative max-md:shrink-0"
           >
             {tab.label}
             {flags.get(tab.case) && (
@@ -158,7 +158,7 @@ export const ModuleConfig = ({ onFormInit }: ConfigProps) => {
         ))}
       </TabsList>
       {tabs.map((tab) => (
-        <TabsContent key={tab.label} value={tab.label}>
+        <TabsContent key={tab.label} value={tab.label} className="max-md:px-2">
           <Suspense fallback={<Spinner size="lg" className="my-5" />}>
             <tab.element onFormInit={onFormInit} />
           </Suspense>

--- a/apps/web/src/pages/Settings/RadioConfig.tsx
+++ b/apps/web/src/pages/Settings/RadioConfig.tsx
@@ -82,12 +82,12 @@ export const RadioConfig = ({ onFormInit }: ConfigProps) => {
 
   return (
     <Tabs defaultValue={t("page.tabLora")}>
-      <TabsList className="w-full dark:bg-slate-700">
+      <TabsList className="w-full max-md:flex-nowrap max-md:overflow-x-auto dark:bg-slate-700">
         {tabs.map((tab) => (
           <TabsTrigger
             key={tab.label}
             value={tab.label}
-            className="dark:text-white relative"
+            className="dark:text-white relative max-md:shrink-0"
           >
             {tab.label}
             {flags.get(tab.case) && (
@@ -100,7 +100,7 @@ export const RadioConfig = ({ onFormInit }: ConfigProps) => {
         ))}
       </TabsList>
       {tabs.map((tab) => (
-        <TabsContent key={tab.label} value={tab.label}>
+        <TabsContent key={tab.label} value={tab.label} className="max-md:px-2">
           <Suspense fallback={<Spinner size="lg" className="my-5" />}>
             <tab.element onFormInit={onFormInit} />
           </Suspense>

--- a/e2e/tests/responsive.mobile.spec.ts
+++ b/e2e/tests/responsive.mobile.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "../fixtures/test.ts";
+
+/**
+ * Mobile responsiveness (meshtastic/web#666).
+ *
+ * Below the `md` breakpoint the side bars stop being columns and are reached
+ * from the header instead. These checks assert the two things that actually
+ * break on a phone: the document must never scroll sideways, and nothing that
+ * lived in a side bar may become unreachable.
+ */
+test.use({ viewport: { width: 390, height: 844 } });
+
+/** Long-lived reminder toasts overlay the page; clear them before interacting. */
+async function dismissToasts(page: import("@playwright/test").Page) {
+  const closers = page.locator("[toast-close]");
+  for (let i = await closers.count(); i > 0; i = await closers.count()) {
+    await closers.first().click();
+    await expect(closers).toHaveCount(i - 1);
+  }
+}
+
+/** The app itself must never scroll sideways, whatever a page puts inside it. */
+async function expectNoHorizontalOverflow(
+  page: import("@playwright/test").Page,
+) {
+  const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+}
+
+test.describe("mobile layout", () => {
+  test.beforeEach(async ({ page, connectionPage, device }) => {
+    await connectionPage.connectHttp({ host: device.host, tls: device.tls });
+    await expect(page.locator('input[name="messageInput"]')).toBeVisible({
+      timeout: 60_000,
+    });
+    await dismissToasts(page);
+  });
+
+  test("reaches navigation and device info through the header drawer", async ({
+    page,
+  }) => {
+    await expectNoHorizontalOverflow(page);
+    // The sidebar is not taking page width...
+    await expect(page.getByRole("button", { name: "Map" })).toBeHidden();
+
+    await page.getByRole("button", { name: "Navigation" }).click();
+    const drawer = page.getByRole("dialog");
+    await expect(drawer).toBeVisible();
+    // ...but everything it carries is still reachable.
+    await expect(drawer.getByRole("button", { name: "Map" })).toBeVisible();
+    await expect(
+      drawer.getByRole("button", { name: "Settings" }),
+    ).toBeVisible();
+    await expect(drawer.getByText("Connected", { exact: true })).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(drawer).toBeHidden();
+  });
+
+  test("navigating from the drawer closes it and shows the page", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Navigation" }).click();
+    await page
+      .getByRole("button", { name: /^Nodes \(/ })
+      .first()
+      .click();
+
+    await expect(page).toHaveURL(/\/nodes/);
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("keeps the wide nodes table inside its own scroll region", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Navigation" }).click();
+    await page
+      .getByRole("button", { name: /^Nodes \(/ })
+      .first()
+      .click();
+    await expect(page.getByRole("table")).toBeVisible();
+
+    // The table is wider than the phone and scrolls — the document does not.
+    const region = page.getByRole("table").locator("xpath=..");
+    const { scrollWidth, clientWidth } = await region.evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(scrollWidth).toBeGreaterThan(clientWidth);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("keeps the composer usable and the node panel reachable", async ({
+    page,
+    messagesPage,
+  }) => {
+    await expect(messagesPage.input()).toBeVisible();
+    await expect(messagesPage.sendButton()).toBeVisible();
+    await messagesPage.input().fill("typed on a phone");
+    await expectNoHorizontalOverflow(page);
+
+    await page.getByRole("button", { name: "Nodes", exact: true }).click();
+    const panel = page.getByRole("dialog");
+    await expect(panel).toBeVisible();
+    await expect(panel.getByPlaceholder("Search nodes...")).toBeVisible();
+  });
+
+  test("keeps the settings tab strip on one scrollable row", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Navigation" }).click();
+    await page.getByRole("button", { name: "Settings" }).click();
+    await page.getByRole("button", { name: "Navigation" }).click();
+    await page.getByRole("button", { name: "Module Config" }).click();
+
+    const list = page.getByRole("tablist").first();
+    await expect(list).toBeVisible();
+    const { scrollWidth, clientWidth, height } = await list.evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+      height: el.getBoundingClientRect().height,
+    }));
+    // One row that scrolls, not a wrapped block filling the screen.
+    expect(scrollWidth).toBeGreaterThan(clientWidth);
+    expect(height).toBeLessThan(80);
+    await expectNoHorizontalOverflow(page);
+  });
+});


### PR DESCRIPTION
## Description

A minimal pass at mobile usability: everything reachable on desktop stays reachable, nothing
overflows, and desktop layout is unchanged.

## Related Issues

Relates to #666.

## Changes Made

- **`PageLayout`** — side bars become header-opened sheets below `md`. Below `md` the page's
  main region adopts focus only when it would otherwise be orphaned on `<body>` — the drawer's
  trigger unmounts with the old route — so a control that survives a breakpoint crossing keeps
  focus. Icon-only actions fall back to their label for the
  accessible name — below `md` the visible label is hidden, so it was the only one left.
- **`Sidebar`** — fills the sheet; collapse toggle hidden.
- **Settings / Channels tab strips** — one scrollable row; 16 module tabs wrapped into a block.
- **`FormWrapper`** — field control row wraps; key fields clipped their own buttons.
- **`FilterControl`** — popover bounded and scrollable; ran off short screens.
- **`Connections`** — header stacks; the title was squeezed to ~145 px.
- **`MessageInput`** — byte counter narrower below `md`.
- **`Toaster`** — toast viewport clears the header while a device is connected; a long-lived
  reminder toast covered the navigation.
- **`App`** — `dvh` for the connected app; `100vh` overshoots the visible viewport by 56 px (measured).
- **`Map`** — two-finger zoom below `md`. maplibre couples zoom and rotate in one handler, so
  rotation comes with it; upstream disables the handler outright, which also costs pinch-zoom on
  a phone. The `+`/`−` controls are unchanged for anyone who does not want the gesture.
- **`Dialog`** — max height uses `dvh`; at `100vh` a tall dialog put its own bottom edge below
  the fold, unreachable because it is `position: fixed`.

**Responsive layout changes are limited to below `md`.** The two dynamic viewport-height fixes
(`App`, `Dialog`) are width-independent by design: the bug is dynamic browser chrome, not width,
so a landscape phone or a tablet at ≥768 px needs them too. On desktop browsers `vh` and `dvh`
resolve identically. Desktop layout is unchanged.

## Testing Done

- +15 unit, +5 e2e. Suites otherwise unchanged: 400 pass / 1 pre-existing fail; e2e 8 passed /
  1 skipped, the skip unchanged from base. That one failure (`transport-node-serial`) is red on
  master too.
- Pixel-diffed against a parallel build of the base at 768 and 1280: identical apart from live
  node data and nondeterministic basemap labels.
- Manual on a phone, against a `meshtasticd` simulator and a physical node.

## Screenshots

All mobile shots at 390×844.

**The problem — the sidebar takes the width, leaving almost nothing for the page.**

![The problem: sidebar consumes the viewport at 390x844](https://raw.githubusercontent.com/makrohard/web/pr-screenshots/01-the-problem.png)

**Messages — before / after.**

![Messages, before and after](https://raw.githubusercontent.com/makrohard/web/pr-screenshots/02-messages.png)

**Nodes — before / after. The wide table now scrolls inside its own region.**

![Nodes table, before and after](https://raw.githubusercontent.com/makrohard/web/pr-screenshots/03-nodes.png)

**Settings → Channels with a submenu open — before / after. The tab strip becomes one scrollable row.**

![Channel settings, before and after](https://raw.githubusercontent.com/makrohard/web/pr-screenshots/04-settings-channels.png)

**Desktop at 1280 — unchanged.**

![Desktop at 1280, unchanged](https://raw.githubusercontent.com/makrohard/web/pr-screenshots/05-desktop-unchanged.png)

---

## Notes for review

- Breakpoint is the existing `md` (48 rem); no new breakpoint. `max-md:` has no precedent here —
  chosen so every rule is greppable and provably desktop-safe.
- Tab classes repeated at 4 call sites on purpose: moving them into `TabsContent` would change
  `AddConnectionDialog`.
- One new hook, `useIsMobile`; `packages/ui`'s equivalent is not reachable from `apps/web`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive mobile navigation drawers with improved focus handling.
  * Enabled touch-friendly map controls on mobile devices.
  * Improved mobile layouts for forms, tabs, filters, messages, settings, and connections.
  * Added scrolling support for overflowing mobile content without horizontal page scrolling.
  * Improved dialog and notification sizing for dynamic mobile viewports.

* **Bug Fixes**
  * Prevented mobile sidebars from collapsing and ensured drawers close appropriately during navigation or viewport changes.

* **Tests**
  * Added unit, layout, and end-to-end coverage for responsive behavior across mobile and desktop views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->